### PR TITLE
Missing examples.properties file no longer causes crash

### DIFF
--- a/app/src/processing/app/contrib/ExamplesContribution.java
+++ b/app/src/processing/app/contrib/ExamplesContribution.java
@@ -17,8 +17,10 @@ public class ExamplesContribution extends LocalContribution {
 
   private ExamplesContribution(File folder) {
     super(folder);
-    compatibleModesList = parseCompatibleModesList(properties
-      .get("compatibleModesList"));
+    if (properties != null) {
+      compatibleModesList = parseCompatibleModesList(properties
+        .get("compatibleModesList"));
+    }
   }
 
   private static ArrayList<String> parseCompatibleModesList(String unparsedModes) {


### PR DESCRIPTION
This PR resolves [#3037](https://github.com/processing/processing/issues/3037) by ensuring that the properties HashMap is not null, i.e., that the .properties file actually exists.