### PR TITLE
Split logging methods from Base

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -34,6 +34,7 @@ import javax.swing.*;
 import javax.swing.tree.*;
 
 import processing.app.contrib.*;
+import processing.app.logging.*;
 import processing.core.*;
 import processing.mode.java.JavaMode;
 
@@ -190,7 +191,7 @@ public class Base {
       } catch (Exception e) {
 //        String mess = e.getMessage();
 //        if (!mess.contains("ch.randelshofer.quaqua.QuaquaLookAndFeel")) {
-        log("Could not set the Look & Feel", e); //$NON-NLS-1$
+        Logger.log("Could not set the Look & Feel", e); //$NON-NLS-1$
 //        }
       }
 
@@ -204,7 +205,7 @@ public class Base {
                        "That's gonna prevent us from continuing.", e);
       }
 
-      log("about to create base..."); //$NON-NLS-1$
+      Logger.log("about to create base..."); //$NON-NLS-1$
       try {
         Base base = new Base(args);
         // Prevent more than one copy of the PDE from running.
@@ -216,7 +217,7 @@ public class Base {
         showBadnessTrace("We're off on the wrong foot",
                          "An error occurred during startup.", t, true);
       }
-      log("done creating base..."); //$NON-NLS-1$
+      Logger.log("done creating base..."); //$NON-NLS-1$
     }
   }
 
@@ -365,17 +366,17 @@ public class Base {
     String lastModeIdentifier = Preferences.get("last.sketch.mode"); //$NON-NLS-1$
     if (lastModeIdentifier == null) {
       nextMode = coreModes[0];
-      log("Nothing set for last.sketch.mode, using coreMode[0]."); //$NON-NLS-1$
+      Logger.log("Nothing set for last.sketch.mode, using coreMode[0]."); //$NON-NLS-1$
     } else {
       for (Mode m : getModeList()) {
         if (m.getIdentifier().equals(lastModeIdentifier)) {
-          logf("Setting next mode to %s.", lastModeIdentifier); //$NON-NLS-1$
+          Logger.logf("Setting next mode to %s.", lastModeIdentifier); //$NON-NLS-1$
           nextMode = m;
         }
       }
       if (nextMode == null) {
         nextMode = coreModes[0];
-        logf("Could not find mode %s, using default.", lastModeIdentifier); //$NON-NLS-1$
+        Logger.logf("Could not find mode %s, using default.", lastModeIdentifier); //$NON-NLS-1$
       }
     }
 
@@ -3170,34 +3171,5 @@ public class Base {
     }
     out.flush();
     out.close();
-  }
-
-
-  static public void log(Object from, String message) {
-    if (DEBUG) {
-      System.out.println(from.getClass().getName() + ": " + message);
-    }
-  }
-
-
-  static public void log(String message) {
-    if (DEBUG) {
-      System.out.println(message);
-    }
-  }
-
-
-  static public void logf(String message, Object... args) {
-    if (DEBUG) {
-      System.out.println(String.format(message, args));
-    }
-  }
-
-
-  static public void log(String message, Throwable e) {
-    if (DEBUG) {
-      System.out.println(message);
-      e.printStackTrace();
-    }
   }
 }

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -23,6 +23,7 @@
 package processing.app;
 
 import processing.app.contrib.ToolContribution;
+import processing.app.logging.Logger;
 import processing.app.syntax.*;
 import processing.app.tools.*;
 import processing.core.*;
@@ -1080,7 +1081,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
           statusError("\"" + tool.getMenuTitle() + "\" is not" +
                       "compatible with this version of Processing");
           //nsme.printStackTrace();
-          Base.log("Incompatible tool found during tool.run()", nsme);
+          Logger.log("Incompatible tool found during tool.run()", nsme);
           item.setEnabled(false);
 
         } catch (Exception ex) {
@@ -1114,13 +1115,13 @@ public abstract class Editor extends JFrame implements RunnerListener {
         System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
                            "compatible with this version of Processing");
         System.err.println("The " + nsme.getMessage() + " method no longer exists.");
-        Base.log("Incompatible Tool found during tool.init()", nsme);
+        Logger.log("Incompatible Tool found during tool.init()", nsme);
 
       } catch (NoClassDefFoundError ncdfe) {
         System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
                            "compatible with this version of Processing");
         System.err.println("The " + ncdfe.getMessage() + " class is no longer available.");
