### PR TITLE
Add translations to Dutch language file

### DIFF
--- a/app/src/processing/app/languages/PDE_nl.properties
+++ b/app/src/processing/app/languages/PDE_nl.properties
@@ -249,10 +249,10 @@ editor.status.drag_and_drop.files_added.n = %d bestanden toegevoegd aan de schet
 editor.status.saving = Bezig met opslaan...
 editor.status.saving.done = Opslaan gereed.
 editor.status.saving.canceled = Opslaan geannuleerd.
-editor.status.printing = Bezig met printen...
-editor.status.printing.done = Printen gereed.
-editor.status.printing.error = Fout tijdens het printen.
-editor.status.printing.canceled = Printen geannuleerd.
+editor.status.printing = Bezig met afdrukken...
+editor.status.printing.done = Afdrukken gereed.
+editor.status.printing.error = Fout tijdens het afdrukken.
+editor.status.printing.canceled = Afdrukken geannuleerd.
 
 
 # ---------------------------------------


### PR DESCRIPTION
I've added Dutch translations for all the new localization Strings.

The Dutch language file is now identical to and up to date with the current PDE.properties file.
