### PR TITLE
fix prev/next tab menu options

### DIFF
--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -555,27 +555,22 @@ public class EditorHeader extends JComponent {
     KeyStroke ctrlAltLeft =
       KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, Toolkit.SHORTCUT_ALT_KEY_MASK);
     item.setAccelerator(ctrlAltLeft);
-    // this didn't want to work consistently
-    /*
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          editor.sketch.prevCode();
+          editor.sketch.handlePrevCode();
         }
       });
-    */
     menu.add(item);
 
     item = new JMenuItem("Next Tab");
     KeyStroke ctrlAltRight =
       KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, Toolkit.SHORTCUT_ALT_KEY_MASK);
     item.setAccelerator(ctrlAltRight);
-    /*
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          editor.sketch.nextCode();
+          editor.sketch.handleNextCode();
         }
       });
-    */
     menu.add(item);
 
     Sketch sketch = editor.getSketch();


### PR DESCRIPTION
The code for the previous / next tab menu works for me now. This fixes issue #179 where the current menu options do nothing when clicked (but did work via key strokes).
