### PR TITLE
Use correct collection in Library.list

### DIFF
--- a/app/src/processing/app/Library.java
+++ b/app/src/processing/app/Library.java
@@ -498,7 +498,7 @@ public class Library extends LocalContribution {
       for (String subfolderName : list) {
         File subfolder = new File(folder, subfolderName);
 
-        if (!libraries.contains(subfolder)) {
+        if (!librariesFolders.contains(subfolder)) {
           ArrayList<File> discoveredLibFolders = new ArrayList<File>();
           discover(subfolder, discoveredLibFolders);
 


### PR DESCRIPTION
I'm not exactly sure what the code is trying to do, but `libraries` is an `ArrayList<Library>` so it can never contain a `File`. The author must have meant to use `librariesFolders`.
