### PR TITLE
disable the selection of current mode to fix #2545

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -386,9 +386,13 @@ public abstract class Editor extends JFrame implements RunnerListener {
     for (final Mode m : base.getModeList()) {
       if (mode == m) {
         JRadioButtonMenuItem item = new JRadioButtonMenuItem(m.getTitle());
-        // doesn't need a listener, since it doesn't do anything
+        item.addItemListener(new ItemListener() {
+          public void itemStateChanged(ItemEvent e) {
+            JRadioButtonMenuItem item = (JRadioButtonMenuItem) e.getSource();
+            item.setSelected(true);
+          }
+        });
         item.setSelected(true);
-        item.setEnabled(false);
         modeMenu.add(item);
       } else {
         JMenuItem item = new JMenuItem(m.getTitle());


### PR DESCRIPTION
Adds a menu item listener to keep the current mode always selected in the mode menu (in case someone clicks it). Fixes issue #2545 .
