### PR TITLE
fixes #2341 - inconsistent bounds checks

### DIFF
--- a/core/src/processing/data/FloatList.java
+++ b/core/src/processing/data/FloatList.java
@@ -110,6 +110,9 @@ public class FloatList implements Iterable<Float> {
    * @brief Get an entry at a particular index
    */
   public float get(int index) {
+    if (index >= count) {
+      throw new ArrayIndexOutOfBoundsException(index);
+    }
     return data[index];
   }
 

--- a/core/src/processing/data/IntList.java
+++ b/core/src/processing/data/IntList.java
@@ -130,6 +130,9 @@ public class IntList implements Iterable<Integer> {
    * @brief Get an entry at a particular index
    */
   public int get(int index) {
+    if (index >= this.count) {
+      throw new ArrayIndexOutOfBoundsException(index);
+    }
     return data[index];
   }
 

--- a/core/src/processing/data/StringList.java
+++ b/core/src/processing/data/StringList.java
@@ -113,6 +113,9 @@ public class StringList implements Iterable<String> {
    * @brief Get an entry at a particular index
    */
   public String get(int index) {
+    if (index >= count) {
+      throw new ArrayIndexOutOfBoundsException(index);
+    }
     return data[index];
   }
 


### PR DESCRIPTION
The core datastructure IntLost, FloatList, and StringList all have
unsafe .get methods that do not perform bounds checking. This is in
contrast to their .remove methods, which do perform bounds checking.
Prior to this patch, the following would print 0:

```
IntList il = new IntList();
println(il.get(5));
```

But if we tried to _remove_ that element, we would get an
ArrayIndexOutOfBoundException:

```
il.remove(5);
```

This patch causes calls to .get to throw exceptions instead of returning
0 (or null in the case of StringList) for uninitialized values.
