### PR TITLE
Fix opengl MULTIPLY blend mode

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -6042,7 +6042,7 @@ public class PGraphicsOpenGL extends PGraphics {
       if (blendEqSupported) {
         pgl.blendEquation(PGL.FUNC_ADD);
       }
-      pgl.blendFunc(PGL.DST_COLOR, PGL.SRC_COLOR);
+      pgl.blendFunc(PGL.DST_COLOR, PGL.ONE_MINUS_SRC_ALPHA);
 
     } else if (blendMode == SCREEN) {
       if (blendEqSupported) {


### PR DESCRIPTION
This changes the opengl multiply blend mode implementation so the output matches the default renderer.

Consider:

``` java
void setup() {
  size(500,500);
  background(255);
  noStroke();
}

void draw() {
  background(255);
  blendMode(BLEND);
  fill(#3D59AB);
  ellipse(width*0.3, height*0.5, width*0.5, height*0.5);
  blendMode(MULTIPLY);
  fill(#FFD700);
  ellipse(width*0.7, height*0.5, width*0.5, height*0.5);
}
```

Result:
![output](https://cloud.githubusercontent.com/assets/1057304/3308283/6361653e-f67a-11e3-95f8-089ceeeb8f10.png)

Change the size method to use P2D instead and you get:
![p2d_output](https://cloud.githubusercontent.com/assets/1057304/3308298/bcaa917e-f67a-11e3-9e2e-dfc02757d4f6.png)

This change makes the P2D renderer output the same as the JAVA2D renderer. 
