### PR TITLE
Permit mouse PRESS to set mouseX/mouseY.

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2772,10 +2772,14 @@ public class PApplet extends Applet
     // also prevents mouseExited() on the mac from hosing the mouse
     // position, because x/y are bizarre values on the exit event.
     // see also the id check below.. both of these go together.
-    // Not necessary to set mouseX/Y on PRESS or RELEASE events because the
-    // actual position will have been set by a MOVE or DRAG event.
-    if (event.getAction() == MouseEvent.DRAG ||
-        event.getAction() == MouseEvent.MOVE) {
+    // Not necessary to set mouseX/Y on RELEASE events because the
+    // actual position will have been set by a PRESS or DRAG event.
+    // However, PRESS events might come without a preceeding move,
+    // if the sketch window gains focus on that PRESS.
+    final int action = event.getAction();
+    if (action == MouseEvent.DRAG ||
+        action == MouseEvent.MOVE ||
+        action == MouseEvent.PRESS) {
       pmouseX = emouseX;
       pmouseY = emouseY;
       mouseX = event.getX();
@@ -2809,7 +2813,7 @@ public class PApplet extends Applet
     // Do this up here in case a registered method relies on the
     // boolean for mousePressed.
 
-    switch (event.getAction()) {
+    switch (action) {
     case MouseEvent.PRESS:
       mousePressed = true;
       break;
@@ -2820,7 +2824,7 @@ public class PApplet extends Applet
 
     handleMethods("mouseEvent", new Object[] { event });
 
-    switch (event.getAction()) {
+    switch (action) {
     case MouseEvent.PRESS:
 //      mousePressed = true;
       mousePressed(event);
@@ -2849,8 +2853,8 @@ public class PApplet extends Applet
       break;
     }
 
-    if ((event.getAction() == MouseEvent.DRAG) ||
-        (event.getAction() == MouseEvent.MOVE)) {
+    if ((action == MouseEvent.DRAG) ||
+        (action == MouseEvent.MOVE)) {
       emouseX = mouseX;
       emouseY = mouseY;
     }

--- a/core/src/processing/event/MouseEvent.java
+++ b/core/src/processing/event/MouseEvent.java
@@ -117,4 +117,33 @@ public class MouseEvent extends Event {
 //  public void setClickCount(int clickCount) {
 //    this.clickCount = clickCount;
 //  }
+
+  private String actionString() {
+    switch (action) {
+    default:
+      return "UNKNOWN";
+    case CLICK:
+      return "CLICK";
+    case DRAG:
+      return "DRAG";
+    case ENTER:
+      return "ENTER";
+    case EXIT:
+      return "EXIT";
+    case MOVE:
+      return "MOVE";
+    case PRESS:
+      return "PRESS";
+    case RELEASE:
+      return "RELEASE";
+    case WHEEL:
+      return "WHEEL";
+    }
+  }
+
+  @Override
+  public String toString() {
+    return String.format("<MouseEvent %s@%d,%d count:%d button:%d>",
+                         actionString(), x, y, count, button);
+  }
 }


### PR DESCRIPTION
If the sketch window happens to gain focus from the mouse press event, without this code, mouseX and mouseY are both 0 when mousePressed gets called.
