### PR TITLE
Add missing double quotes to readlink call. Opening paths with spaces no...

### DIFF
--- a/build/linux/processing
+++ b/build/linux/processing
@@ -108,7 +108,7 @@ then
 else
   # Start Processing in the same directory as this script
   if [ "$1" ]; then
-    SKETCH=`readlink -f $1`
+    SKETCH=`readlink -f "$1"`
   else
     SKETCH=
   fi


### PR DESCRIPTION
...w works.

I was trying to make it possible to double click on .pde files on Ubuntu 13.04 following http://forum.processing.org/topic/ubuntu-12-10-launch-pde-files-from-nautilus
I noticed that files found in paths that include spaces would not open. I fixed it by adding double quotes to a readlink call at the end of the Processing launcher script. Other similar calls to readlink in the same file already included double quotes.
