### PR TITLE
Syntax highlighting  bug

### DIFF
--- a/app/src/processing/app/syntax/PdeKeywords.java
+++ b/app/src/processing/app/syntax/PdeKeywords.java
@@ -137,7 +137,8 @@ public class PdeKeywords extends TokenMarker {
               lastOffset = lastKeyword = mlength;
               break loop;
             }
-            i++;  // http://processing.org/bugs/bugzilla/609.html [jdf] 
+            if(array[i1]!=' ')
+              i++;  // http://processing.org/bugs/bugzilla/609.html [jdf] 
           }
           break;
         default:


### PR DESCRIPTION
#1681

Syntax highlighting with / bug low
file :PdeKeywords.java  
function:markTokensImpl(...) 

Explanation:

During the scanning of the line to check if the Token belongs to
Processing Syntax ,When my current character is "/" , we check if the
next character(if any) is "*" or "/" , and we do then an increment of
the scanning index , so in this case , and if the next character in an
alphabet we don’t have a problem , but if it is " " (a space) , the loss
of this character will make the  lastKeyword scan index incorrect , so
we get this problem  of highlighting . To solve it, we check before
incrementing the index, if the next character is " ", so we don’t
increment.

Result and Test:
The example mouseX/ mouseY  highlight the two PDE keyword and  
 the fix  http://processing.org/bugs/bugzilla/609.html
//*
println("1");
/_/
println("2");
//_/
still working .So i think this fix works
