### PR TITLE
Fix processing.mode.java.runner.Runner's exception trace for when the file name of a StackTraceElement is not known ( Fixes Issue #2346 )

### DIFF
--- a/app/src/processing/mode/java/runner/Runner.java
+++ b/app/src/processing/mode/java/runner/Runner.java
@@ -923,7 +923,7 @@ public class Runner implements MessageConsumer {
         ObjectReference ref = (ObjectReference)val;
         method = ((ClassType) ref.referenceType()).concreteMethodByName("getFileName", "()Ljava/lang/String;");
         StringReference strref = (StringReference) ref.invokeMethod(thread, method, new ArrayList<Value>(), ObjectReference.INVOKE_SINGLE_THREADED);
-        String filename = strref.value();
+        String filename = strref == null ? "Unknown Source" : strref.value();
         method = ((ClassType) ref.referenceType()).concreteMethodByName("getLineNumber", "()I");
         IntegerValue intval = (IntegerValue) ref.invokeMethod(thread, method, new ArrayList<Value>(), ObjectReference.INVOKE_SINGLE_THREADED);
         int lineNumber = intval.intValue() - 1;


### PR DESCRIPTION
StackTraceElement.getFileName() returns null when the source file is not known. [source](http://docs.oracle.com/javase/7/docs/api/java/lang/StackTraceElement.html#getFileName%28%29)

Fixes issue #2346.
