### PR TITLE
Permit implementing captureEvent without having to link to Capture at buildtime.

### DIFF
--- a/java/libraries/video/src/processing/video/Capture.java
+++ b/java/libraries/video/src/processing/video/Capture.java
@@ -1018,19 +1018,8 @@ public class Capture extends PImage implements PConstants {
       return;
     }
 
-    // Creates a captureEvent.
-    if (captureEventMethod != null) {
-      try {
-        captureEventMethod.invoke(eventHandler, this);
-      } catch (Exception e) {
-        System.err.println(
-          "error, disabling captureEvent() for capture object");
-        e.printStackTrace();
-        captureEventMethod = null;
-      }
-    }
+    fireCaptureEvent();
   }
-
 
   protected synchronized void invokeEvent(int w, int h, Buffer buffer) {
     available = true;
@@ -1044,6 +1033,10 @@ public class Capture extends PImage implements PConstants {
     }    
     natBuffer = buffer;
 
+    fireCaptureEvent();
+  }
+
+  private void fireCaptureEvent() {
     // Creates a captureEvent.
     if (captureEventMethod != null) {
       try {
@@ -1056,7 +1049,6 @@ public class Capture extends PImage implements PConstants {
       }
     }
   }
-
 
   ////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This is useful for Python mode, or potentially any other Java-compatible Processing that doesn't allow reflection on the sketch.

This doesn't break any existing sketches, nor introduce the necessity for callback-passing or interfaces.
