### PR TITLE
Ignoring the build jre.zips.

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,1 +1,3 @@
 work
+linux/jre.tgz
+windows/jre.zip


### PR DESCRIPTION
This pull requests adds two entries to `build/.gitignore` for the downloaded jre.zip files when building on win/linux.