-        Base.log("Incompatible Tool found during tool.init()", ncdfe);
+        Logger.log("Incompatible Tool found during tool.init()", ncdfe);
 
       } catch (Error err) {
         System.err.println("An error occurred inside \"" + tool.getMenuTitle() + "\"");

--- a/app/src/processing/app/Library.java
+++ b/app/src/processing/app/Library.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.*;
 
 import processing.app.contrib.*;
+import processing.app.logging.Logger;
 import processing.core.*;
 
 
@@ -88,7 +89,7 @@ public class Library extends LocalContribution {
     try {
       return new Library(folder);
 //    } catch (IgnorableException ig) {
-//      Base.log(ig.getMessage());
+//      Logger.log(ig.getMessage());
     } catch (Error err) {
       // Handles UnsupportedClassVersionError and others
       err.printStackTrace();

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -25,6 +25,7 @@ import java.awt.*;
 import java.io.*;
 import java.util.*;
 
+import processing.app.logging.Logger;
 import processing.core.*;
 
 
@@ -345,7 +346,7 @@ public class Preferences {
     } catch (Exception e) {
       // Adding try/catch block because this may be where 
       // a lot of startup crashes are happening. 
-      Base.log("Error with font " + get(attr) + " for attribute " + attr); 
+      Logger.log("Error with font " + get(attr) + " for attribute " + attr);
     }
     return new Font("Dialog", Font.PLAIN, 12);
   }

--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -34,6 +34,7 @@ import javax.swing.event.*;
 
 import processing.app.ColorChooser;
 import processing.app.Language;
+import processing.app.logging.Logger;
 import processing.core.*;
 
 
@@ -721,7 +722,7 @@ public class PreferencesFrame {
       Preferences.set("editor.font.size", String.valueOf(selection));
 
     } catch (NumberFormatException e) {
-      Base.log("Ignoring invalid font size " + fontSizeField); //$NON-NLS-1$
+      Logger.log("Ignoring invalid font size " + fontSizeField); //$NON-NLS-1$
       fontSizeField.setSelectedItem(Preferences.getInteger("editor.font.size"));
     }
     
@@ -734,7 +735,7 @@ public class PreferencesFrame {
       Preferences.set("console.font.size", String.valueOf(selection));
 
     } catch (NumberFormatException e) {
-      Base.log("Ignoring invalid font size " + consoleSizeField); //$NON-NLS-1$
+      Logger.log("Ignoring invalid font size " + consoleSizeField); //$NON-NLS-1$
       consoleSizeField.setSelectedItem(Preferences.getInteger("console.font.size"));
     }
     

--- a/app/src/processing/app/Recent.java
+++ b/app/src/processing/app/Recent.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 
 import javax.swing.*;
 
+import processing.app.logging.Logger;
 import processing.core.PApplet;
 
 
@@ -80,7 +81,7 @@ public class Recent {
           if (new File(line).exists()) {  // don't add ghost entries
             records.add(new Record(line));
           } else {
-            Base.log(this, "ghost file: " + line);
+            Logger.log(this, "ghost file: " + line);
           }
         }
       }
@@ -229,7 +230,7 @@ public class Recent {
 //      rec.path = newPath;
 //      save();
 //    } else {
-//      Base.log(this, "Could not find " + oldPath +
+//      Logger.log(this, "Could not find " + oldPath +
 //               " in list of recent sketches to replace with " + newPath);
 //    }
 //  }

--- a/app/src/processing/app/Settings.java
+++ b/app/src/processing/app/Settings.java
@@ -27,6 +27,7 @@ import java.awt.*;
 import java.io.*;
 import java.util.*;
 
+import processing.app.logging.Logger;
 import processing.core.*;
 
 
@@ -224,7 +225,7 @@ public class Settings {
     } catch (Exception e) {
       // Adding try/catch block because this may be where 
       // a lot of startup crashes are happening. 
-      Base.log("Error with font " + get(attr) + " for attribute " + attr); 
+      Logger.log("Error with font " + get(attr) + " for attribute " + attr);
     }
     return new Font("Dialog", Font.PLAIN, 12);
   }

--- a/app/src/processing/app/SingleInstance.java
+++ b/app/src/processing/app/SingleInstance.java
@@ -29,6 +29,7 @@ import java.net.Socket;
 
 import javax.swing.SwingUtilities;
 
+import processing.app.logging.Logger;
 import processing.core.PApplet;
 
 
@@ -74,28 +75,28 @@ public class SingleInstance {
               Socket s = ss.accept();  // blocks (sleeps) until connection
               final BufferedReader reader = PApplet.createReader(s.getInputStream());
               String receivedKey = reader.readLine();
-              Base.log(this, "key is " + key + ", received is " + receivedKey);
-//              Base.log(this, "platform base is " + platform.base);
+              Logger.log(this, "key is " + key + ", received is " + receivedKey);
+//              Logger.log(this, "platform base is " + platform.base);
 
 //              if (platform.base != null) {
               if (key.equals(receivedKey)) {
                 SwingUtilities.invokeLater(new Runnable() {
                   public void run() {
                     try {
-                      Base.log(this, "about to read line");
+                      Logger.log(this, "about to read line");
                       String path = reader.readLine();
                       if (path == null) {
                         // Because an attempt was made to launch the PDE again,
                         // throw the user a bone by at least opening a new
                         // Untitled window for them.
-                        Base.log(this, "opening new empty sketch");
+                        Logger.log(this, "opening new empty sketch");
 //                        platform.base.handleNew();
                         base.handleNew();
 
                       } else {
                         // loop through the sketches that were passed in
                         do {
-                          Base.log(this, "calling open with " + path);
+                          Logger.log(this, "calling open with " + path);
 //                        platform.base.handleOpen(filename);
                           base.handleOpen(path);
                           path = reader.readLine();
@@ -107,18 +108,18 @@ public class SingleInstance {
                   }
                 });
               } else {
-                Base.log(this, "keys do not match");
+                Logger.log(this, "keys do not match");
               }
 //              }
             } catch (IOException e) {
-              Base.log("SingleInstance error while listening", e);
+              Logger.log("SingleInstance error while listening", e);
             }
           }
         }
       }, "SingleInstance Server").start();
 
     } catch (IOException e) {
-      Base.log("Could not create single instance server.", e);
+      Logger.log("Could not create single instance server.", e);
     }
   }
 

