### PR TITLE
Scrolling on Contribution Manager is now much smoother

### DIFF
--- a/app/src/processing/app/contrib/ContributionListPanel.java
+++ b/app/src/processing/app/contrib/ContributionListPanel.java
@@ -279,13 +279,14 @@ public class ContributionListPanel extends JPanel implements Scrollable, Contrib
   public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
     if (orientation == SwingConstants.VERTICAL) {
       int blockAmount = visibleRect.height;
-      if (direction > 0) {
-        visibleRect.y += blockAmount;
-      } else {
-        visibleRect.y -= blockAmount;
-      }
-
-      blockAmount += getScrollableUnitIncrement(visibleRect, orientation, direction);
+//      if (direction > 0) {
+//        visibleRect.y += blockAmount;
+//      } else {
+//        visibleRect.y -= blockAmount;
+//      }
+//
+//      blockAmount += getScrollableUnitIncrement(visibleRect, orientation, direction);
+      blockAmount /= 10;
       return blockAmount;
     }
     return 0;


### PR DESCRIPTION
This fixes #2189  
The scroll amount is now set to one-tenth of what is visible, which seemed optimal after a little experimentation.