### PR TITLE
Do not set indeterminate state on progress bars

### DIFF
--- a/app/src/processing/app/contrib/ContributionPanel.java
+++ b/app/src/processing/app/contrib/ContributionPanel.java
@@ -484,7 +484,7 @@ class ContributionPanel extends JPanel {
 
   protected void resetInstallProgressBarState() {
     installProgressBar.setString("Starting");
-    installProgressBar.setIndeterminate(true);
+    installProgressBar.setIndeterminate(false);
     installProgressBar.setValue(0);
     installProgressBar.setVisible(false);
   }


### PR DESCRIPTION
The progress bars for installing third-party libraries were initialized
with indeterminate mode.  This results in a pretty _I'm doing something_
animation which slows down the system.  Furthermore, the progress bars are
not even visible, so there is no need for any animation.

Fixes processing#1561
