### PR TITLE
updated build howto to point to correct address on github

### DIFF
--- a/build/howto.txt
+++ b/build/howto.txt
@@ -1,5 +1,5 @@
 As part of a grand plan for Casey and I to rid ourselves of as much of
 the duct tape and chewing gum that's holding together processing.org, 
-this document has been moved to Google Code:
+this document has been moved to Github:
 
-http://code.google.com/p/processing/wiki/BuildInstructions
+https://github.com/processing/processing/wiki/Build-Instructions


### PR DESCRIPTION
The old link simply pointed to the github address, this points to the new address.
