### PR TITLE
Status Messages/Errors now clear in Contribution Managers

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -125,6 +125,7 @@ public class ContributionManagerDialog {
    * Close the window after an OK or Cancel.
    */
   protected void disposeFrame() {
+    status.clear();
     dialog.dispose();
     editor = null;
   }

--- a/app/src/processing/app/contrib/ContributionPanel.java
+++ b/app/src/processing/app/contrib/ContributionPanel.java
@@ -101,6 +101,7 @@ class ContributionPanel extends JPanel {
 
     installActionListener = new ActionListener() {
       public void actionPerformed(ActionEvent e) {
+        listPanel.contribManager.status.clear();
         if (contrib instanceof AvailableContribution) {
           installContribution((AvailableContribution) contrib);
           contribListing.replaceContribution(contrib, contrib);
@@ -110,6 +111,7 @@ class ContributionPanel extends JPanel {
 
     undoActionListener = new ActionListener() {
       public void actionPerformed(ActionEvent e) {
+        listPanel.contribManager.status.clear();
         if (contrib instanceof LocalContribution) {
           LocalContribution installed = (LocalContribution) contrib;
           installed.setDeletionFlag(false);
@@ -120,6 +122,7 @@ class ContributionPanel extends JPanel {
 
     removeActionListener = new ActionListener() {
       public void actionPerformed(ActionEvent arg) {
+        listPanel.contribManager.status.clear();
         if (contrib.isInstalled() && contrib instanceof LocalContribution) {
           updateButton.setEnabled(false);
           installRemoveButton.setEnabled(false);
@@ -211,6 +214,7 @@ class ContributionPanel extends JPanel {
       updateButton.setVisible(false);
       updateButton.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
+          listPanel.contribManager.status.clear();
           updateButton.setEnabled(false);
           AvailableContribution ad = contribListing.getAvailableContribution(contrib);
           String url = ad.link;

--- a/app/src/processing/app/contrib/StatusPanel.java
+++ b/app/src/processing/app/contrib/StatusPanel.java
@@ -45,6 +45,11 @@ class StatusPanel extends JLabel {
     setText(message);
     repaint();
   }
+  
+  void clear() {
+    setText("");
+    repaint();
+  }
 }
 
 


### PR DESCRIPTION
This resolves Issue [#2599](https://github.com/processing/processing/issues/2599).

Status and error messages in the contribution (library/tool/mode/update managers) now clear when the user closes the manager, or when the user installs a contribution, removes a contribution, undoes a remove or updates a contribution.
