### PR TITLE
Added accessor methods for Editor Status properties

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2551,6 +2551,21 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
   }
 
+  /**
+   * Returns the current notice message in the 
+   * editor status bar.
+   */
+  public String getStatusMessage(){
+    return status.message;
+  }
+  
+  /**
+   * Returns the current mode of the editor status bar 
+   * NOTICE, ERR or EDIT 
+   */
+  public int getStatusMode(){
+    return status.mode;
+  }
 
   /**
    * Clear the status area.

--- a/app/src/processing/app/EditorStatus.java
+++ b/app/src/processing/app/EditorStatus.java
@@ -36,11 +36,11 @@ public class EditorStatus extends JPanel {
   Color[] bgcolor;
   Color[] fgcolor;
 
-  static final int NOTICE = 0;
-  static final int ERR    = 1;
+  public static final int NOTICE = 0;
+  public static final int ERR    = 1;
   //static final int PROMPT = 2;
   //static final int EDIT   = 3;
-  static final int EDIT   = 2;
+  public static final int EDIT   = 2;
 
   static final int YES    = 1;
   static final int NO     = 2;


### PR DESCRIPTION
Added two methods to Editor - getStatusMessage() and getStatusMode(), as discussed in #2430
