### PR TITLE
Cut and Copy are now working .

### DIFF
--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -986,10 +986,16 @@ public abstract class Editor extends JFrame implements RunnerListener {
     menu.addMenuListener(new MenuListener() {
     
       @Override
-      public void menuCanceled(MenuEvent e) { }
+      public void menuCanceled(MenuEvent e) {
+        copyItems.setEnabled(true);
+        cutItems.setEnabled(true);
+      }
     
       @Override
-      public void menuDeselected(MenuEvent e) { }
+      public void menuDeselected(MenuEvent e) {
+        copyItems.setEnabled(true);
+        cutItems.setEnabled(true);
+      }
 
       @Override
       public void menuSelected(MenuEvent e) {

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -1413,7 +1413,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
     
     public void actionPerformed(ActionEvent e) {
-      System.out.println(e.getActionCommand());
       handleCut();
     }
     


### PR DESCRIPTION
Fix for #3136 and the discussion done in #3057 
The problem was that when Edit menu was opened without selecting any text the cut and copy options were disabled but when the menu was closed these options remained disabled and after that when cut/copy command was executed a doClick() was done on these items which were left disabled thus these command were not working.  
 