### PR TITLE
fix tiny typo in Table writeHTML()

### DIFF
--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -1108,7 +1108,7 @@ public class Table {
     writer.println("  </table>");
     writer.println("</body>");
 
-    writer.println("</hmtl>");
+    writer.println("</html>");
     writer.flush();
   }
 


### PR DESCRIPTION
just noticed a tiny typo in the writeHTML method of saveTable()
