### PR TITLE
Fix #364 if-else autoformatting

### DIFF
--- a/app/src/processing/mode/java/AutoFormat.java
+++ b/app/src/processing/mode/java/AutoFormat.java
@@ -154,8 +154,8 @@ public class AutoFormat implements Formatter {
       if (lastNonSpaceChar() == '}') {
         trimRight(result);
         result.append(" ");
-        e_flg = false;
       }
+      e_flg = false;
     }
     result.append(buf);
     buf.setLength(0);


### PR DESCRIPTION
The auto-formatting of if-else statements, specifically the new line for else, has bugged me for a long time, but I always though this was the intended formatting style in Processing. Until I saw issue #364 today. So apparantly it is an issue, outstanding!

This pull request fixes the issue at hand, while having no impact on other auto-formatting results as different users have pointed out in issue #1791 in reply to an earlier - now revoked - fix by another user. All different code examples were extensively tested against both 2.1.2 and the patched code. Additional spaces and hard returns are also handled correctly by the patched code. Once again, the result is that the bug is fixed and no other auto-formatting results are impacted.

For a full comparison, see below:

**Code examples that neither 2.1.2 or the patched code change after running auto-format:**

INITIAL & AUTO-FORMATTED CODE:

``` java
if (true) background(0);
else if (true) background(0);

if (true) background(0); // comment
else if (true) background(0);

if (true) {
  background(0);
}
// comment
else if (true) {
  background(0);
}
```

**Code examples that 2.1.2 and the patched code both change in the exact same way after running auto-format:**

INITIAL CODE:

``` java
if (true) background(0); else if (true) background(0);

if (true) background(0); else background(0);
```

AUTO-FORMATTED CODE (both in 2.1.2 and the patched code):

``` java
if (true) background(0); 
else if (true) background(0);

if (true) background(0); 
else background(0);
```

**Code examples that differ in how 2.1.2 and the patched code handle them:**

INITIAL CODE:

``` java
if (true) {
  background(0);
} else {
  background(0);
}

if (true) { background(0); } else if (true) { background(0); }
```

AUTO-FORMATTED CODE (2.1.2):

``` java
if (true) {
  background(0);
} 
else {
  background(0);
}

if (true) { 
  background(0);
} 
else if (true) { 
  background(0);
}
```

AUTO-FORMATTED CODE (patched code):

``` java
if (true) {
  background(0);
} else {
  background(0);
}

if (true) { 
  background(0);
} else if (true) { 
  background(0);
}
```

For your consideration...
