### PR TITLE
Preprocessor now accepts whitespace after height (fixes #2924)

### DIFF
--- a/app/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/app/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -167,7 +167,7 @@ public class PdePreprocessor {
    * and pasting from the reference.
    */
   public static final String SIZE_REGEX =
-    "(?:^|\\s|;)size\\s*\\(\\s*([^\\s,]+)\\s*,\\s*([^\\s,\\)]+),?\\s*([^\\)]*)\\s*\\)\\s*\\;";
+    "(?:^|\\s|;)size\\s*\\(\\s*([^\\s,]+)\\s*,\\s*([^\\s,\\)]+)\\s*,?\\s*([^\\)]*)\\s*\\)\\s*\\;";
     //"(?:^|\\s|;)size\\s*\\(\\s*(\\S+)\\s*,\\s*([^\\s,\\)]+),?\\s*([^\\)]*)\\s*\\)\\s*\\;";
 
   


### PR DESCRIPTION
Fixes #2924

As @benfry said, there was a missing white space after second match group.

Test with online tool looks good (check matches in the right column): http://regex101.com/r/sP8rI1/1
Spaces around renderer are trimmed in the preproc code later.
