### PR TITLE
Clear the global PGL on dispose().

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -651,9 +651,13 @@ public class PGraphicsOpenGL extends PGraphics {
     deleteFinalizedGLResources();
 
     if (primarySurface) pgl.deleteSurface();
+    // This next line is critical to release many static allocations.
+    // This is important in the context of, say, a unit test suite, which
+    // runs more than one OpenGL sketch within the same classloader
+    // (as in the case of processing.py). Please don't remove it!
+    pgl = null;
   }
 
-//  @Override
   @Override
   protected void finalize() throws Throwable {
     try {


### PR DESCRIPTION
A single-line patch.

As the comment says,

// This next line is critical to release many static allocations.
// This is important in the context of, say, a unit test suite, which
// runs more than one OpenGL sketch within the same classloader
// (as in the case of processing.py).

I never had this problem before, because only one of my processing.py unit tests had used an OpenGL renderer until recently.
