### PR TITLE
Fixed "else" Autoformat issue #364

### DIFF
--- a/app/src/processing/mode/java/AutoFormat.java
+++ b/app/src/processing/mode/java/AutoFormat.java
@@ -376,6 +376,11 @@ public class AutoFormat implements Formatter {
           if ((!s_flag) || buf.length() > 0) {
             buf.append(c);
           }
+          // issue https://github.com/processing/processing/issues/364
+          s_flag = false;
+          trimRight(result);
+          result.append(" ");
+
           writeIndentedLine();
           s_flag = false;
           break;


### PR DESCRIPTION
I've read a [Project List](https://github.com/processing/processing/wiki/Project-List) page. "Else"-autoformat is one of the most-improtant ones.

This commit fixes #364.
"else" statements are correctly formatted.

Autoformat Before:

```
  if(i%20 == 0) {
    println("hello world 1");
  } 
  else {
    println("hello world 2");
  }
```

Autoformat After:

```
  if (i%20 == 0) {
    println("hello world 1");
  } else {
    println("hello world 2");
  }
```
