### PR TITLE
Allow exported linux applications to be launched from a different folder

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1430,9 +1430,9 @@ public class JavaBuild {
         exportClassPath.append(jarList[i]);
       }
     } else {
+      exportClassPath.append("$APPDIR");
       for (int i = 0; i < jarList.length; i++) {
-        if (i != 0) exportClassPath.append(":");
-        exportClassPath.append("$APPDIR/lib/" + jarList[i]);
+        exportClassPath.append(":$APPDIR/lib/" + jarList[i]);
       }
     }
 


### PR DESCRIPTION
This addresses Issue #1046 which deals with launching exported linux applications from a different folder.  The problem was that the $APPDIR folder was not added to the classpath so it was not finding the data folder when the script was launched from a different location.  