### PR TITLE
Allow receiving video capture events without java reflection.

### DIFF
--- a/java/libraries/video/src/processing/video/CaptureHandler.java
+++ b/java/libraries/video/src/processing/video/CaptureHandler.java
@@ -1,0 +1,5 @@
+package processing.video;
+
+public interface CaptureHandler {
+  public void handleCapture(Capture capture);
+}

--- a/java/libraries/video/src/processing/video/ReflectionCaptureHandler.java
+++ b/java/libraries/video/src/processing/video/ReflectionCaptureHandler.java
@@ -1,0 +1,30 @@
+package processing.video;
+
+import java.lang.reflect.Method;
+
+public class ReflectionCaptureHandler implements CaptureHandler {
+
+  private final Object instance;
+  private final Method handler;
+  private boolean ok = true;
+
+  public ReflectionCaptureHandler(Object instance, Method handler) {
+    this.instance = instance;
+    this.handler = handler;
+  }
+
+  @Override
+  public void handleCapture(Capture capture) {
+    if (!ok) {
+      return;
+    }
+    try {
+      handler.invoke(instance, capture);
+    } catch (Exception e) {
+      System.err.println("error, disabling captureEvent() for capture object");
+      e.printStackTrace();
+      ok = false;
+    }
+  }
+
+}


### PR DESCRIPTION
This permits Python mode sketches to receive capture events (without breaking compatibility with all existing Java-mode sketches that simply define captureEvent()).

Examples:

``` python
def handleCaptureEvent(capture):
    capture.read()
cam.setCaptureHandler(handleCaptureEvent)

# or even

cam.setCaptureHandler(lambda cam: cam.read())
```
