### PR TITLE
Fixed build errors on OS X, when ant is run from a location other than build/macosx

### DIFF
--- a/build/macosx/appbundler/src/com/oracle/appbundler/BundleDocument.java
+++ b/build/macosx/appbundler/src/com/oracle/appbundler/BundleDocument.java
@@ -34,8 +34,7 @@ import org.apache.tools.ant.BuildException;
 public class BundleDocument {
     private String name = "editor";
     private String role = "";
-    private String icon = null;
-    private File iconFile;
+    private File icon = null;
     private String[] extensions;
     private boolean isPackage = false;
 
@@ -56,9 +55,8 @@ public class BundleDocument {
         }
     }
     
-    public void setIcon(String icon) {
+    public void setIcon(File icon) {
       this.icon = icon;
-      this.iconFile = new File(icon);
     }
     
     public void setName(String name) {
@@ -82,12 +80,12 @@ public class BundleDocument {
 //    }
     
     public String getIconName() {
-        return iconFile.getName();
+        return icon.getName();
     }
     
     
     public File getIconFile() {
-        return iconFile;
+        return icon;
     }
     
     public String getName() {


### PR DESCRIPTION
This should fix this issue: https://github.com/processing/processing/issues/2127

I used a File instead of a String for the icon, just like it's done in AppBundlerTask. This way a correct file path gets passed in, instead of relative path that works only from build/macosx.
