### PR TITLE
Fixes Issue #2576 NPE when calling ip() on disconnected clients.

### DIFF
--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -77,6 +77,7 @@ public class Client implements Runnable {
       socket = new Socket(this.host, this.port);
       input = socket.getInputStream();
       output = socket.getOutputStream();
+      ip = socket.getInetAddress().getHostAddress();
 
       thread = new Thread(this);
       thread.start();
@@ -123,6 +124,7 @@ public class Client implements Runnable {
 
     input = socket.getInputStream();
     output = socket.getOutputStream();
+    ip = socket.getInetAddress().getHostAddress();
 
     thread = new Thread(this);
     thread.start();
@@ -274,7 +276,7 @@ public class Client implements Runnable {
    * @brief Returns the IP address of the machine as a String
    */
   public String ip() {
-    return socket.getInetAddress().getHostAddress();
+    return ip;
   }
 
 


### PR DESCRIPTION
I went with the option of returning the ip address that was used when the connection was active.
