### PR TITLE
Add short[] support for printArray()

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -4709,6 +4709,13 @@ public class PApplet extends Applet
           }
           break;
 
+        case 'S':  // short
+          short ss[] = (short[]) what;
+          for (int i = 0; i < ss.length; i++) {
+            System.out.println("[" + i + "] " + ss[i]);
+          }
+          break;
+
         case 'C':  // char
           char cc[] = (char[]) what;
           for (int i = 0; i < cc.length; i++) {
@@ -4723,7 +4730,7 @@ public class PApplet extends Applet
           }
           break;
 
-        case 'J':  // int
+        case 'J':  // long
           long jj[] = (long[]) what;
           for (int i = 0; i < jj.length; i++) {
             System.out.println("[" + i + "] " + jj[i]);


### PR DESCRIPTION
There are 8 primitive types in Java. Method **printArray()** supports all but `short`!  :rage1:
Although `short` isn't a Processing's "official" type, but neither are `long` nor `double`!  :see_no_evil:
In order to correct this grave prejudiced injustice, I'm begging you devs to accept this pull request!  :angel:
