### PR TITLE
Fix index out of bounds for OffsetMatcher

### DIFF
--- a/pdex/src/processing/mode/experimental/OffsetMatcher.java
+++ b/pdex/src/processing/mode/experimental/OffsetMatcher.java
@@ -90,12 +90,16 @@ public class OffsetMatcher {
         continue;
       } else if (offsetMatch.get(i).javaOffset == javaOff) {
 //        int j = i;
-        while (offsetMatch.get(--i).javaOffset == javaOff) {
+//        while (offsetMatch.get(--i).javaOffset == javaOff) {
 //          log("MP " + offsetMatch.get(i).javaOffset + " "
 //              + offsetMatch.get(i).pdeOffset);
+//        }
+
+        if (i > 0) {
+            int pdeOff = offsetMatch.get(i++).pdeOffset;
+            while (i > 0 && offsetMatch.get(--i).pdeOffset == pdeOff);            
         }
-        int pdeOff = offsetMatch.get(++i).pdeOffset;
-        while (i > 0 && offsetMatch.get(--i).pdeOffset == pdeOff);
+
         int j = i + 1;
         if (j > -1 && j < offsetMatch.size())
           return offsetMatch.get(j).pdeOffset;


### PR DESCRIPTION
Fix for exception triggered when removing the last curly bracket.

TODO:
- [ ] line number for the curly bracket is still incorrect

Note:
- classes to look for bugs : ErrorCheckerService and OffsetMatcher
