### PR TITLE
Made ant deb depend on dist

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -759,7 +759,7 @@
     </echo>
   </target>
   
-  <target name="deb" depends="linux-dist" 
+  <target name="deb" depends="dist" 
 	  description="Build .deb of linux version">
 
    <!-- start with a clean debian folder -->


### PR DESCRIPTION
The deb target now explicitly depends on dist so the $version property will be set.  See issue #2973.
