### PR TITLE
A couple of tweaks for up to 40% faster PDE start-up

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -143,6 +143,7 @@ public class Base {
 
 
   static private void createAndShowGUI(String[] args) {
+    long time1 = System.currentTimeMillis();
     try {
       File versionFile = getContentFile("lib/version.txt"); //$NON-NLS-1$
       if (versionFile.exists()) {
@@ -157,7 +158,7 @@ public class Base {
     }
 
     initPlatform();
-
+    log("   initPlatform() took " + ((System.currentTimeMillis()) - time1) + "ms    ");
     // Use native popups so they don't look so crappy on OS X
     JPopupMenu.setDefaultLightWeightPopupEnabled(false);
 
@@ -213,6 +214,8 @@ public class Base {
       }
       log("done creating base..."); //$NON-NLS-1$
     }
+    //System.err.println("   Total startup time: " + ((System.currentTimeMillis()) - time1) + "ms    ");
+    log("   Total startup time: " + ((System.currentTimeMillis()) - time1) + "ms    ");
   }
 
 
@@ -348,10 +351,11 @@ public class Base {
 //        removeDir(contrib.getFolder());
 //      }
 //    }
+    long time1 = System.currentTimeMillis(), time2;
     ContributionManager.cleanup();
     buildCoreModes();
     rebuildContribModes();
-
+    log("   Loading Modes took: " + ((System.currentTimeMillis()) - time1) + "ms    ");
     // Needs to happen after the sketchbook folder has been located.
     // Also relies on the modes to be loaded so it knows what can be
     // marked as an example.
@@ -395,7 +399,7 @@ public class Base {
 //    // Check if there were previously opened sketches to be restored
 //    boolean opened = restoreSketches();
     boolean opened = false;
-
+    time2 = System.currentTimeMillis();
     // Check if any files were passed in on the command line
     for (int i = 0; i < args.length; i++) {
       String path = args[i];
@@ -423,7 +427,7 @@ public class Base {
 //    } else {
 //      System.out.println("something else was opened");
     }
-
+    log("   Editor open took : " + ((System.currentTimeMillis()) - time2) + "ms    ");
     // check for updates
     if (Preferences.getBoolean("update.check")) { //$NON-NLS-1$
       new UpdateCheck(this);
@@ -1250,10 +1254,28 @@ public class Base {
 
 
   public JMenu getSketchbookMenu() {
+    long t1 = System.currentTimeMillis();
     if (sketchbookMenu == null) {
       sketchbookMenu = new JMenu("Sketchbook");
       rebuildSketchbookMenu();
     }
+    log("   getSketchbookMenu() took: " +(System.currentTimeMillis()-t1) + "ms   ");
+    return sketchbookMenu;
+  }
+  
+  public JMenu getSketchbookMenuFast() {
+    final long t1 = System.currentTimeMillis();
+    if (sketchbookMenu == null) {
+      sketchbookMenu = new JMenu("Loading Sketchbook..");
+      // Populate the menu via a separate thread
+      new Thread(new Runnable() {
+        public void run() {
+          rebuildSketchbookMenu();
+          sketchbookMenu.setText("Sketchbook");
+        }
+      }).start();
+    }
+    log("   getSketchbookMenuFast() took: " +(System.currentTimeMillis()-t1) + "ms   ");
     return sketchbookMenu;
   }
 


### PR DESCRIPTION
I was taking a look at the start up process of the PDE and found a couple of bottlenecks that occur due to file I/O. After eliminating them, on my setup, (Ubuntu 12.10 x64, no SSD) the average start up time decreased from ~1900ms to ~1170ms. An improvement of nearly 40%.

I found these culprits:
- Base.getSketchbookMenu(), which when invoked for the first time, populates the menu and then returns the JMenu. The file I/O in the first function call was taking ~500ms with my sketchbook. This method is first called in the Editor class constructor. I modified this function to immediately return a blank JMenu, so that the Editor loads up quickly via the main thread. The sketchbook JMenu, in the meanwhile, is populated in the background by a separate thread without blocking the main thread from loading the Editor. This shaved off ~500 ms from the start up time. I added a new getSketchbookMenuFast() method. 
- Editor.getToolMenu() - A similar case as the above, where JMenu takes time to be populated when done in the main thread. Following similar approach as above, I lazy load this menu in the background. This saved another ~200ms. I added a  getToolMenuFast() method.
