### PR TITLE
Fixes NPE when writing to disconnected client, Issue #2577

### DIFF
--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -309,8 +309,8 @@ public class Server implements Runnable {
   public void write(int data) {  // will also cover char
     int index = 0;
     while (index < clientCount) {
-      clients[index].write(data);
       if (clients[index].active()) {
+        clients[index].write(data);
         index++;
       } else {
         removeIndex(index);
@@ -322,8 +322,8 @@ public class Server implements Runnable {
   public void write(byte data[]) {
     int index = 0;
     while (index < clientCount) {
-      clients[index].write(data);
       if (clients[index].active()) {
+        clients[index].write(data);
         index++;
       } else {
         removeIndex(index);
@@ -335,8 +335,8 @@ public class Server implements Runnable {
   public void write(String data) {
     int index = 0;
     while (index < clientCount) {
-      clients[index].write(data);
       if (clients[index].active()) {
+        clients[index].write(data);
         index++;
       } else {
         removeIndex(index);


### PR DESCRIPTION
In every situation I have tested, checking if the client is active before writing to the client prevents the NPE message but does not change the functionality.  I have not been able to create an instance where the act of calling the write method before checking if the client is active has the effect of changing the active() method to return False when it would have otherwise returned True.
