### PR TITLE
Fatal errors now kill processing, enabling building it again without killing it manually without using the Task Manager

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -2060,6 +2060,9 @@ public class Base {
                                     fatal ?
                                     JOptionPane.ERROR_MESSAGE :
                                     JOptionPane.WARNING_MESSAGE);
+
+      if (fatal)
+        System.exit(1);
     }
   }
 


### PR DESCRIPTION
This commit resolves fatal errors, such as those indicated by the dialog box "We're off on the wrong foot", and not the usually non-fatal errors which sometimes might be fatal (such as those indicated by the dialog box "Terrible News", which though often non-fatal, might sometimes be fatal, as in #3063), thereby partly fixing the issue described in #3068.