### PR TITLE
Erroneous file change detection fix

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -2396,34 +2396,42 @@ public abstract class Editor extends JFrame implements RunnerListener {
 //    }
   }
   
+  //used to prevent the fileChangeListener from asking for reloads after internal changes
+  public void setWatcherSave() {
+    watcherSave = true;
+  }
+  
   //set to true when the sketch is saved from inside processing
   private boolean watcherSave;
-  private boolean watcherReloaded;
-  
+
   //the key which is being used to poll the fs for changes
   private WatchKey watcherKey = null;
 
   private void initFileChangeListener() {
     try {
       WatchService watchService = FileSystems.getDefault().newWatchService();
-      Path folderPath = sketch.getFolder().toPath(); 
-      watcherKey = folderPath.register(watchService,
-//                              StandardWatchEventKinds.ENTRY_CREATE,
-//                              StandardWatchEventKinds.ENTRY_DELETE,
-                                StandardWatchEventKinds.ENTRY_MODIFY);
+      watcherKey = sketch
+        .getFolder()
+        .toPath()
+        .register(watchService, StandardWatchEventKinds.ENTRY_CREATE,
+                  StandardWatchEventKinds.ENTRY_DELETE,
+                  StandardWatchEventKinds.ENTRY_MODIFY);
     } catch (IOException e) {
       e.printStackTrace();
     }
 
     final WatchKey finKey = watcherKey;
 
-    // if the key is null for some reason, don't bother attaching 
-    // a listener to it, they can deal without one
+    //if the key is null for some reason, don't bother attaching a listener to it
     if (finKey != null) {
       // the key can now be polled for changes in the files
       addWindowFocusListener(new WindowFocusListener() {
         @Override
         public void windowGainedFocus(WindowEvent arg0) {
+          //we switched locations (saveAs), ignore old things
+          if (watcherKey != finKey) {
+            return;
+          }
           // check preference here for enabled or not?
 
           //if the directory was deleted, then don't scan
@@ -2431,12 +2439,16 @@ public abstract class Editor extends JFrame implements RunnerListener {
             List<WatchEvent<?>> events = finKey.pollEvents();
             processFileEvents(events);
           }
+
+          List<WatchEvent<?>> events = finKey.pollEvents();
+          if (!watcherSave)
+            processFileEvents(events);
         }
 
         @Override
         public void windowLostFocus(WindowEvent arg0) {
           //we switched locations (saveAs), ignore old things
-          if (key != finKey) {
+          if (watcherKey != finKey) {
             return;
           }
           List<WatchEvent<?>> events = finKey.pollEvents();
@@ -2456,34 +2468,57 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * @param events the list of events that have occured in the sketch folder
    */
   private void processFileEvents(List<WatchEvent<?>> events) {
-    watcherReloaded = false;
     for (WatchEvent<?> e : events) {
-      //the context is the name of the file inside the path
-      //due to some weird shit, if a file was editted in gedit, the context is .goutputstream-XXXXX
-      //this makes things.... complicated
-      //System.out.println(e.context());      
-
-      //if we already reloaded in this cycle, then don't reload again
-      if (watcherReloaded){
-        break;
+      boolean sketchFile = false;
+      Path file = ((Path) e.context()).getFileName();
+      for (String s : getMode().getExtensions()) {
+        //if it is a change to a file with a known extension
+        if (file.toString().endsWith(s)) {
+          sketchFile = true;
+          break;
+        }
       }
-      if (e.kind().equals(StandardWatchEventKinds.ENTRY_MODIFY)) {
-//        Path p = (Path) e.context();
-//        Path root = (Path) key.watchable();
-//        Path path = root.resolve(p);
-        int response = 
-          Base.showYesNoQuestion(Editor.this, "File Modified",
-                                 "A file has been modified externally",
-                                 "Would you like to reload the sketch?");
-        if (response == 0) {
-          // reload the sketch
+      //if the file is not a known type, then go the the next event
+      if (!sketchFile) {
+        continue;
+      }
+
+      int response = Base
+        .showYesNoQuestion(Editor.this,
+                           "File Modified",
+                           "Your sketch has been modified externally",
+                           "Would you like to reload the sketch?");
+      if (response == 0) {
+        //grab the 'main' code in case this reload tries to delete everything
+        File sc = sketch.getMainFile();
+        //reload the sketch
+        try {
           sketch.reload();
           header.rebuild();
-          watcherReloaded = true;
+        } catch (Exception f) {
+          if (sketch.getCodeCount() < 1) {
+            Base
+              .showWarning("Canceling Reload",
+                           "You cannot delete the last code file in a sketch!");
+            //if they deleted the last file, re-save the SketchCode
+            try {
+              //make a blank file
+              sc.createNewFile();
+            } catch (IOException e1) {
+              //if that didn't work, tell them it's un-recoverable
+              Base.showError("Reload failed",
+                             "The sketch contians no code files", e1);
+              //don't try to reload again after the double fail
+              //this editor is probably trashed by this point, but a save-as might be possible
+              break;
+            }
+            //don't ask for another reload after this save
+            watcherSave = true;
+            return;
+          }
         }
-      } else {
-        // called when a file is created or deleted
-        // for now, do nothing
+        //now that we've reloaded once, don't try to reload again
+        break;
       }
     }
     watcherSave = false;
@@ -2519,7 +2554,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
   public boolean handleSave(boolean immediately) {
 //    handleStop();  // 0136
 
-    watcherSave = true;
+    setWatcherSave();
     if (sketch.isUntitled()) {
       return handleSaveAs();
       // need to get the name, user might also cancel here
@@ -2563,6 +2598,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
     statusNotice(Language.text("editor.status.saving"));
     try {
       if (sketch.saveAs()) {
+        //a saveAs moves where the files are, so a listener must be attached to the new location
+        initFileChangeListener();
         // statusNotice("Done Saving.");
     	// status is now printed from Sketch so that "Done Saving."
     	// is only printed after Save As when progress bar is shown.  

--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -512,6 +512,7 @@ public class EditorHeader extends JComponent {
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           editor.getSketch().handleNewCode();
+          editor.setWatcherSave();
         }
       });
     menu.add(item);
@@ -533,7 +534,6 @@ public class EditorHeader extends JComponent {
     item = new JMenuItem(Language.text("editor.header.delete"));
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          System.out.println("here high");
           Sketch sketch = editor.getSketch();
           if (!Base.isMacOS() &&  // ok on OS X
               editor.base.editors.size() == 1 &&  // mmm! accessor
@@ -542,6 +542,7 @@ public class EditorHeader extends JComponent {
                                Language.text("editor.header.delete.warning.text"), null);
           } else {
             editor.getSketch().handleDeleteCode();
+            editor.setWatcherSave();
           }
         }
       });


### PR DESCRIPTION
This is a fix to Issue #2759. It should no longer erroneously detect changes when compiling, saving images, or exporting
-    Listens for any files of the appropriate type for the current mode (e.g. in Java mode .pde and .java files)
-    Listens to Creates and Deletes as well
-    If the last code-file was deleted from the sketch it will attempt to re-save that file to prevent a crash
-    Fix: now adapts to the new location if SaveAs was called

P.S. Sorry if this is a round-about way of doing this pull request, still learning how to use git properly
