### PR TITLE
Contributions Managers now show specific titles (like "Mode Manager", "Tool Manager", etc.) in the user's preferred language

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -44,6 +44,7 @@ public class ContributionManagerDialog {
   static final String ANY_CATEGORY = Language.text("contrib.all");
 
   JFrame dialog;
+  String title;
   ContributionFilter filter;
   JComboBox categoryChooser;
   JScrollPane scrollPane;
@@ -60,8 +61,16 @@ public class ContributionManagerDialog {
 
   public ContributionManagerDialog(ContributionType type) {
     if (type == null) {
+      title = Language.text("contrib.manager_title.update");
       filter = ContributionType.createUpdateFilter();
     } else {
+      if (type == ContributionType.MODE)
+        title = Language.text("contrib.manager_title.mode");
+      else if (type == ContributionType.TOOL)
+        title = Language.text("contrib.manager_title.tool");
+      else if (type == ContributionType.LIBRARY)
+        title = Language.text("contrib.manager_title.library");
+      
       filter = type.createFilter();    
     }
     contribListing = ContributionListing.getInstance();
@@ -83,7 +92,7 @@ public class ContributionManagerDialog {
     this.editor = editor;
 
     if (dialog == null) {
-      dialog = new JFrame(Language.text("contrib"));
+      dialog = new JFrame(title);
 
       restartButton = new JButton(Language.text("contrib.restart"));
       restartButton.setVisible(false);
@@ -97,7 +106,7 @@ public class ContributionManagerDialog {
             Editor ed = iter.next();
             if (ed.getSketch().isModified()) {
               int option = Base
-                .showYesNoQuestion(editor, Language.text("contrib"),
+                .showYesNoQuestion(editor, title,
                                    Language.text("contrib.unsaved_changes"),
                                    Language.text("contrib.unsaved_changes.prompt"));
 

--- a/app/src/processing/app/languages/PDE.properties
+++ b/app/src/processing/app/languages/PDE.properties
@@ -259,6 +259,10 @@ editor.status.printing.canceled = Printing canceled.
 # Contribution Panel
 
 contrib = Contribution Manager
+contrib.manager_title.update = Update Manager
+contrib.manager_title.mode = Mode Manager
+contrib.manager_title.tool = Tool Manager
+contrib.manager_title.library = Library Manager
 contrib.category = Category:
 contrib.filter_your_search = Filter your search...
 contrib.restart = Restart Processing


### PR DESCRIPTION
There was no contributions field in the PDE.properties, which caused a MissingResourceException to be thrown each time a Tool/Mode/Library Manager was started. Further, we may need the title String, since each of the managers will need their entire title specified (since concatenating the type.getTitle() with " Manager" would no longer work, since, for example, in French, it would be written the other way around).
