### PR TITLE
MenuBar shortcut not being typed in the editor

### DIFF
--- a/app/src/processing/app/syntax/DefaultInputHandler.java
+++ b/app/src/processing/app/syntax/DefaultInputHandler.java
@@ -249,6 +249,9 @@ public class DefaultInputHandler extends InputHandler
                 // http://code.google.com/p/processing/issues/detail?id=596
                 if ((modifiers & InputEvent.CTRL_MASK) != 0 && c == '/') return;
 
+                //Prevents the Menubar shortcuts from getting typed into the editor
+                if((modifiers & InputEvent.ALT_MASK) != 0) return;
+
                 if (c != KeyEvent.CHAR_UNDEFINED) // &&
                   //                (modifiers & KeyEvent.ALT_MASK) == 0)
                 {


### PR DESCRIPTION
Fix for #3057 
In this i have ignored all the alt + characters.
Do let me know if this is the required behaviour. Or should i only ignore the keys which are shortcuts (eg. F,E,S,D etc. )