### PR TITLE
IllegalArgumentException not getting thrown when clicking in a second sketch window

### DIFF
--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -1247,7 +1247,7 @@ public class JEditTextArea extends JComponent
       newBias = true;
     }
 
-    if(newStart < 0 || newEnd > getDocumentLength())
+    if((newStart < 0 || newEnd > getDocumentLength()) && start != end)
     {
       throw new IllegalArgumentException("Bounds out of"
           + " range: " + newStart + "," +


### PR DESCRIPTION
Fix for #2530 