### PR TITLE
Update Brackets.java

### DIFF
--- a/app/src/processing/app/syntax/Brackets.java
+++ b/app/src/processing/app/syntax/Brackets.java
@@ -90,7 +90,7 @@ public class Brackets {
           readComment(text);
         } else if (d == '*') {
           readMLComment(text);
-        }
+        } else pos--; // Go back because there isn't a comment.
       } else if (c == '"' || c == '\'') {
         readString(text, c);
       } else if (c == '{' || c == '[' || c == '(' || c == '}' || c == ']'


### PR DESCRIPTION
Fixed bug first spotted at ~~http://code.google.com/p/processing/issues/detail?id=1032~~ https://github.com/processing/processing/issues/1070#issuecomment-13355806 where brackets aren't seen directly after a slash.
An example that previously failed:

``` Java
min(1, x/(1.0));
min(1, x /(1.0));
```
