### PR TITLE
New preference "run.jdk.unsupported" to disable the warning message for unsupported JDK.

### DIFF
--- a/app/src/processing/app/linux/Platform.java
+++ b/app/src/processing/app/linux/Platform.java
@@ -38,13 +38,15 @@ public class Platform extends processing.app.Platform {
     if (javaVendor == null ||
         (!javaVendor.contains("Sun") && !javaVendor.contains("Oracle")) ||
         javaVM == null || !javaVM.contains("Java")) {
-      Base.showWarning("Not fond of this Java VM",
-        "Processing requires Java 6 from Sun (i.e. the sun-java-jdk\n" +
-        "package on Ubuntu). Other versions such as OpenJDK, IcedTea,\n" +
-        "and GCJ are strongly discouraged. Among other things, you're\n" +
-        "likely to run into problems with sketch window size and\n" +
-        "placement. For more background, please read the wiki:\n" +
-        "http://wiki.processing.org/w/Supported_Platforms#Linux", null);
+      if (!Preferences.getBoolean("run.jdk.unsupported")) {
+        Base.showWarning("Not fond of this Java VM",
+          "Processing requires Java 6 from Sun (i.e. the sun-java-jdk\n" +
+          "package on Ubuntu). Other versions such as OpenJDK, IcedTea,\n" +
+          "and GCJ are strongly discouraged. Among other things, you're\n" +
+          "likely to run into problems with sketch window size and\n" +
+          "placement. For more background, please read the wiki:\n" +
+          "http://wiki.processing.org/w/Supported_Platforms#Linux", null);
+	  }
     }
   }
 

--- a/build/shared/lib/preferences.txt
+++ b/build/shared/lib/preferences.txt
@@ -328,3 +328,8 @@ run.present.stop.color = #cccccc
 #run.present.exclusive = false
 # use this by default to hide the menu bar and dock on osx
 #run.present.exclusive.macosx = true
+
+# true to disable warning messages when you are running Processing with
+# unsupported JDK such as OpenJDK or GCJ. You should NOT true this until
+# you understand what you are doing.
+run.jdk.unsupported = false


### PR DESCRIPTION
In order to test the latest processing with OpenJDK, I am heavily using the latest Processing with OpenJDK 7. Every time I launches Processing it shows a warning message saying I'm running it with an unsupported JDK. This message would be very useful for users, but annoying for me. I have added an option to disable the message.

I did not add a check box to the warning message dialog to true this option, because someone will turn the check box on without reading the message (it's human's natural behavior) and it will cause nightmare.
