### PR TITLE
Fixes ant building on Windows

### DIFF
--- a/build/windows/config-cmd.xml
+++ b/build/windows/config-cmd.xml
@@ -35,7 +35,7 @@
     <!-- for 2.2, set a minimum version -->
     <minVersion>1.7.0_40</minVersion>
     <!-- increase available per PDE X request -->
-    <maxHeapSize>256m</maxHeapSize>
+    <maxHeapSize>256</maxHeapSize>
   </jre>
   <messages>
     <startupErr>An error occurred while starting the application.</startupErr>

--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -35,7 +35,7 @@
     <!-- for 2.2, set a minimum version -->
     <minVersion>1.7.0_40</minVersion>
     <!-- increase available per PDE X request -->
-    <maxHeapSize>256m</maxHeapSize>
+    <maxHeapSize>256</maxHeapSize>
   </jre>
   <splash>
     <file>about.bmp</file>


### PR DESCRIPTION
There is `java.lang.NumberFormatException` on `256m`, there should be just `256`. After the change, building on Windows works as expected.
