### PR TITLE
Another convenient main() method to ease sketch instantiation w/ extra a...

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10592,7 +10592,7 @@ public class PApplet extends Applet
    * @param extraArgs sketch configuration strings
    */
   static public void main(String mainClass, String[] passedArgs, String... extraArgs) {
-    extraArgs = extraArgs==null? new String[] { mainClass } : append(extraArgs, mainClass);
+    extraArgs = extraArgs != null? append(extraArgs, mainClass) : new String[] { mainClass };
     if (passedArgs != null)  extraArgs = concat(extraArgs, passedArgs);
     runSketch(extraArgs, null);
   }


### PR DESCRIPTION
...rgs

There are times we need to instantiate the sketch w/ diff. behaviors like:
- "--full screen"
- "--hide-stop"
- "--location=x,y"
- "--display=n"
- etc.

For example, this request from Processing's forum:
http://forum.Processing.org/two/discussion/7519/how-to-change-background-color-of-present-mode-and-remove-graphical-stop-option

``` Java
static final void main(String[] args) {
  String sketch = Thread.currentThread()
    .getStackTrace()[1].getClassName();

  main(sketch, args
    , "--full-screen"
    , "--hide-stop"
    , "--bgcolor=#000000"
    , "--stop-color=#000000"
    );
}

static final void main(String mainClass, String[] passedArgs, String... extraArgs) {
  runSketch(concat(append(extraArgs, mainClass), passedArgs), null);
}

void setup() {
  size(displayWidth, displayHeight, JAVA2D);
  smooth(4);
  noLoop();
  frameRate(10);

  textSize(0200);
  textAlign(CENTER, CENTER);

  keyPressed();
  println(args);
}

void draw() {
  background(-1);
  text(width + " x " + height, width>>1, height>>1);
}

void keyPressed() {
  fill((color) random(#000000));
  redraw();
}

void mousePressed() {
  keyPressed();
}
```
