### PR TITLE
fix firstLine when modifying lines above it (fixes #2654)

### DIFF
--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -414,6 +414,11 @@ public class JEditTextArea extends JComponent
    * updating the scroll bars.
    */
   public void setFirstLine(int firstLine) {
+    if(firstLine < 0 || firstLine > getLineCount()) {
+      throw new IllegalArgumentException("First line out of range: "
+        + firstLine + " [0, " + getLineCount() + "]");
+    }
+
     if (firstLine == this.firstLine) return;
 
     this.firstLine = firstLine;
@@ -2086,7 +2091,7 @@ public class JEditTextArea extends JComponent
     // do magic stuff
     else if(line < firstLine)
     {
-      setFirstLine(firstLine + count);
+      setFirstLine(line);
     }
     // end of magic stuff
     else


### PR DESCRIPTION
Fix for #2654.

Fixed behavior when modifying lines above `firstLine`, the behavior is now like that of common text editors.

What would happen is `firstLine` would become negative and the next time `documentChanged` is triggered the `firstLine` would then be properly set and the text editor redrawn.

I'm not a wizard yet but setting firstLine to be a negative number sounds like witchcraft. I've added an exception to `setFirstLine()`.
