### PR TITLE
Clearing the status bar in the proper way

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2635,7 +2635,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * Clear the status area.
    */
   public void statusEmpty() {
-    statusNotice(EMPTY);
+    status.empty();
   }
 
 


### PR DESCRIPTION
For the past 10 years the status bar has been cleared by printing spaces
over its previous contents. This commit tries to add more sanity where
it is definitely needed.
