### PR TITLE
Add related entry (frameCount) to saveFrame() reference

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -4270,6 +4270,7 @@ public class PApplet extends Applet
    * @webref output:image
    * @see PApplet#save(String)
    * @see PApplet#createGraphics(int, int, String, String)
+   * @see PApplet#frameCount
    * @param filename any sequence of letters or numbers that ends with either ".tif", ".tga", ".jpg", or ".png"
    */
   public void saveFrame(String filename) {


### PR DESCRIPTION
Fixes processing/processing-web#357 (on the processing side).

Works in tandem with processing/processing-web#408.
