### PR TITLE
Also trying to set displayWidth and displayHeight in init().

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -902,6 +902,21 @@ public class PApplet extends Applet
       }
     } catch (Exception e) { }  // may be a security problem
 
+    // Figure out the available display width and height.
+    // No major problem if this fails, we have to try again anyway in
+    // handleDraw() on the first (== 0) frame.
+    if (getGraphicsConfiguration() != null) {
+        GraphicsDevice displayDevice = getGraphicsConfiguration().getDevice();
+        
+        if (displayDevice != null) {
+          Rectangle screenRect =
+            displayDevice.getDefaultConfiguration().getBounds();
+
+          displayWidth = screenRect.width;
+          displayHeight = screenRect.height;
+        }
+    }
+     
     Dimension size = getSize();
     if ((size.width != 0) && (size.height != 0)) {
       // When this PApplet is embedded inside a Java application with other
@@ -2271,8 +2286,7 @@ public class PApplet extends Applet
         if (displayDevice == null) return;
         Rectangle screenRect =
           displayDevice.getDefaultConfiguration().getBounds();
-//        screenX = screenRect.x;
-//        screenY = screenRect.y;
+
         displayWidth = screenRect.width;
         displayHeight = screenRect.height;
 


### PR DESCRIPTION
This fixes an issue where **displayWidth** and **displayHeight** are still 0 when used in sketchWidth() and sketchHeight(). This approach is described in the Processing [Wiki](http://wiki.processing.org/w/Window_Size_and_Full_Screen) to make a full-screen sketch that fills the whole screen without any borders.

See #2039 for more information.
### Code to reproduce the described bug

Run with _Present_.

``` java
void draw() {
  background(52);

  stroke(255, 69, 0);

  line(0, 0, width, height);
  line(width, 0, 0, height);
}

public int sketchWidth() {
  return displayWidth;
}

public int sketchHeight() {
  return displayHeight;
}
```
