### PR TITLE
Fix outlines around scaled fonts (#2845)

### DIFF
--- a/core/src/processing/opengl/FontTexture.java
+++ b/core/src/processing/opengl/FontTexture.java
@@ -151,9 +151,15 @@ class FontTexture implements PConstants {
     } else if (resize) {
       // Replacing old smaller texture with larger one.
       // But first we must copy the contents of the older
-      // texture into the new one.
+      // texture into the new one. Setting blend mode to
+      // REPLACE to preserve color of transparent pixels.
       Texture tex0 = textures[currentTex];
+
+      tex.pg.pushStyle();
+      tex.pg.blendMode(REPLACE);
       tex.put(tex0);
+      tex.pg.popStyle();
+
       textures[currentTex] = tex;
 
       pg.setCache(images[currentTex], tex);


### PR DESCRIPTION
Fixes #2845. When resizing font texture to add new character, color of transparent pixels was not preserved. This caused black outlines around characters due to alpha interpolation, as explained in #1997.
