### PR TITLE
Fix OpenGL PGL init issues observed using OpenGL ES 2

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -624,6 +624,7 @@ public class PGL {
 
       pg.parent.setLayout(new BorderLayout());
       pg.parent.add(canvasAWT, BorderLayout.CENTER);
+      pg.parent.validate();
       pg.parent.removeListeners(pg.parent);
       pg.parent.addListeners(canvasAWT);
 
@@ -641,6 +642,7 @@ public class PGL {
 
       pg.parent.setLayout(new BorderLayout());
       pg.parent.add(canvasNEWT, BorderLayout.CENTER);
+      pg.parent.validate();
 
       if (events == NEWT) {
         NEWTMouseListener mouseListener = new NEWTMouseListener();


### PR DESCRIPTION
This pull request enables Processing P3D sketches to be used on GNU/Linux armhf OpenGL ES 2 devices.

Tested on a Toshiba AC100, Tegra 2 GPU, running Ubuntu 12.10 armhf.
