### PR TITLE
Fixed: PGraphicsOpenGL would allocate humongous textures for each font instance

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -3276,18 +3276,14 @@ public class PGraphicsOpenGL extends PGraphics {
   protected void textLineImpl(char buffer[], int start, int stop,
                               float x, float y) {
     textTex = pgPrimary.getFontTexture(textFont);
-    if (textTex == null) {
-      textTex = new FontTexture(pgPrimary, textFont, maxTextureSize,
-                                maxTextureSize, is3D());
-      pgPrimary.setFontTexture(textFont, textTex);
-    } else {
-      if (textTex.contextIsOutdated()) {
-        textTex = new FontTexture(pgPrimary, textFont,
+
+    if (textTex == null || textTex.contextIsOutdated()) {
+      textTex = new FontTexture(pgPrimary, textFont,
           PApplet.min(PGL.MAX_FONT_TEX_SIZE, maxTextureSize),
           PApplet.min(PGL.MAX_FONT_TEX_SIZE, maxTextureSize), is3D());
-        pgPrimary.setFontTexture(textFont, textTex);
-      }
+      pgPrimary.setFontTexture(textFont, textTex);
     }
+    
     textTex.begin();
 
     // Saving style parameters modified by text rendering.


### PR DESCRIPTION
When using the PGraphicsOpenGL renderer Processing would allocate a texture with the maximum allowed width (e.g. 8192x512 pixels for a 10px font) for each font. This lead to severe GPU memory problems, especially when using multiple fonts; and having mip-maps enabled. 

I merged the two conditions for creating a new font texture into one.

![screen shot 2013-05-17 at 22 55 03](https://f.cloud.github.com/assets/385154/520541/606ac586-bf3b-11e2-9c84-2ba6124a1bd2.png)
