### PR TITLE
Minor improvements to the Contribution Manager's updates check

### DIFF
--- a/app/src/processing/app/UpdateCheck.java
+++ b/app/src/processing/app/UpdateCheck.java
@@ -123,12 +123,14 @@ public class UpdateCheck {
         // Wait for xml file to be downloaded and updates to come in.
         // (this should really be handled better).
         Thread.sleep(5 * 1000);
-        if ((!base.libraryManagerFrame.hasAlreadyBeenOpened() &&
-             base.libraryManagerFrame.hasUpdates(base)) ||
-            (!base.toolManagerFrame.hasAlreadyBeenOpened() &&
-             base.toolManagerFrame.hasUpdates(base)) ||
-            (!base.modeManagerFrame.hasAlreadyBeenOpened() &&
-             base.modeManagerFrame.hasUpdates(base))) {
+        if ((!base.libraryManagerFrame.hasAlreadyBeenOpened()
+              && !base.toolManagerFrame.hasAlreadyBeenOpened()
+              && !base.modeManagerFrame.hasAlreadyBeenOpened()
+              && !base.exampleManagerFrame.hasAlreadyBeenOpened())
+          && (base.libraryManagerFrame.hasUpdates(base)
+              || base.toolManagerFrame.hasUpdates(base)
+              || base.modeManagerFrame.hasUpdates(base)
+              || base.exampleManagerFrame.hasUpdates(base))) {
           promptToOpenContributionManager();
         }
       }


### PR DESCRIPTION
The commit of this PR does the following:
- Makes the 'Contribution updates are available' popup less obtrusive- displays the pop-up only if none of the Contributions Manager windows have been opened yet, but at least one installed contribution has an update: resolves [#2859](https://github.com/processing/processing/issues/2859).
- Adds examples-packages into the update check
