### PR TITLE
Fix the shortcut keybindings in editor tab popup menu

### DIFF
--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -119,7 +119,6 @@ public class EditorHeader extends JComponent {
 
           if ((x > menuLeft) && (x < menuRight)) {
             popup.show(EditorHeader.this, x, y);
-
           } else {
             Sketch sketch = editor.getSketch();
 //            for (int i = 0; i < sketch.getCodeCount(); i++) {
@@ -469,13 +468,17 @@ public class EditorHeader extends JComponent {
             // may be redundant.
             repaint();
           }
-
           public void popupMenuWillBecomeInvisible(PopupMenuEvent e) { }
           public void popupMenuWillBecomeVisible(PopupMenuEvent e) { }
         });
       */
     }
     JMenuItem item;
+    InputMap mInputMap = editor.getRootPane().getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+    ActionMap mActionMap = editor.getRootPane().getActionMap();
+    Action action;
+    String mapKey;
+    KeyStroke keyStroke;
 
     // maybe this shouldn't have a command key anyways..
     // since we're not trying to make this a full ide..
@@ -508,75 +511,91 @@ public class EditorHeader extends JComponent {
     */
 
     //item = new JMenuItem("New Tab");
-    item = Toolkit.newJMenuItemShift(Language.text("editor.header.new_tab"), 'N');
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          editor.getSketch().handleNewCode();
-          editor.setWatcherSave();
-        }
-      });
+    item = Toolkit.newJMenuItemShift(Language.text("editor.header.new_tab"), KeyEvent.VK_N);
+    action = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        editor.getSketch().handleNewCode();
+        editor.setWatcherSave();
+      }
+    };
+    mapKey = "editor.header.new_tab";
+    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.SHORTCUT_SHIFT_KEY_MASK);
+    mInputMap.put(keyStroke, mapKey);
+    mActionMap.put(mapKey, action);
+    item.addActionListener(action);
     menu.add(item);
 
     item = new JMenuItem(Language.text("editor.header.rename"));
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          editor.getSketch().handleRenameCode();
-          /*
-          // this is already being called by nameCode(), the second stage of rename
-          if (editor.sketch.current == editor.sketch.code[0]) {
-            editor.sketchbook.rebuildMenus();
-          }
-          */
+    action = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        editor.getSketch().handleRenameCode();
+        /*
+        // this is already being called by nameCode(), the second stage of rename
+        if (editor.sketch.current == editor.sketch.code[0]) {
+          editor.sketchbook.rebuildMenus();
         }
-      });
+        */
+      }
+    };
+    item.addActionListener(action);
     menu.add(item);
 
-    item = new JMenuItem(Language.text("editor.header.delete"));
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          Sketch sketch = editor.getSketch();
-          if (!Base.isMacOS() &&  // ok on OS X
-              editor.base.editors.size() == 1 &&  // mmm! accessor
-              sketch.getCurrentCodeIndex() == 0) {
-              Base.showWarning(Language.text("editor.header.delete.warning.title"),
-                               Language.text("editor.header.delete.warning.text"), null);
-          } else {
-            editor.getSketch().handleDeleteCode();
-            editor.setWatcherSave();
-          }
+    item = Toolkit.newJMenuItemShift(Language.text("editor.header.delete"), KeyEvent.VK_D);
+    action = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        Sketch sketch = editor.getSketch();
+        if (!Base.isMacOS() &&  // ok on OS X
+            editor.base.editors.size() == 1 &&  // mmm! accessor
+            sketch.getCurrentCodeIndex() == 0) {
+            Base.showWarning(Language.text("editor.header.delete.warning.title"),
+                             Language.text("editor.header.delete.warning.text"), null);
+        } else {
+          editor.getSketch().handleDeleteCode();
+          editor.setWatcherSave();
         }
-      });
+      }
+    };
+    mapKey = "editor.header.delete";
+    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.SHORTCUT_SHIFT_KEY_MASK);
+    mInputMap.put(keyStroke, mapKey);
+    mActionMap.put(mapKey, action);
+    item.addActionListener(action);
     menu.add(item);
 
     menu.addSeparator();
 
     //  KeyEvent.VK_LEFT and VK_RIGHT will make Windows beep
-
-    item = new JMenuItem(Language.text("editor.header.previous_tab"));
-    KeyStroke ctrlAltLeft =
-      KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, Toolkit.SHORTCUT_ALT_KEY_MASK);
-    item.setAccelerator(ctrlAltLeft);
-    // this didn't want to work consistently
-    /*
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          editor.sketch.prevCode();
-        }
-      });
-    */
+    item = Toolkit.newJMenuItemShift(Language.text("editor.header.previous_tab"), KeyEvent.VK_LEFT);
+    action = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        Sketch sketch = editor.getSketch();
+        sketch.setCurrentCode(sketch.getCurrentCodeIndex() - 1);
+      }
+    };
+    mapKey = "editor.header.previous_tab";
+    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, Toolkit.SHORTCUT_SHIFT_KEY_MASK);
+    mInputMap.put(keyStroke, mapKey);
+    mActionMap.put(mapKey, action);
+    item.addActionListener(action);
     menu.add(item);
 
-    item = new JMenuItem(Language.text("editor.header.next_tab"));
-    KeyStroke ctrlAltRight =
-      KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, Toolkit.SHORTCUT_ALT_KEY_MASK);
-    item.setAccelerator(ctrlAltRight);
-    /*
-    item.addActionListener(new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-          editor.sketch.nextCode();
-        }
-      });
-    */
+    item = Toolkit.newJMenuItemShift(Language.text("editor.header.next_tab"), KeyEvent.VK_RIGHT);
+    action = new AbstractAction() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        Sketch sketch = editor.getSketch();
+        sketch.setCurrentCode(sketch.getCurrentCodeIndex() + 1);
+      }
+    };
+    mapKey = "editor.header.next_tab";
+    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, Toolkit.SHORTCUT_SHIFT_KEY_MASK);
+    mInputMap.put(keyStroke, mapKey);
+    mActionMap.put(mapKey, action);
+    item.addActionListener(action);
     menu.add(item);
 
     Sketch sketch = editor.getSketch();

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1199,7 +1199,8 @@ public class Sketch {
 //      System.out.println(current.visited);
 //    }
     // if current is null, then this is the first setCurrent(0)
-    if ((currentIndex == which) && (current != null)) {
+    if (((currentIndex == which) && (current != null))
+      || which >= codeCount || which < 0) {
       return;
     }
 

--- a/app/src/processing/app/Toolkit.java
+++ b/app/src/processing/app/Toolkit.java
@@ -76,6 +76,8 @@ public class Toolkit {
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK = ActionEvent.ALT_MASK |
     awtToolkit.getMenuShortcutKeyMask();
+  static final int SHORTCUT_SHIFT_KEY_MASK = ActionEvent.SHIFT_MASK |
+    SHORTCUT_KEY_MASK;
 
 
   /**


### PR DESCRIPTION
Signed-off-by: Umair Khan omerjerk@gmail.com

This pull request targets the following issues of the tabs popup menu :
1. The shortcuts worked only until the popup menu was dismissed for the first time. Please refer to this for the reason : http://stackoverflow.com/questions/19862673/jpopup-key-bindings-only-work-1-time
2. The previous tab and next tab options were not working at all as there was no code to handle this.
