### PR TITLE
Prevent memory leak of Client by unregistering parent dispose method

### DIFF
--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -61,6 +61,7 @@ public class Client implements Runnable {
   int bufferIndex;
   int bufferLast;
 
+  boolean isDisposeRegistered = false;
   
   /**
    * @param parent typically use "this"
@@ -81,6 +82,7 @@ public class Client implements Runnable {
       thread.start();
 
       parent.registerMethod("dispose", this);
+      isDisposeRegistered = true;
 
       // reflection to check whether host sketch has a call for
       // public void clientEvent(processing.net.Client)
@@ -157,6 +159,9 @@ public class Client implements Runnable {
         e.printStackTrace();
         disconnectEventMethod = null;
       }
+    }
+    if(isDisposeRegistered){
+      parent.unregisterMethod("dispose", this);
     }
     dispose();
   }

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -162,6 +162,7 @@ public class Client implements Runnable {
     }
     if(isDisposeRegistered){
       parent.unregisterMethod("dispose", this);
+      isDisposeRegistered = false;
     }
     dispose();
   }


### PR DESCRIPTION
This addresses issue #1400 dealing with a memory leak in the processing.net.Client which occurs when the parent "dispose" method is not unregistered if the client is stopped.  Rather than trying to track the state of several different variables, I've just declared an explicit boolean variable to track whether or not the dispose method needs to be unregistered.  Now when spawning and closing Clients the memory usage stays consistent.