### PR TITLE
Create a JFileChooser as a field in order to remember current directory.

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -127,6 +127,8 @@ public class Base {
   private JMenu sketchbookMenu;
 
   private Recent recent;
+
+  private JFileChooser fileChooser; // to remember the current directory
 //  private JMenu recentMenu;
 
   static protected File sketchbookFolder;
@@ -851,10 +853,13 @@ public class Base {
       }
 
     } else {
-      JFileChooser fc = new JFileChooser();
-      fc.setDialogTitle(prompt);
+      if (fileChooser == null)
+      {
+        fileChooser = new JFileChooser();
+      }
+      fileChooser.setDialogTitle(prompt);
 
-      fc.setFileFilter(new javax.swing.filechooser.FileFilter() {
+      fileChooser.setFileFilter(new javax.swing.filechooser.FileFilter() {
         public boolean accept(File file) {
           // JFileChooser requires you to explicitly say yes to directories
           // as well (unlike the AWT chooser). Useful, but... different.
@@ -874,8 +879,8 @@ public class Base {
           return "Processing Sketch";
         }
       });
-      if (fc.showOpenDialog(activeEditor) == JFileChooser.APPROVE_OPTION) {
-        handleOpen(fc.getSelectedFile().getAbsolutePath());
+      if (fileChooser.showOpenDialog(activeEditor) == JFileChooser.APPROVE_OPTION) {
+        handleOpen(fileChooser.getSelectedFile().getAbsolutePath());
       }
     }
   }


### PR DESCRIPTION
On Linux, when you do a File/Open, you always go back to the default directory. If you need to open several sketches from a deeply nested folder, this can be annoying. By creating a JFileChooser member of the class Base, the file chooser will "remember" your current directory.
