### PR TITLE
Allow python mode sketches to continue running after "Stop" button is pressed.

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10916,7 +10916,7 @@ public class PApplet extends Applet
         label.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(java.awt.event.MouseEvent e) {
-              System.exit(0);
+              applet.exit();
             }
           });
         frame.add(label);


### PR DESCRIPTION
This fixes a bug in Processing.py, https://github.com/jdf/processing.py-bugs/issues/91.
