### PR TITLE
Remove "unofficial" types from printArray()

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -4694,21 +4694,28 @@ public class PApplet extends Applet
             }
           }
           break;
-
+        /* Why would n1 would need a boolean[] after all?
         case 'Z':  // boolean
           boolean zz[] = (boolean[]) what;
           for (int i = 0; i < zz.length; i++) {
             System.out.println("[" + i + "] " + zz[i]);
           }
           break;
-
+        */
         case 'B':  // byte
           byte bb[] = (byte[]) what;
           for (int i = 0; i < bb.length; i++) {
             System.out.println("[" + i + "] " + bb[i]);
           }
           break;
-
+        /* I was refused even though I'm the only 1 missing!
+        case 'S':  // short
+          byte ss[] = (short[]) what;
+          for (int i = 0; i < ss.length; i++) {
+            System.out.println("[" + i + "] " + ss[i]);
+          }
+          break;
+        */
         case 'C':  // char
           char cc[] = (char[]) what;
           for (int i = 0; i < cc.length; i++) {
@@ -4722,28 +4729,28 @@ public class PApplet extends Applet
             System.out.println("[" + i + "] " + ii[i]);
           }
           break;
-
+        /* I'm as non-official as any other primitive!
         case 'J':  // int
           long jj[] = (long[]) what;
           for (int i = 0; i < jj.length; i++) {
             System.out.println("[" + i + "] " + jj[i]);
           }
           break;
-
+        */
         case 'F':  // float
           float ff[] = (float[]) what;
           for (int i = 0; i < ff.length; i++) {
             System.out.println("[" + i + "] " + ff[i]);
           }
           break;
-
+        /* Use float[] instead, dumb!!!
         case 'D':  // double
           double dd[] = (double[]) what;
           for (int i = 0; i < dd.length; i++) {
             System.out.println("[" + i + "] " + dd[i]);
           }
           break;
-
+        */
         default:
           System.out.println(what);
         }


### PR DESCRIPTION
As a protest for the bureaucratic intransigence refusal to include the missing `short[]` in **printArray()**, 
I've made this opposite proposal: https://github.com/processing/processing/pull/2896/files

Motive given there was: "'shorts' are not supported in Processing and are omitted on purpose."
But neither `long` nor `double` are "official"; and they were contemplated into **printArray()** nonetheless!

Another case is `boolean[]`. It's more like hit 'n' miss.
There are some array util methods which got it, but most don't.
Very inconsistent to say the least. So `boolean` is out for conciseness' sake!

A pity this project are kept under 7 locks. Alas...  :disappointed:
My only fear is that this pull request may end up being accepted! Oh the irony...  :weary:
