### PR TITLE
File changed detection, Issue #1939

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2400,7 +2400,12 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
         @Override
         public void windowLostFocus(WindowEvent arg0){
-          //do nothing
+          List<WatchEvent<?>> events = finKey.pollEvents();
+          //don't ask to reload a file we saved
+          if(!saved){
+            processFileEvents(events);
+          }
+          saved = false;
         }
       };
       //the key can now be polled for changes in the files
@@ -2424,10 +2429,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       //this makes things.... complicated
       //System.out.println(e.context());
       
-      //don't ask to reload a file we saved
-      if(saved){
-        break;
-      }
+
       //if we already reloaded in this cycle, then don't reload again
       if (didReload){
         break;


### PR DESCRIPTION
https://github.com/processing/processing/issues/1939

This monitors the open sketch for modifications to the file that it contains and offers the user the option to reload the sketch.

There are a few issues with this implementation, due to how java.nio works.
- The monitor detects, when files are modified, but not when they are deleted or created
- The monitor detects any files modified in the sketch directory, not just source
- The monitor can have a miss an update if a file was saved inside the editor and then a file was modified from outside the editor within 5 seconds (give or take)
- There is no way for the monitor to easily detect which file was modified, so the entire sketchbook is updated
