### PR TITLE
Fix NPE in PDE, affecting color picker and other Tools.

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2369,7 +2369,9 @@ public class PApplet extends Applet
           render();
         } else {
           Graphics screen = getGraphics();
-          screen.drawImage(g.image, 0, 0, width, height, null);
+          if (screen != null) {
+            screen.drawImage(g.image, 0, 0, width, height, null);
+          }
         }
       } else {
         repaint();


### PR DESCRIPTION
A couple of Tools in the Base menu are not rendering due to NullPointerExceptions early in the PApplet lifecycle. This patch fixes those.