--- a/app/src/processing/app/Toolkit.java
+++ b/app/src/processing/app/Toolkit.java
@@ -56,6 +56,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JRootPane;
 import javax.swing.KeyStroke;
 
+import processing.app.logging.Logger;
 
 /**
  * Utility functions for base that require a java.awt.Toolkit object. These
@@ -408,7 +409,7 @@ public class Toolkit {
         //monoBoldFont = createFont("SourceCodePro-Semibold.ttf", size);
         monoBoldFont = createFont("SourceCodePro-Bold.ttf", size);
       } catch (Exception e) {
-        Base.log("Could not load mono font", e);
+        Logger.log("Could not load mono font", e);
         monoFont = new Font("Monospaced", Font.PLAIN, size);
         monoBoldFont = new Font("Monospaced", Font.BOLD, size);
       }
@@ -435,7 +436,7 @@ public class Toolkit {
         sansFont = createFont("SourceSansPro-Regular.ttf", size);
         sansBoldFont = createFont("SourceSansPro-Semibold.ttf", size);
       } catch (Exception e) {
-        Base.log("Could not load sans font", e);
+        Logger.log("Could not load sans font", e);
         sansFont = new Font("SansSerif", Font.PLAIN, size);
         sansBoldFont = new Font("SansSerif", Font.BOLD, size);
       }

--- a/app/src/processing/app/contrib/ContributionType.java
+++ b/app/src/processing/app/contrib/ContributionType.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import processing.app.Base;
 import processing.app.Editor;
 import processing.app.Library;
+import processing.app.logging.Logger;
 
 public enum ContributionType {
   LIBRARY, TOOL, MODE;
@@ -157,7 +158,7 @@ public enum ContributionType {
       return null;
 
     } else if (folders.length > 1) {
-      Base.log("More than one " + toString() + " found inside " + folder.getAbsolutePath());
+      Logger.log("More than one " + toString() + " found inside " + folder.getAbsolutePath());
     }
     return folders[0];
   }

--- a/app/src/processing/app/contrib/LocalContribution.java
+++ b/app/src/processing/app/contrib/LocalContribution.java
@@ -31,6 +31,7 @@ import java.util.zip.*;
 import javax.swing.JOptionPane;
 
 import processing.app.*;
+import processing.app.logging.Logger;
 
 
 /** 
@@ -86,7 +87,7 @@ public abstract class LocalContribution extends Contribution {
       }
       
     } else {
-      Base.log("No properties file at " + propertiesFile.getAbsolutePath());
+      Logger.log("No properties file at " + propertiesFile.getAbsolutePath());
       // We'll need this to be set at a minimum.
       name = folder.getName();
       categories = defaultCategory();
@@ -97,7 +98,7 @@ public abstract class LocalContribution extends Contribution {
   public String initLoader(String className) throws Exception {
     File modeDirectory = new File(folder, getTypeName());
     if (modeDirectory.exists()) {
-      Base.log("checking mode folder regarding " + className);
+      Logger.log("checking mode folder regarding " + className);
       // If no class name specified, search the main <modename>.jar for the
       // full name package and mode name.
       if (className == null) {
@@ -120,12 +121,12 @@ public abstract class LocalContribution extends Contribution {
       if (archives != null && archives.length > 0) {
         URL[] urlList = new URL[archives.length];
         for (int j = 0; j < urlList.length; j++) {
-          Base.log("Found archive " + archives[j] + " for " + getName());
+          Logger.log("Found archive " + archives[j] + " for " + getName());
           urlList[j] = archives[j].toURI().toURL();
         }
 //        loader = new URLClassLoader(urlList, Thread.currentThread().getContextClassLoader());
         loader = new URLClassLoader(urlList);
-        Base.log("loading above JARs with loader " + loader);
+        Logger.log("loading above JARs with loader " + loader);
 //        System.out.println("listing classes for loader " + loader);
 //        listClasses(loader);
       }
@@ -189,7 +190,7 @@ public abstract class LocalContribution extends Contribution {
 //      return null;
 //    
 //    } else if (folders.length > 1) {
-//      Base.log("More than one " + type.toString() + " found inside " + folder.getAbsolutePath());
+//      Logger.log("More than one " + type.toString() + " found inside " + folder.getAbsolutePath());
 //    }
 //    return folders[0];
 //  }

--- a/app/src/processing/app/contrib/ModeContribution.java
+++ b/app/src/processing/app/contrib/ModeContribution.java
@@ -29,6 +29,7 @@ import java.util.*;
 
 import processing.app.Base;
 import processing.app.Mode;
+import processing.app.logging.Logger;
 
 
 public class ModeContribution extends LocalContribution {
@@ -46,7 +47,7 @@ public class ModeContribution extends LocalContribution {
       return new ModeContribution(base, folder, searchName);
       
     } catch (IgnorableException ig) {
-      Base.log(ig.getMessage());
+      Logger.log(ig.getMessage());
       
     } catch (Throwable err) {  
       // Throwable to catch Exceptions or UnsupportedClassVersionError et al
@@ -56,7 +57,7 @@ public class ModeContribution extends LocalContribution {
         // For the built-in modes, don't print the exception, just log it
         // for debugging. This should be impossible for most users to reach,
         // but it helps us load experimental mode when it's available.
-        Base.log("ModeContribution.load() failed for " + searchName, err);
+        Logger.log("ModeContribution.load() failed for " + searchName, err);
       }
     }
     return null;
@@ -125,7 +126,7 @@ public class ModeContribution extends LocalContribution {
           try {
             contribModes.add(new ModeContribution(base, folder, null));
           } catch (IgnorableException ig) {
-            Base.log(ig.getMessage());
+            Logger.log(ig.getMessage());
           } catch (Throwable e) {
             e.printStackTrace();
           }

--- a/app/src/processing/app/contrib/ToolContribution.java
+++ b/app/src/processing/app/contrib/ToolContribution.java
@@ -29,6 +29,7 @@ import java.util.*;
 import processing.app.Base;
 //import processing.app.Base;
 import processing.app.Editor;
+import processing.app.logging.Logger;
 import processing.app.tools.Tool;
 
 
@@ -40,7 +41,7 @@ public class ToolContribution extends LocalContribution implements Tool {
     try {
       return new ToolContribution(folder);
     } catch (IgnorableException ig) {
-      Base.log(ig.getMessage());
+      Logger.log(ig.getMessage());
     } catch (Error err) {
       // Handles UnsupportedClassVersionError and others
       err.printStackTrace();

--- a/app/src/processing/app/logging/Logger.java
+++ b/app/src/processing/app/logging/Logger.java
@@ -1,0 +1,54 @@
+/* -*- mode: java; c-basic-offset: 2; indent-tabs-mode: nil -*- */
+
+/*
+  Part of the Processing project - http://processing.org
+
+  Copyright (c) 2004-13 Ben Fry and Casey Reas
+  Copyright (c) 2001-04 Massachusetts Institute of Technology
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  version 2, as published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+package processing.app.logging;
+
+import processing.app.Base;
+
+public class Logger {
+  static public void log(Object from, String message) {
+    if (Base.DEBUG) {
+      System.out.println(from.getClass().getName() + ": " + message);
+    }
+  }
+
+
+  static public void log(String message) {
+    if (Base.DEBUG) {
+      System.out.println(message);
+    }
+  }
+
+
+  static public void logf(String message, Object... args) {
+    if (Base.DEBUG) {
+      System.out.println(String.format(message, args));
+    }
+  }
+
+
+  static public void log(String message, Throwable e) {
+    if (Base.DEBUG) {
+      System.out.println(message);
+      e.printStackTrace();
+    }
+  }
+}

--- a/app/src/processing/app/platform/WindowsPlatform.java
+++ b/app/src/processing/app/platform/WindowsPlatform.java
@@ -39,6 +39,7 @@ import processing.app.Base;
 import processing.app.Platform;
 import processing.app.Preferences;
 import processing.app.platform.WindowsRegistry.REGISTRY_ROOT_KEY;
+import processing.app.logging.Logger;
 import processing.core.PApplet;
 
 
@@ -215,7 +216,7 @@ public class WindowsPlatform extends Platform {
       // hooray!
 
     } else {
-      Base.log("Could not associate files, turning off auto-associate pref.");
+      Logger.log("Could not associate files, turning off auto-associate pref.");
       Preferences.setBoolean("platform.auto_file_type_associations", false);
     }
   }
@@ -359,7 +360,7 @@ public class WindowsPlatform extends Platform {
 //      moveToTrash(new File[] { file });
 //    } catch (IOException e) {
 //      e.printStackTrace();
-//      Base.log("Could not move " + file.getAbsolutePath() + " to the trash.", e);
+//      Logger.log("Could not move " + file.getAbsolutePath() + " to the trash.", e);
 //      return false;
 //    }
 //    return true;

--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -29,6 +29,7 @@ import java.awt.im.InputMethodRequests;
 import java.awt.print.Printable;
 
 import processing.app.syntax.im.InputMethodSupport;
+import processing.app.logging.Logger;
 import processing.core.PApplet;
 
 /**
@@ -2352,7 +2353,7 @@ public class JEditTextArea extends JComponent
         try {
           select(getMarkPosition(), xyToOffset(evt.getX(), evt.getY()));
         } catch (ArrayIndexOutOfBoundsException e) {
-          Base.log("xToOffset problem", e);
+          Logger.log("xToOffset problem", e);
         }
       } else {
         int line = yToLine(evt.getY());

--- a/app/src/processing/mode/java/JavaMode.java
+++ b/app/src/processing/mode/java/JavaMode.java
@@ -105,7 +105,7 @@ public class JavaMode extends Mode {
 //        coreLibrary = getLibrary("processing.core");
 //        System.out.println("core found at " + coreLibrary.getLibraryPath());
 //      } catch (SketchException e) { 
-//        Base.log("Serious problem while locating processing.core", e);
+//        Logger.log("Serious problem while locating processing.core", e);
 //      }
     }
     return coreLibrary;


### PR DESCRIPTION
You may need to run `ant clean` for this to work.

This PR:
- Slims down the `Base` class.
- Makes it easier to locate and refactor logging code.
- Makes it easier to eventually change logging behavior by injecting a different logger or using plain `java.util.logging`:

```
Logger.init(new NullLogger());
```

I made the minimum necessary changes for things to work. Further improvements could be done in other pull requests.
