### PR TITLE
Use correct parameter types in FloatList methods

### DIFF
--- a/core/src/processing/data/FloatList.java
+++ b/core/src/processing/data/FloatList.java
@@ -300,7 +300,7 @@ public class FloatList implements Iterable<Float> {
 
 
   // same as splice
-  public void insert(int index, int[] values) {
+  public void insert(int index, float[] values) {
     if (index < 0) {
       throw new IllegalArgumentException("insert() index cannot be negative: it was " + index);
     }
@@ -328,7 +328,7 @@ public class FloatList implements Iterable<Float> {
   }
 
 
-  public void insert(int index, IntList list) {
+  public void insert(int index, FloatList list) {
     insert(index, list.values());
   }
 


### PR DESCRIPTION
I believe this was a copy-paste error, since it is a bit odd that they accepted only `int`-type arguments. If there is a need to preserve backwards compatibility, I can add the corresponding `int[]` and `IntList` methods.
