### PR TITLE
Fixes processing/processing#1810 where a png data would be written instead of jpeg data.

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -3109,6 +3109,7 @@ public class PImage implements PConstants, Cloneable {
       ImageWriter writer = null;
       ImageWriteParam param = null;
       IIOMetadata metadata = null;
+      
       if (extension.equals("jpg") || extension.equals("jpeg")) {
         if ((writer = imageioWriter("jpeg")) != null) {
           // Set JPEG quality to 90% with baseline optimization. Setting this
@@ -3120,12 +3121,16 @@ public class PImage implements PConstants, Cloneable {
           param.setCompressionQuality(0.9f);
         }
       }
-      if ((writer = imageioWriter("png")) != null) {
-        param = writer.getDefaultWriteParam();
-        if (false) {
-          metadata = imageioDPI(writer, param, 100);
+
+      if (extension.equals("png")) {
+        if ((writer = imageioWriter("png")) != null) {
+          param = writer.getDefaultWriteParam();
+          if (false) {
+            metadata = imageioDPI(writer, param, 100);
+          }
         }
       }
+
       if (writer != null) {
         BufferedOutputStream output =
           new BufferedOutputStream(PApplet.createOutput(file));


### PR DESCRIPTION
See issue #1810

The file being saved (although it has the jpg extension) was a actually a PNG:

![screen shot 2013-05-26 at 14 08 01](https://f.cloud.github.com/assets/385154/565276/f7fe0008-c5fc-11e2-9ff2-b0102301cece.png)
