### PR TITLE
Fix #2228 - PImage resize transparent bug (alternative solution)

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -283,10 +283,14 @@ public class PImage implements PConstants, Cloneable {
       width = bi.getWidth();
       height = bi.getHeight();
       pixels = new int[width * height];
-      WritableRaster raster = bi.getRaster();
-      raster.getDataElements(0, 0, width, height, pixels);
-      if (bi.getType() == BufferedImage.TYPE_INT_ARGB) {
+      pixels = ((DataBufferInt) bi.getRaster().getDataBuffer()).getData();
+      int type = bi.getType();
+      if (type == BufferedImage.TYPE_INT_ARGB) {
         format = ARGB;
+      } else if (type == BufferedImage.TYPE_INT_RGB) {
+        for (int i = 0; i < pixels.length; i++) {
+          pixels[i] = (255 << 24) | pixels[i];
+        }
       }
 
     } else {  // go the old school java 1.0 route


### PR DESCRIPTION
This pull request fixes issue #2228.

**Solution:**
When the BufferedImage is of type BufferedImage.TYPE_INT_RGB the adapted code makes sure all pixels are fully opaque. This pull request provides a cleaner solution than the previous pull request #2312 because it respects and leaves intact the RGB / ARGB type of the image.
