### PR TITLE
Help>References and Help>Environment open in default browser in Windows

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1232,6 +1232,11 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
   public void showReference(String filename) {
     File file = new File(mode.getReferenceFolder(), filename);
+    try {
+      file = file.getCanonicalFile();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
     // Prepend with file:// and also encode spaces & other characters
     Base.openURL(file.toURI().toString());
   }


### PR DESCRIPTION
This fixes [#2656](https://github.com/processing/processing/issues/2656)
