### PR TITLE
Implement GroupLayout in PreferencesFrame

### DIFF
--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -362,8 +362,9 @@ public class PreferencesFrame {
 
     // [ ] Automatically associate .pde files with Processing
 
-    if (Base.isWindows()) {
-      autoAssociateBox = new JCheckBox(Language.text("preferences.automatically_associate_pde_files"));
+    autoAssociateBox = new JCheckBox(Language.text("preferences.automatically_associate_pde_files"));
+    if (!Base.isWindows()) {
+      autoAssociateBox.setVisible(false);
     }
 
     // More preferences are in the ...


### PR DESCRIPTION
Fixes issue #67.

I have implemented GroupLayout in the PreferencesFrame class. All the code for manual placement was removed and placement of the various JComponents is now handled automatically. See line 426+ for a description of the chosen layout scheme.
