### PR TITLE
Update spanish translation

### DIFF
--- a/app/src/processing/app/languages/PDE_es.properties
+++ b/app/src/processing/app/languages/PDE_es.properties
@@ -140,6 +140,7 @@ preferences.show_warnings = Mostrar advertencias
 preferences.code_completion = Autocompletado de código
 preferences.trigger_with = Activar con 
 preferences.cmd_space = espacio
+preferences.suggest_imports = Sugerir declaraciones de importación
 preferences.increase_max_memory = Aumentar memoria máxima disponible a
 preferences.delete_previous_folder_on_export = Eliminar directorio anterior al exportar
 preferences.hide_toolbar_background_image = Ocultar imagen de fondo de la barra de herramientas
@@ -165,6 +166,7 @@ sketchbook.tree = Sketchbook
 
 # Examples (Frame)
 examples = Ejemplos
+examples.add_examples = Añadir ejemplos...
 
 # Export (Frame)
 export = Opciones de exportación
@@ -259,8 +261,18 @@ editor.status.printing.canceled = Impresión cancelada.
 # Contribution Panel
 
 contrib = Gestor de contribuciones
+contrib.manager_title.update = Gestor de actualizaciones
+contrib.manager_title.mode = Gestor de Modos
+contrib.manager_title.tool = Gestor de Herramientas
+contrib.manager_title.library = Gestor de Bibliotecas
+contrib.manager_title.examples-package = Gestor de Paquetes de Ejemplo
 contrib.category = Categoría:
 contrib.filter_your_search = Filtrar tu búsqueda...
+contrib.show_only_compatible.mode = Mostrar sólo modos compatibles
+contrib.show_only_compatible.tool = Mostrar sólo herramientas compatibles
+contrib.show_only_compatible.library = Mostrar sólo bibliotecas compatibles
+contrib.show_only_compatible.examples-package = Mostrar sólo ejemplos compatibles
+contrib.show_only_compatible.update = Mostrar sólo actualizaciones compatibles
 contrib.restart = Reiniciar Processing
 contrib.unsaved_changes = Se encontraron cambios sin guardar
 contrib.unsaved_changes.prompt = ¿Seguro que deseas reiniciar Processing sin guardar primero?
@@ -278,6 +290,7 @@ contrib.errors.overwriting_properties = Ocurrió un error al sobrescribir el arc
 contrib.errors.install_failed = La instalación falló.
 contrib.errors.update_on_restart_failed = La actualización al reiniciar de %s falló.
 contrib.errors.temporary_directory = No se pudo escribir al directorio temporal.
+contrib.errors.contrib_download.timeout = El tiempo de conexión expiró al intentar descargar %s.
 contrib.all = All
 contrib.undo = Deshacer
 contrib.remove = Eliminar


### PR DESCRIPTION
This should make the spanish translation complete up to this day.

To help myself and other translators I made this simple [script](https://gist.github.com/federicobond/741d5c7df61191e13408) that is useful to find untranslated keys. Could be useful to put in a wiki page for future reference.
