### PR TITLE
Custom DPI settings for PDF output

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10827,6 +10827,18 @@ public class PApplet extends Applet
 
 
   /**
+   *  Same as above, but also set the DPI before calling beginRecord()
+   */
+  public PGraphics beginRecord(String renderer, String filename, float dpi) {
+    filename = insertFrame(filename);
+    PGraphics rec = createGraphics(width, height, renderer, filename);
+    rec.setDpi(dpi);
+    beginRecord(rec);
+    return rec; 
+  }
+
+
+  /**
    * @nowebref
    * Begin recording (echoing) commands to the specified PGraphics object.
    */

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -855,6 +855,14 @@ public class PGraphics extends PImage implements PConstants {
 
 
   /**
+   *  Dummy implementation, classes overwrite this if needed
+   *  See PApplet.beginRecord(String, String, float)
+   */
+  protected void setDpi(float dpi) {
+  }
+
+
+  /**
    * ( begin auto-generated from PGraphics_endDraw.xml )
    *
    * Finalizes the rendering of a PGraphics object so that it can be shown on screen.

--- a/java/libraries/pdf/src/processing/pdf/PGraphicsPDF.java
+++ b/java/libraries/pdf/src/processing/pdf/PGraphicsPDF.java
@@ -62,6 +62,8 @@ public class PGraphicsPDF extends PGraphicsJava2D {
   static protected DefaultFontMapper mapper;
   static protected String[] fontList;
 
+  private float dpi = 72;
+
 
   /*
   public PGraphicsPDF() {
@@ -80,6 +82,17 @@ public class PGraphicsPDF extends PGraphicsJava2D {
     if (file == null) {
       throw new RuntimeException("PGraphicsPDF requires an absolute path " +
                                  "for the location of the output file.");
+    }
+  }
+
+
+  /**
+   *  Set the number of Dots per inch in the output PDF
+   *  Defaults to 72
+   */
+  protected void setDpi(float dpi) {
+    if (0.0f < dpi) {
+      this.dpi = dpi;
     }
   }
 
@@ -113,7 +126,7 @@ public class PGraphicsPDF extends PGraphicsJava2D {
 //    long t0 = System.currentTimeMillis();
 
     if (document == null) {
-      document = new Document(new Rectangle(width, height));
+      document = new Document(new Rectangle((float)(width*(72.0f/this.dpi)), (float)(height*(72.0/this.dpi))));
       try {
         if (file != null) {
           //BufferedOutputStream output = new BufferedOutputStream(stream, 16384);
@@ -136,7 +149,7 @@ public class PGraphicsPDF extends PGraphicsJava2D {
 //      System.out.println("beginDraw fonts " + (System.currentTimeMillis() - t));
 //      g2 = content.createGraphics(width, height, getMapper());
 //      if (textMode == SHAPE) {
-      g2 = content.createGraphicsShapes(width, height);
+      g2 = content.createGraphicsShapes((float)(width*(72.0f/this.dpi)), (float)(height*(72.0/this.dpi)));
 //      } else if (textMode == MODEL) {
 //        g2 = content.createGraphics(width, height, getMapper());
 //      }
@@ -149,6 +162,7 @@ public class PGraphicsPDF extends PGraphicsJava2D {
 //    super.beginDraw();
     checkSettings();
     resetMatrix(); // reset model matrix
+    g2.scale(72.0f/this.dpi, 72.0f/this.dpi);
     vertexCount = 0;
 
     // Also need to push the matrix since the matrix doesn't reset on each run


### PR DESCRIPTION
"It works here" :) Inspired by the way the support for retina displays works.

Since we need the DPI setting inside beginDraw(), I went for adding a variant of beginRecord() in PApplet that takes a third, float argument.
