### PR TITLE
Server check for dead clients while checking for available messages

### DIFF
--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -220,6 +220,16 @@ public class Server implements Runnable {
       for (int i = 0; i < clientCount; i++) {
         int which = (index + i) % clientCount;
         Client client = clients[which];
+        //Check for valid client
+        if (!client.active()){
+          removeIndex(which);  //Remove dead client
+          i--;                 //Don't skip the next client
+          //If the client has data make sure lastAvailable
+          //doesn't end up skipping the next client
+          which--;
+          //fall through to allow data from dead clients
+          //to be retreived.
+        }
         if (client.available() > 0) {
           lastAvailable = which;
           return client;


### PR DESCRIPTION
As discussed in issue #3089 the processing.net.Server only cleans up dead clients when trying to write to them.  This patch has the server also check for dead clients while it is looking for available data to read.  The check is done in such a way so that a client that has died with unread data can still be read.  Additionally, the order of the clients should remain consistent and no client should be skipped.  I have included comments explaining the code so that in the future the non-obvious statements can be easily understood.