### PR TITLE
Fixes blending operations in Java2D

### DIFF
--- a/core/src/processing/core/PGraphicsJava2D.java
+++ b/core/src/processing/core/PGraphicsJava2D.java
@@ -743,11 +743,14 @@ public class PGraphicsJava2D extends PGraphics {
       int[] srcPixels = new int[width];
       int[] dstPixels = new int[width];
 
+      // Java won't set the high bits when RGB, returns 0 for alpha
+      int alphaFiller = (dstIn.getNumBands() == 3) ? (0xFF << 24) : 0x00;
+
       for (int y = 0; y < height; y++) {
         src.getDataElements(0, y, width, 1, srcPixels);
         dstIn.getDataElements(0, y, width, 1, dstPixels);
         for (int x = 0; x < width; x++) {
-          dstPixels[x] = blendColor(srcPixels[x], dstPixels[x], mode);
+          dstPixels[x] = blendColor(srcPixels[x], alphaFiller | dstPixels[x], mode);
         }
         dstOut.setDataElements(0, y, width, 1, dstPixels);
       }
@@ -1671,7 +1674,7 @@ public class PGraphicsJava2D extends PGraphics {
     if (textFont == null) {
       defaultFontOrDeath("textWidth");
     }
-        
+
     Font font = (Font) textFont.getNative();
     //if (font != null && (textFont.isStream() || hints[ENABLE_NATIVE_FONTS])) {
     if (font != null) {


### PR DESCRIPTION
Fixes #2012, fixes #2275. It's the same problem as #2030 - Java won't
set the high bits when destination is RGB, returns 0 for alpha in
BlendingContext#compose(Raster, Raster, WritableRaster). That's why blending operations in Java2D didn't work properly.
