### PR TITLE
Error Check now happens only on text update, instead of running forever

### DIFF
--- a/experimental/src/processing/mode/experimental/ErrorCheckerService.java
+++ b/experimental/src/processing/mode/experimental/ErrorCheckerService.java
@@ -10,6 +10,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -221,6 +222,11 @@ public class ErrorCheckerService implements Runnable{
     });
   }
 
+  /**
+   * checkCode() only on text area update
+   */
+  protected AtomicInteger textModified = new AtomicInteger(0);
+  
   public void run() {
     stopThread = false;
     
@@ -237,11 +243,17 @@ public class ErrorCheckerService implements Runnable{
       if (pauseThread)
         continue;
 
+      if(textModified.get() == 0)
+    	  continue;
+      
       // Check every x seconds
       checkCode();
      
     }
   }
+  
+  
+  
   
   private boolean checkCode() {
     
@@ -270,6 +282,17 @@ public class ErrorCheckerService implements Runnable{
       editor.updateErrorBar(problemsList);
       updateEditorStatus();
       updateTextAreaPainter();
+      int x = textModified.get();
+      //System.out.println("TM " + x);
+      if(x>=3){
+    	  textModified.set(3);
+    	  x = 3;
+      }
+      
+      if(x>0)
+    	  textModified.set(x - 1);
+      else
+    	  textModified.set(0);
       return true;
 
     } catch (Exception e) {

--- a/experimental/src/processing/mode/experimental/TextArea.java
+++ b/experimental/src/processing/mode/experimental/TextArea.java
@@ -21,6 +21,7 @@ import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.FontMetrics;
 import java.awt.event.ComponentListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
@@ -50,6 +51,7 @@ public class TextArea extends JEditTextArea {
     protected Map<Integer, String> gutterText = new HashMap(); // maps line index to gutter text
     protected Map<Integer, Color> gutterTextColors = new HashMap(); // maps line index to gutter text color
     protected TextAreaPainter customPainter;
+    protected ErrorCheckerService errorCheckerService;
     
     public TextArea(TextAreaDefaults defaults, DebugEditor editor) {
         super(defaults);
@@ -99,7 +101,15 @@ public class TextArea extends JEditTextArea {
      */
     public void setECSandThemeforTextArea(ErrorCheckerService ecs, ExperimentalMode mode)
     {
-      customPainter.setECSandTheme(ecs, mode);
+    	errorCheckerService = ecs;
+    	customPainter.setECSandTheme(ecs, mode);
+    }
+    
+    public void processKeyEvent(KeyEvent evt) {
+        super.processKeyEvent(evt);
+        if(evt.getID() == KeyEvent.KEY_TYPED){
+        	errorCheckerService.textModified.incrementAndGet();
+        }
     }
 
     /**


### PR DESCRIPTION
When the text is modified in the textarea, only then update occurs. At other times, the error checker service thread stays idle.

Success on 3rd attempt! :D
