### PR TITLE
Fix Issue 1827

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -6174,7 +6174,7 @@ public class PApplet extends Applet
    * @see PApplet#saveJSONObject(JSONObject, String)
    */
   public boolean saveJSONArray(JSONArray json, String filename) {
-    return saveJSONArray(json, filename);
+    return saveJSONArray(json, filename, null);
   }
 
 


### PR DESCRIPTION
Fix the accidental recursion in PApplet.saveJSONArray by adding a third null parameter
