### PR TITLE
Fix build: Syntax error on token "<", ? expected after this token

### DIFF
--- a/pdex/src/processing/mode/experimental/VariableInspector.java
+++ b/pdex/src/processing/mode/experimental/VariableInspector.java
@@ -74,7 +74,7 @@ public class VariableInspector extends javax.swing.JFrame {
     protected List<VariableNode> declaredThisFields; // declared i.e. non-inherited fields of this
     protected DebugEditor editor; // the editor
     protected Debugger dbg; // the debugger
-    protected List<TreePath> expandedNodes = new ArrayList<>(); // list of expanded tree paths. (using list to maintain the order of expansion)
+    protected List<TreePath> expandedNodes = new ArrayList<TreePath>(); // list of expanded tree paths. (using list to maintain the order of expansion)
     protected boolean p5mode = true; // processing / "advanced" mode flag (currently not used
 
     /**
@@ -515,7 +515,7 @@ public class VariableInspector extends javax.swing.JFrame {
             // first remove all children of collapsed path
             // this makes sure children do not appear before parents in the list.
             // (children can't be expanded before their parents)
-            List<TreePath> removalList = new ArrayList<>();
+            List<TreePath> removalList = new ArrayList<TreePath>();
             for (TreePath path : expandedNodes) {
                 if (path.getParentPath().equals(tee.getPath())) {
                     removalList.add(path);

--- a/pdex/src/processing/mode/experimental/VariableNode.java
+++ b/pdex/src/processing/mode/experimental/VariableNode.java
@@ -53,7 +53,7 @@ public class VariableNode implements MutableTreeNode {
     protected String type;
     protected String name;
     protected Value value;
-    protected List<MutableTreeNode> children = new ArrayList<>();
+    protected List<MutableTreeNode> children = new ArrayList<MutableTreeNode>();
     protected MutableTreeNode parent;
 
     /**


### PR DESCRIPTION
Compiling in Mavericks with Java 1.7.0_65 fails with the following errors. Replacing diamond operators for standard generic parameters solves the problem.

```
    [javac] Compiling 2 source files to /processing/pdex/bin                                                            [11/429]
    [javac] ----------
    [javac] 1. WARNING in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 65)
    [javac]     public class VariableInspector extends javax.swing.JFrame {
    [javac]                  ^^^^^^^^^^^^^^^^^
    [javac] The serializable class VariableInspector does not declare a static final serialVersionUID field of type long
    [javac] ----------
    [javac] 2. ERROR in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 77)
    [javac]     protected List<TreePath> expandedNodes = new ArrayList<>(); // list of expanded tree paths. (using list to maintain the order of expansion)
    [javac]                                                           ^
    [javac] Syntax error on token "<", ? expected after this token
    [javac] ----------
    [javac] 3. WARNING in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 168)
    [javac]     public Class getColumnClass(int i) {
    [javac]            ^^^^^
    [javac] Class is a raw type. References to generic type Class<T> should be parameterized
    [javac] ----------
    [javac] 4. WARNING in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 393)
    [javac]     protected class ValueCellRenderer extends DefaultOutlineCellRenderer {
    [javac]                     ^^^^^^^^^^^^^^^^^
    [javac] The serializable class ValueCellRenderer does not declare a static final serialVersionUID field of type long
    [javac] ----------
    [javac] 5. WARNING in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 437)
    [javac]     protected class ValueCellEditor extends DefaultCellEditor {
    [javac]                     ^^^^^^^^^^^^^^^
    [javac] The serializable class ValueCellEditor does not declare a static final serialVersionUID field of type long
    [javac] ----------
    [javac] 6. ERROR in /processing/pdex/src/processing/mode/experimental/VariableInspector.java (at line 518)
    [javac]     List<TreePath> removalList = new ArrayList<>();
    [javac]                                               ^
    [javac] Syntax error on token "<", ? expected after this token
    [javac] ----------
    [javac] ----------
    [javac] 7. ERROR in /processing/pdex/src/processing/mode/experimental/VariableNode.java (at line 56)
    [javac]     protected List<MutableTreeNode> children = new ArrayList<>();
    [javac]                                                             ^
    [javac] Syntax error on token "<", ? expected after this token
    [javac] ----------
    [javac] 8. WARNING in /processing/pdex/src/processing/mode/experimental/VariableNode.java (at line 234)
    [javac]     public Enumeration children() {
    [javac]            ^^^^^^^^^^^
    [javac] Enumeration is a raw type. References to generic type Enumeration<E> should be parameterized
    [javac] ----------
    [javac] 8 problems (3 errors, 5 warnings)
```
