### PR TITLE
Fix #2228 - PImageResizeTransparantBug

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -640,8 +640,7 @@ public class PImage implements PConstants, Cloneable {
   // http://code.google.com/p/processing/issues/detail?id=1463
   static private BufferedImage shrinkImage(BufferedImage img,
                                            int targetWidth, int targetHeight) {
-    int type = (img.getTransparency() == Transparency.OPAQUE) ?
-      BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+    int type = BufferedImage.TYPE_INT_ARGB;
     BufferedImage outgoing = img;
     BufferedImage scratchImage = null;
     Graphics2D g2 = null;


### PR DESCRIPTION
This pull request fixes issue #2228.

**Problem:**
1. The resize() method creates a BufferedImage with the shrinkImage() method
2. The type set for opaque images is BufferedImage.TYPE_INT_RGB
3. The resize() method then creates a PImage from the BufferedImage with the PImage(Image img) constructor
4. The PImage(Image img) constructor uses raster.getDataElements(0, 0, width, height, pixels).
**5. When the type is BufferedImage.TYPE_INT_RGB the raster.getDataElements() method returns pixels with no transparency (aka alpha 00 instead of FF).**
5. The end result is that all fully opaque images ironically become fully transparent images. Hence they are no longer visibly drawn.

**Solution:**
Make sure that all BufferedImages created with the shrinkImage() method are of type BufferedImage.TYPE_INT_ARGB. With this change, the raster.getDataElements() method will return the correct alpha value for both opaque and transparent images.

**Consequences:**
The format variable is switched to ARGB via the PImage(Image img) constructor, since it follows the type of the BufferedImage.
