### PR TITLE
Correct mode is now selected in modeMenu,  resolving Issue #2615

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -390,6 +390,16 @@ public abstract class Editor extends JFrame implements RunnerListener {
       item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           base.changeMode(m);
+          if (sketch.isModified()) {
+            for (Component c : modeMenu.getPopupMenu().getComponents()) {
+              if (c instanceof JRadioButtonMenuItem) {
+                if (((JRadioButtonMenuItem)c).getText() == mode.getTitle()) {
+                  ((JRadioButtonMenuItem)c).setSelected(true);
+                  break;
+                }
+              }
+            }
+          }
         }
       });
       modeMenu.add(item);


### PR DESCRIPTION
This resolves [Issue #2615](https://github.com/processing/processing/issues/2615), where trying to change the Mode when there are unsaved changes doesn't change the mode, but shows the mode as being changed in the modeMenu popup. What has been done is that in case there are unsaved changes in the sketch, the last mode is selected again.
