### PR TITLE
Fix localization in OS X

### DIFF
--- a/app/src/processing/app/Language.java
+++ b/app/src/processing/app/Language.java
@@ -87,6 +87,7 @@ public class Language {
   
   static private String[] listSupported() {
     // List of languages in alphabetical order. (Add yours here.)
+    // Also remember to add it to the corresponding build/build.xml rule.
     final String[] SUPPORTED = {
       "de", // German, Deutsch
       "en", // English
@@ -147,6 +148,7 @@ public class Language {
     } catch (Exception e) {
       e.printStackTrace();
     }
+    Base.getPlatform().saveLanguage(language);
   }
   
   

--- a/app/src/processing/app/Platform.java
+++ b/app/src/processing/app/Platform.java
@@ -74,6 +74,7 @@ public class Platform {
     }
   }
 
+  public void saveLanguage(String languageCode) {}
 
   public void init(Base base) {
     this.base = base;

--- a/app/src/processing/app/platform/MacPlatform.java
+++ b/app/src/processing/app/platform/MacPlatform.java
@@ -24,6 +24,7 @@ package processing.app.platform;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import com.apple.eio.FileManager;
 
@@ -47,6 +48,18 @@ public class MacPlatform extends Platform {
   }
   */
 
+  public void saveLanguage(String language) {
+    String[] cmdarray = new String[]{
+      "defaults", "write",
+      System.getProperty("user.home") + "/Library/Preferences/org.processing.app",
+      "AppleLanguages", "-array", language
+    };
+    try {
+      Runtime.getRuntime().exec(cmdarray);
+    } catch (IOException e) {
+      Base.log("Error saving platform language: " + e.getMessage());
+    }
+  }
 
   public void init(Base base) {
     super.init(base);

--- a/build/build.xml
+++ b/build/build.xml
@@ -496,6 +496,8 @@
              value="macosx/work/Processing.app/Contents/Java" />
     </antcall>
 
+    <exec executable="macosx/language_gen.py" />
+
     <property name="launch4j.dir" value="macosx/work/Processing.app/Contents/Java/modes/java/application/launch4j" />
 
     <!-- rename the version we need -->

--- a/build/macosx/language_gen.py
+++ b/build/macosx/language_gen.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+
+import os, re
+
+BASEDIR = os.path.dirname(os.path.realpath(__file__))
+
+def supported_languages():
+    path = "../../app/src/processing/app/languages/languages.txt"
+    with open(os.path.join(BASEDIR, path)) as f:
+        lines = f.read().splitlines()
+
+    lines = filter(lambda l: re.match(r'^[a-z]{2}', l), lines)
+    lines = map(lambda l: re.sub(r'#.*', '', l).strip(), lines)
+    return lines
+
+def lproj_directory(lang):
+    path = "work/Processing.app/Contents/Resources/{}.lproj".format(lang)
+    return os.path.join(BASEDIR, path)
+
+
+if __name__ == "__main__":
+    for lang in supported_languages():
+        try:
+            os.mkdir(lproj_directory(lang))
+        except OSError:
+            pass


### PR DESCRIPTION
Prior to this fix, the application menu in OS X would ignore the current localization setting and default to english.

The fix consists of two parts:
1. Declare support for each language by including an empty `.lproj` directory inside the Resources folder of the app bundle.
2. Make sure that OS X honors the user specified language by writing its value in the `AppleLanguages` key of the application defaults file.

Note that the `ant` code is a bit funny, since it requires `ant-contrib` and is even longer than just copying the mkdir line for each supported language, but it does have the benefit that translators don't need to change yet another piece of code. It just reads each key from the `languages.txt` file.
