### PR TITLE
contributions.txt now gets deleted and recreated instead of overwritten

### DIFF
--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -23,6 +23,7 @@ package processing.app.contrib;
 
 import java.io.*;
 import java.net.*;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -385,8 +386,16 @@ public class ContributionListing {
         }
 
         if (!progress.isFinished()) {
-          ContributionManager.download(url, listingFile, progress);
+          File tempContribFile = Base.getSettingsFile("contributions_temp.txt");
+          tempContribFile.setWritable(true);
+          ContributionManager.download(url, tempContribFile, progress);
           if (!progress.isCanceled() && !progress.isError()) {
+            try {
+              Files.deleteIfExists(listingFile.toPath());
+              listingFile = new File(Files.move(tempContribFile.toPath(), tempContribFile.toPath().resolveSibling(listingFile.toPath())).toString());
+            } catch (IOException e) {
+              e.printStackTrace();
+            }
             hasDownloadedLatestList = true;
             hasListDownloadFailed = false;
             setAdvertisedList(listingFile);


### PR DESCRIPTION
The contributions listing is now downloaded into a temporary file first. Once the listing is downloaded, the old ```contributions.txt``` file is deleted, and the temporary file is then renamed to ```contributions.txt```. This is required because the local copy of the ```contributions.txt``` (strangely enough) does not get updated sometimes (although this error is not easily reproducible by locally modifying the file, except when the file is from the processing website), as found [here](https://github.com/processing/processing/issues/2843). This PR fixes #2994.