### PR TITLE
Contrib Manager does not stop parsing contribs.txt if an error exists

### DIFF
--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -515,7 +515,13 @@ public class ContributionListing {
         ContributionType contribType = ContributionType.fromName(type);
         if (contribType == null) {
           System.err.println("Error in contribution listing file on line " + (start+1));
-          return outgoing;
+          // Scan forward for the next blank line
+          int end = ++start;
+          while (end < lines.length && !lines[end].equals("")) {
+            end++;
+          }
+          start = end + 1;
+          continue;
         }
 
         // Scan forward for the next blank line


### PR DESCRIPTION
The implementation is a slightly modified version of @prisonerjohn 's suggestion [here](https://github.com/processing/processing/issues/2953#issuecomment-71921649). It has been tested to run well with both the current contribs.txt as well as a the contribs.txt [here](https://github.com/joelmoniz/G4P_Examples/blob/master/contributions.txt) which contains entries for the now  renamed ```examples-package``` type.