### PR TITLE
Save now creates opaque images from primary OpenGL surface (#3031)

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -5631,6 +5631,29 @@ public class PGraphicsOpenGL extends PGraphics {
 
   //////////////////////////////////////////////////////////////
 
+  // SAVE
+
+
+  @Override
+  public boolean save(String filename) {
+
+    // Act as opaque surface for the purposes of saving.
+    // This is a hack, primary surface is supposed to be
+    // opaque by default.
+    if (primarySurface) {
+      int prevFormat = format;
+      format = RGB;
+      boolean result = super.save(filename);
+      format = prevFormat;
+      return result;
+    }
+
+    return super.save(filename);
+  }
+
+
+  //////////////////////////////////////////////////////////////
+
   // LOAD/UPDATE TEXTURE
 
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -5637,9 +5637,7 @@ public class PGraphicsOpenGL extends PGraphics {
   @Override
   public boolean save(String filename) {
 
-    // Act as opaque surface for the purposes of saving.
-    // This is a hack, primary surface is supposed to be
-    // opaque by default.
+    // Act as an opaque surface for the purposes of saving.
     if (primarySurface) {
       int prevFormat = format;
       format = RGB;


### PR DESCRIPTION
Fixes #3031