### PR TITLE
Adds splash screen for linux

### DIFF
--- a/build/linux/processing
+++ b/build/linux/processing
@@ -114,5 +114,5 @@ else
   fi
   cd "$APPDIR"
 
-  java -Djna.nosys=true -Xmx256m processing.app.Base "$SKETCH" &
+  java -splash:lib/about.jpg -Djna.nosys=true -Xmx256m processing.app.Base "$SKETCH" &
 fi


### PR DESCRIPTION
As listed in the todo.txt file, this commit adds the splash screen when launching processing on linux.
