### PR TITLE
Replace Thread with invokeLater in PreferencesFrame

### DIFF
--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -800,11 +800,11 @@ public class PreferencesFrame {
     }
     
     // This takes a while to load, so run it from a separate thread
-    new Thread(new Runnable() {
+    EventQueue.invokeLater(new Runnable() {
       public void run() {
         initFontList();
       }
-    }).start();
+    });
     
     fontSizeField.setSelectedItem(Preferences.getInteger("editor.font.size"));
     consoleSizeField.setSelectedItem(Preferences.getInteger("console.font.size"));


### PR DESCRIPTION
GUI components can only be updated safely from the main event thread. `invokeLater` could also be called from the new thread, but the performance difference is negligible.
