### PR TITLE
PdeKeyListener.java: tab key behaves correctly if !editor.tabs.expand

### DIFF
--- a/app/src/processing/mode/java/PdeKeyListener.java
+++ b/app/src/processing/mode/java/PdeKeyListener.java
@@ -194,6 +194,9 @@ public class PdeKeyListener {
         textarea.setSelectedText(spaces(tabSize));
         event.consume();
         return true;
+      } else if (!Preferences.getBoolean("editor.tabs.expand")) {
+        textarea.setSelectedText("\t");
+        event.consume();
       }
       break;
 


### PR DESCRIPTION
If the `editor.tabs.expand` preference setting is set to `false` (tabs 
are _not_ expanded to spaces), insert a tab character when the tab key 
is pressed. Previously nothing would be inserted.

Current (incorrect) behaviour:
![processing-expand-tab-2014 06 22](https://cloud.githubusercontent.com/assets/342964/3352193/470ef188-fa37-11e3-8ffd-81f5cce20844.gif)
