### PR TITLE
Do not wait for debugger to start running sketch

### DIFF
--- a/app/src/processing/mode/java/runner/Runner.java
+++ b/app/src/processing/mode/java/runner/Runner.java
@@ -678,7 +678,9 @@ public class Runner implements MessageConsumer {
 
             for (Event event : eventSet) {
 //              System.out.println("EventThread.handleEvent -> " + event);
-              if (event instanceof ExceptionEvent) {
+              if (event instanceof VMStartEvent) {
+                vm.resume();
+              } else if (event instanceof ExceptionEvent) {
 //                for (ThreadReference thread : vm.allThreads()) {
 //                  System.out.println("thread : " + thread);
 ////                  thread.suspend();
@@ -709,14 +711,6 @@ public class Runner implements MessageConsumer {
                                          System.out);
     errThread.start();
     outThread.start();
-
-    try {
-        Thread.sleep(1000);
-    } catch(InterruptedException ex) {
-        Thread.currentThread().interrupt();
-    }
-
-    vm.resume();
 
     // Shutdown begins when event thread terminates
     try {


### PR DESCRIPTION
By default, the java VM is started with options for attaching a remote
debugger.  The sketch is suspended until the remote debugger connects.
This always succeeds the first time a sketch is run.  At least on OS X
10.9, this seems to be very fragile, and successive runs of the sketch
often fail to start.  This commit tells the VM to _not_ wait for the
debugger before starting the sketch.

Fixes processing#2402
