### PR TITLE
Line coloring is now proper for filtered contributions (both when comboBox and filterFields are used for filtering)

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -106,7 +106,7 @@ public class ContributionManagerDialog {
               status.setErrorMessage("Connection timed out while " +
                                      "downloading the contribution list.");
             } else {
-              status.setErrorMessage("Could not download the list" +
+              status.setErrorMessage("Could not download the list " +
                                      "of available contributions.");
             }
             exception.printStackTrace();
@@ -163,6 +163,7 @@ public class ContributionManagerDialog {
             category = null;
           }
           filterLibraries(category, filterField.filters);
+          contributionListPanel.updateColors();
         }
       });
       
@@ -419,6 +420,8 @@ public class ContributionManagerDialog {
       filter = filter.replaceAll("[^\\x30-\\x39^\\x61-\\x7a^\\x3a]", " ");
       filters = Arrays.asList(filter.split(" "));
       filterLibraries(category, filters);
+
+      contributionListPanel.updateColors();
     }
 
     public String getFilterText() {


### PR DESCRIPTION
This commit fixes [Issue #2583](https://github.com/processing/processing/issues/2583).

The only thing that needed to be done was to call the updateColors() method every time either a choice is made using the comboBox, or something is typed in the filterField.
