### PR TITLE
fix #2173 Multi byte character overlapping

### DIFF
--- a/app/src/processing/app/syntax/TextAreaPainter.java
+++ b/app/src/processing/app/syntax/TextAreaPainter.java
@@ -666,10 +666,9 @@ public class TextAreaPainter extends JComponent implements TabExpander {
     y += fm.getHeight();
     // doesn't respect fixed width like it should
 //    x = Utilities.drawTabbedText(currentLine, x, y, gfx, this, 0);
-    int w = fm.charWidth(' ');
     for (int i = 0; i < currentLine.count; i++) {
       gfx.drawChars(currentLine.array, currentLine.offset+i, 1, x, y);
-      x += w;
+      x += fm.charWidth(currentLine.array[currentLine.offset+i]);
     }
 
     // Draw characters via input method. 
@@ -761,10 +760,9 @@ public class TextAreaPainter extends JComponent implements TabExpander {
       // doesn't respect mono metrics, insists on spacing w/ fractional or something
 //      x = Utilities.drawTabbedText(line, x, y, gfx, this, 0);
 //      gfx.drawChars(line.array, line.offset, line.count, x, y);
-      int w = fm.charWidth(' ');
       for (int i = 0; i < line.count; i++) {
         gfx.drawChars(line.array, line.offset+i, 1, x, y);
-        x += w;
+        x += fm.charWidth(line.array[line.offset+i]);
       }
       //x += fm.charsWidth(line.array, line.offset, line.count);
       //x += fm.charWidth(' ') * line.count;


### PR DESCRIPTION
Hi.
I examined about #2173, and I think this lines causes the problem.
- https://github.com/processing/processing/blob/master/app/src/processing/app/syntax/TextAreaPainter.java#L669-L672
- https://github.com/processing/processing/blob/master/app/src/processing/app/syntax/TextAreaPainter.java#L764-L767

Here, only ascii space's width is used to calculate the character's x-coordinate.
but the width of Japanese/Chinese character is about twice the ascii character.

e9caccb: This change is the cause of the problem.

---

I hope my patch makes the code better.

But I do not know the background well,
therefore I cannot determine whether this modification is appropriate.

If you don't want to use changeable (proportional font's) width, the solution I can think of is:
1. check whether each of the character is multi byte (or single byte).
2. if the character is single byte, use width of ' ' (ascii space, a.k.a single byte space).
3. if the character is multi byte, use width of '　' (multi byte space).

(But in a troublesome thing, Japanese includes multi byte character that has width as same as ascii characters.)
