### PR TITLE
build failed, because of missing directory

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -233,7 +233,7 @@
     <subant buildpath="../java/libraries/net" target="clean"/>
     <subant buildpath="../java/libraries/pdf" target="clean"/>
     <subant buildpath="../java/libraries/serial" target="clean"/>
-    <subant buildpath="../java/libraries/sound" target="clean"/>
+    <!-- <subant buildpath="../java/libraries/sound" target="clean"/> -->
     <subant buildpath="shared/tools/MovieMaker" target="clean"/>
     <subant buildpath="../pdex" target="clean"/>
 
@@ -248,7 +248,7 @@
     <subant buildpath="../java/libraries/net" target="build"/>
     <subant buildpath="../java/libraries/pdf" target="build"/>
     <subant buildpath="../java/libraries/serial" target="build"/>
-    <subant buildpath="../java/libraries/sound" target="build"/>
+    <!-- <subant buildpath="../java/libraries/sound" target="build"/> -->
     <subant buildpath="shared/tools/MovieMaker" target="build"/>
     <subant buildpath="../pdex" target="package"/>
   </target>


### PR DESCRIPTION
Hello,

the basic build script failed, because the `java/sound` directory was missing. The reason is, that we migrate the sound library out of the main repository ([3c3fb4f](https://github.com/processing/processing/commit/3c3fb4f1a497b5da6e5a35186a94365f0b2b0727)). I just commented out the paths in the `build.xml`, because I don't know if it will come back.

Happy coding,
Darius
