### PR TITLE
Fix #2004 - Indent breaks when hitting enter before spaces

### DIFF
--- a/app/src/processing/mode/java/PdeKeyListener.java
+++ b/app/src/processing/mode/java/PdeKeyListener.java
@@ -304,9 +304,11 @@ public class PdeKeyListener {
           //textarea.setSelectionStart(origIndex + 1);
           textarea.setSelectionEnd(textarea.getSelectionStop() - spaceCount);
           textarea.setSelectedText("\n");
+          textarea.setCaretPosition(textarea.getCaretPosition() + extraCount + spaceCount);
         } else {
           String insertion = "\n" + spaces(spaceCount);
           textarea.setSelectedText(insertion);
+          textarea.setCaretPosition(textarea.getCaretPosition() + extraCount);
         }
 
         // not gonna bother handling more than one brace


### PR DESCRIPTION
Fix #2004 - Indent breaks when hitting enter before spaces

The underlying problem for this issue was not the indent itself, but the caret position afterwards.

This solution handles all possible situations:
- extra spaces after caret > indent (inside IF)
- extra spaces after caret <= indent (inside ELSE)
