### PR TITLE
Highlighting of keywords followed by parens (#2099)

### DIFF
--- a/app/src/processing/app/syntax/PdeKeywords.java
+++ b/app/src/processing/app/syntax/PdeKeywords.java
@@ -50,13 +50,24 @@ public class PdeKeywords extends TokenMarker {
     int num = coloring.charAt(coloring.length() - 1) - '1';
 //    byte id = (byte) ((isKey ? Token.KEYWORD1 : Token.LITERAL1) + num);
     int id = 0;
-    boolean paren = false;
     switch (coloring.charAt(0)) {
-      case 'K': id = Token.KEYWORD1 + num; break;
-      case 'L': id = Token.LITERAL1 + num; break;
-      case 'F': id = Token.FUNCTION1 + num; paren = true; break;
+      case 'K':
+        id = Token.KEYWORD1 + num;
+        keywordColoring.add(keyword, (byte) id, false);
+        if (id == Token.KEYWORD6) {
+          // these can be followed by parens
+          keywordColoring.add(keyword, (byte) id, true);
+        }
+        break;
+      case 'L':
+        id = Token.LITERAL1 + num;
+        keywordColoring.add(keyword, (byte) id, false);
+        break;
+      case 'F':
+        id = Token.FUNCTION1 + num;
+        keywordColoring.add(keyword, (byte) id, true);
+        break;
     }
-    keywordColoring.add(keyword, (byte) id, paren);
   }
 
 

--- a/app/src/processing/app/syntax/PdeTextAreaDefaults.java
+++ b/app/src/processing/app/syntax/PdeTextAreaDefaults.java
@@ -215,6 +215,7 @@ public class PdeTextAreaDefaults extends TextAreaDefaults {
     styles[Token.KEYWORD3] = mode.getStyle("keyword3");
     styles[Token.KEYWORD4] = mode.getStyle("keyword4");
     styles[Token.KEYWORD5] = mode.getStyle("keyword5");
+    styles[Token.KEYWORD6] = mode.getStyle("keyword6");
 
     styles[Token.FUNCTION1] = mode.getStyle("function1");
     styles[Token.FUNCTION2] = mode.getStyle("function2");

--- a/app/src/processing/app/syntax/Token.java
+++ b/app/src/processing/app/syntax/Token.java
@@ -56,32 +56,35 @@ public class Token {
 
   /** Datatypes (int, boolean, etc.) */
   public static final byte KEYWORD5 = 10;
+  
+  /** Keywords which can be followed by parenthesis */
+  public static final byte KEYWORD6 = 11;
 
   /** Functions */
-  public static final byte FUNCTION1 = 11;
+  public static final byte FUNCTION1 = 12;
 
   /** Methods (functions inside a class) */
-  public static final byte FUNCTION2 = 12;
+  public static final byte FUNCTION2 = 13;
 
   /** Loop/function-like blocks (for, while, etc.) */
-  public static final byte FUNCTION3 = 13;
+  public static final byte FUNCTION3 = 14;
 
   /** Built-in Processing functions (setup, draw, mouseDragged). */
-  public static final byte FUNCTION4 = 14;
+  public static final byte FUNCTION4 = 15;
 
   /**
    * Operator token id. This can be used to mark an
    * operator. (eg, SQL mode marks +, -, etc with this
    * token type)
    */
-  public static final byte OPERATOR = 15;
+  public static final byte OPERATOR = 16;
 
   /**
    * Invalid token id. This can be used to mark invalid
    * or incomplete tokens, so the user can easily spot
    * syntax errors.
    */
-  public static final byte INVALID = 16;
+  public static final byte INVALID = 17;
 
   /** The total number of defined token ids. */
   public static final byte ID_COUNT = INVALID + 1;

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -248,6 +248,7 @@ editor.token.keyword2.style = #33997e,plain
 editor.token.keyword3.style = #669900,plain
 editor.token.keyword4.style = #d94a7a,plain
 editor.token.keyword5.style = #e2661a,plain
+editor.token.keyword6.style = #33997e,plain
 
 editor.token.literal1.style = #7D4793,plain
 editor.token.literal2.style = #718a62,plain

--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -180,9 +180,7 @@ WHITESPACE	LITERAL2
 # Java keywords (void, import, , etc.)
 		
 abstract	KEYWORD1
-assert	KEYWORD1
 break	KEYWORD1	break
-case	KEYWORD1	case
 class	KEYWORD1	class
 continue	KEYWORD1	continue
 default	KEYWORD1	default	
@@ -202,17 +200,23 @@ package	KEYWORD1
 private	KEYWORD1	private
 protected	KEYWORD1	
 public	KEYWORD1	public
-return	KEYWORD1	return	
 static	KEYWORD1	static
-strictfp	KEYWORD1
-super	KEYWORD1	super
-this	KEYWORD1	this
-throw	KEYWORD1	
+strictfp	KEYWORD1	
 throws	KEYWORD1	
 transient	KEYWORD1
 true	KEYWORD1	true
 void	KEYWORD1	void
 volatile	KEYWORD1
+
+
+# Java keywords which can be followed by a parenthesis
+
+assert	KEYWORD6
+case	KEYWORD6	case
+return	KEYWORD6	return	
+super	KEYWORD6	super
+this	KEYWORD6	this
+throw	KEYWORD6
 
 
 # Datatypes

--- a/pdex/keywords.txt
+++ b/pdex/keywords.txt
@@ -180,9 +180,7 @@ WHITESPACE	LITERAL2
 # Java keywords (void, import, , etc.)
 		
 abstract	KEYWORD1
-assert	KEYWORD1
 break	KEYWORD1	break
-case	KEYWORD1	case
 class	KEYWORD1	class
 continue	KEYWORD1	continue
 default	KEYWORD1	default	
@@ -202,17 +200,23 @@ package	KEYWORD1
 private	KEYWORD1	private
 protected	KEYWORD1	
 public	KEYWORD1	public
-return	KEYWORD1	return	
 static	KEYWORD1	static
-strictfp	KEYWORD1
-super	KEYWORD1	super
-this	KEYWORD1	this
-throw	KEYWORD1	
+strictfp	KEYWORD1	
 throws	KEYWORD1	
 transient	KEYWORD1
 true	KEYWORD1	true
 void	KEYWORD1	void
 volatile	KEYWORD1
+
+
+# Java keywords which can be followed by a parenthesis
+
+assert	KEYWORD6
+case	KEYWORD6	case
+return	KEYWORD6	return	
+super	KEYWORD6	super
+this	KEYWORD6	this
+throw	KEYWORD6
 
 
 # Datatypes


### PR DESCRIPTION
Keywords which can be followed by an expression were not highlighted if the expression was in parens. Now fixed. Fixes #2099.
