### PR TITLE
Enable mask() on PGragraphicsJava2D

### DIFF
--- a/core/src/processing/core/PGraphicsJava2D.java
+++ b/core/src/processing/core/PGraphicsJava2D.java
@@ -2708,24 +2708,6 @@ public class PGraphicsJava2D extends PGraphics {
 
   //////////////////////////////////////////////////////////////
 
-  // MASK
-
-
-  @Override
-  public void mask(int alpha[]) {
-    showMethodWarning("mask");
-  }
-
-
-  @Override
-  public void mask(PImage alpha) {
-    showMethodWarning("mask");
-  }
-
-
-
-  //////////////////////////////////////////////////////////////
-
   // FILTER
 
   // Because the PImage versions call loadPixels() and


### PR DESCRIPTION
The default implementation in `PImage` works fine with the Java2D renderer
(it's quite simple and operates directly on the pixels array), but for
some reason `PGraphicsJava2D` was overriding the default implementation
with a warning.
