### PR TITLE
Fix erroneous file change detection Issue #2759

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2563,16 +2563,10 @@ public abstract class Editor extends JFrame implements RunnerListener {
     statusNotice(Language.text("editor.status.saving"));
     try {
       if (sketch.saveAs()) {
-<<<<<<< HEAD
-        //a saveAs moves where the files are, so a listener must be attached to the new location
-        initFileChangeListener();
-        statusNotice("Done Saving.");
-=======
         // statusNotice("Done Saving.");
     	// status is now printed from Sketch so that "Done Saving."
     	// is only printed after Save As when progress bar is shown.  
     	  
->>>>>>> upstream/master
         // Disabling this for 0125, instead rebuild the menu inside
         // the Save As method of the Sketch object, since that's the
         // only one who knows whether something was renamed.

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -511,8 +511,6 @@ public class EditorHeader extends JComponent {
     item = Toolkit.newJMenuItemShift(Language.text("editor.header.new_tab"), 'N');
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          //prevent reload request
-          editor.setChanged();
           editor.getSketch().handleNewCode();
         }
       });
@@ -544,8 +542,6 @@ public class EditorHeader extends JComponent {
                                Language.text("editor.header.delete.warning.text"), null);
           } else {
             editor.getSketch().handleDeleteCode();
-            //prevent reload request
-            editor.setChanged();
           }
         }
       });


### PR DESCRIPTION
This should fix the erroneous file change detection that was noted by several users in issue #2759. 

It now only scans files which are part of the sketch for changes. 

There is still a possibilitiy for erroneous "file changed" messages if a file that is not part of the sketch is edited with gedit (this is the lesser of 2 evils, the other being a file edited with gedit wouldn't get reloaded)
