### PR TITLE
Refactor ContributionManager code

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -477,7 +477,6 @@ public class ContributionManagerDialog {
           } else {
             status.setErrorMessage(Language.text("contrib.errors.list_download"));
           }
-          exception.printStackTrace();
           retryConnectingButton.setVisible(true);
         }
         else {


### PR DESCRIPTION
 * Change argument types to take generic `ProgressMonitor` instances.
 * Move error handling code closer to the error source.
 * Reduce nesting to make code easier to follow and reason about.

Some deeper code changes to reduce duplication are outside the scope of this PR.

This may also make it easier to solve #2798. cc/ @joelmoniz