### PR TITLE
Fix unneeded scroll bar display in code completion suggestion box

### DIFF
--- a/pdex/src/processing/mode/experimental/CompletionPanel.java
+++ b/pdex/src/processing/mode/experimental/CompletionPanel.java
@@ -189,6 +189,9 @@ public class CompletionPanel {
 
     float h = itemHeight * (itemCount);
 
+    if (itemCount >= 4)
+    	h += itemHeight * 0.3; // a bit of offset
+
     return Math.min(maxHeight, (int) h); // popup menu height
   }
   


### PR DESCRIPTION
Fix for issue #2758 where unneeded horizontal and vertical scroll bars were displayed in the code completion suggestion box. A slight offset for both dimensions solves the issue.
