### PR TITLE
Using sketchQuality() does not work properly with P3D, OPENGL, P2D

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -3096,7 +3096,11 @@ public class PGraphicsOpenGL extends PGraphics {
 
   @Override
   public void smooth() {
-    smooth(2);
+    if (quality < 2) {
+      smooth(2);
+    } else {
+      smooth(quality);
+    }
   }
 
 
@@ -3124,6 +3128,7 @@ public class PGraphicsOpenGL extends PGraphics {
       lastSmoothCall = parent.frameCount;
 
       quality = level;
+      
       if (quality == 1) {
         quality = 0;
       }


### PR DESCRIPTION
This modification fixes the situation that using `sketchQuality()` does not work properly with the PGraphicsOpenGl based renderers. Because smooth() is called on initialization if the quality is > 2, which is fine for the 2D software renderers (only the `smooth` flag is set to true), but the current `smooth()` implementation in PGraphicsOpenGl  would actually always call `smooth(2)`, thus degrading the set quality.

Here is a little sketch to replicate the bug:

``` java
int sketchWidth() { return 200; }
int sketchHeight() { return 200; }
int sketchQuality() { return 8; }
String sketchRenderer() { return P3D; }

void setup() { 
}

void draw() {
  background(50);

  text("Set quality: " + sketchQuality(), 20, 20);
  text("Actual quality: " + g.quality, 20, 35);

  stroke(255);
  fill(255, 69, 0);
  ellipse(width * 0.5, height * 0.5, 40, 50);

  line(0, 0, 100, 200);
}
```
