### PR TITLE
Catch MissingResourceException when language key is missing

### DIFF
--- a/app/src/processing/app/Language.java
+++ b/app/src/processing/app/Language.java
@@ -165,8 +165,13 @@ public class Language {
 
   /** Get translation from bundles. */
   static public String text(String text) {
-    String result = init().bundle.getString(text);
-    return (result == null) ? text : result;
+    ResourceBundle bundle = init().bundle;
+
+    try {
+      return bundle.getString(text);
+    } catch (MissingResourceException e) {
+      return text;
+    }
   }
 
   


### PR DESCRIPTION
I'm taking a wild guess here that the try/catch block will be faster for the happy cases than always checking if the key exists first.

Refs #2777
