### PR TITLE
textarea painter update bug fix.

### DIFF
--- a/experimental/src/processing/mode/experimental/ErrorCheckerService.java
+++ b/experimental/src/processing/mode/experimental/ErrorCheckerService.java
@@ -677,12 +677,12 @@ public class ErrorCheckerService implements Runnable{
    */
   public void updatePaintedThingy() {
     editor.getTextArea().repaint();
+    updateEditorStatus();
     currentTab = editor.getSketch().getCodeIndex(
         editor.getSketch().getCurrentCode());
     if (currentTab != lastTab) {
       lastTab = currentTab;
-      editor.updateErrorBar(problemsList);
-      updateEditorStatus();
+      editor.updateErrorBar(problemsList);      
       return;
     }
 


### PR DESCRIPTION
Textarea, EditorStatus weren't getting updated correctly on switching tabs before.
