### PR TITLE
Fix typo "platforms" in PDE.properties

### DIFF
--- a/app/src/processing/app/languages/PDE.properties
+++ b/app/src/processing/app/languages/PDE.properties
@@ -156,7 +156,7 @@ export.options = Options
 export.options.fullscreen = Full Screen (Present mode)
 export.options.show_stop_button = Show a Stop button
 export.description.line1 = Export to Application creates double-clickable, 
-export.description.line2 = standalone applications for the selected plaforms.
+export.description.line2 = standalone applications for the selected platforms.
 
 # Find (Frame)
 find = Find


### PR DESCRIPTION
Fixes a typo in PDE.properties (English) where "plaforms" should be "platforms"
