### PR TITLE
Automatically install libraries that a user imports, if not already installed

### DIFF
--- a/app/src/processing/app/contrib/AvailableContribution.java
+++ b/app/src/processing/app/contrib/AvailableContribution.java
@@ -251,9 +251,9 @@ public class AvailableContribution extends Contribution {
         sb.deleteCharAt(sb.length() - 1);
         category = sb.toString();
       }
-      
+
       String specifiedImport = "";
-      List<String> importsList = parseImports(properties.get("imports")); 
+      List<String> importsList = parseImports(properties.get("imports"));
       if (importsList == null || importsList.isEmpty()) {
         specifiedImport = getImportStr();
       } else {

--- a/app/src/processing/app/contrib/AvailableContribution.java
+++ b/app/src/processing/app/contrib/AvailableContribution.java
@@ -33,7 +33,7 @@ import processing.core.PApplet;
 /**
  * A class to hold information about a Contribution that can be downloaded. 
  */
-class AvailableContribution extends Contribution {
+public class AvailableContribution extends Contribution {
   protected final ContributionType type;   // Library, tool, etc.
   protected final String link;             // Direct link to download the file
 
@@ -44,6 +44,7 @@ class AvailableContribution extends Contribution {
     
     //category = ContributionListing.getCategory(params.get("category"));
     categories = parseCategories(params.get("category"));
+    specifiedImports = parseImports(params.get("imports"));
     name = params.get("name");
     authorList = params.get("authorList");
     url = params.get("url");
@@ -250,6 +251,20 @@ class AvailableContribution extends Contribution {
         sb.deleteCharAt(sb.length() - 1);
         category = sb.toString();
       }
+      
+      String specifiedImport = "";
+      List<String> importsList = parseImports(properties.get("imports")); 
+      if (importsList == null || importsList.isEmpty()) {
+        specifiedImport = getImportStr();
+      } else {
+        StringBuilder sbImport = new StringBuilder();
+        for (String it : specifiedImports) {
+          sbImport.append(it);
+          sbImport.append(',');
+        }
+        sbImport.deleteCharAt(sbImport.length() - 1);
+        specifiedImport = sbImport.toString();
+      }
 
       String authorList = properties.get("authorList");
       if (authorList == null || authorList.isEmpty()) {
@@ -336,6 +351,9 @@ class AvailableContribution extends Contribution {
         writer.println("lastUpdated=" + lastUpdated);
         writer.println("minRevision=" + minRev);
         writer.println("maxRevision=" + maxRev);
+        if (getType() == ContributionType.LIBRARY) {
+          writer.println("imports=" + specifiedImport);
+        }
         if (getType() == ContributionType.EXAMPLES) {
           writer.println("compatibleModesList=" + compatibleContribsList);
         }

--- a/app/src/processing/app/contrib/Contribution.java
+++ b/app/src/processing/app/contrib/Contribution.java
@@ -92,18 +92,18 @@ abstract public class Contribution {
   
   
   protected String getImportStr() {
-    if (specifiedImports == null || specifiedImports.isEmpty())
+    if (specifiedImports == null || specifiedImports.isEmpty()) {
       return "";
+    }
     StringBuilder sb = new StringBuilder();
     for (String importName : specifiedImports) {
       sb.append(importName);
       sb.append(',');
     }
-    sb.deleteCharAt(sb.length()-1);  // delete last comma
+    sb.deleteCharAt(sb.length() - 1); // delete last comma
     return sb.toString();
   }
-  
-  
+
   protected boolean hasImport(String importName) {
     if (specifiedImports != null && importName != null) {
       for (String c : specifiedImports) {
@@ -267,13 +267,13 @@ abstract public class Contribution {
    */
   static List<String> parseImports(String importStr) {
     List<String> outgoing = new ArrayList<String>();
-    
+
     if (importStr != null) {
       String[] importList = PApplet.trim(PApplet.split(importStr, ','));
       for (String importName : importList) {
-          outgoing.add(importName);
+        outgoing.add(importName);
       }
     }
-    return (outgoing.size() > 0) ? outgoing : null; 
+    return (outgoing.size() > 0) ? outgoing : null;
   }
 }

--- a/app/src/processing/app/contrib/Contribution.java
+++ b/app/src/processing/app/contrib/Contribution.java
@@ -47,6 +47,7 @@ abstract public class Contribution {
   protected long lastUpdated;   //  1402805757
   protected int minRevision;    //  0
   protected int maxRevision;    //  227
+  protected List<String> specifiedImports; // pdf.export.*,pdf.convert.common.*
   
   
   // "Sound"
@@ -76,6 +77,37 @@ abstract public class Contribution {
     if (category != null) {
       for (String c : categories) {
         if (category.equalsIgnoreCase(c)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }  
+  
+  
+  // pdf.export.*,pdf.convert.common.*
+  protected List<String> getImports() {
+    return specifiedImports;
+  }
+  
+  
+  protected String getImportStr() {
+    if (specifiedImports == null || specifiedImports.isEmpty())
+      return "";
+    StringBuilder sb = new StringBuilder();
+    for (String importName : specifiedImports) {
+      sb.append(importName);
+      sb.append(',');
+    }
+    sb.deleteCharAt(sb.length()-1);  // delete last comma
+    return sb.toString();
+  }
+  
+  
+  protected boolean hasImport(String importName) {
+    if (specifiedImports != null && importName != null) {
+      for (String c : specifiedImports) {
+        if (importName.equalsIgnoreCase(c)) {
           return true;
         }
       }
@@ -227,5 +259,21 @@ abstract public class Contribution {
       return defaultCategory();
     }
     return outgoing;
+  }
+  
+  
+  /**
+   * @return the list of imports that this contribution (library) contains.
+   */
+  static List<String> parseImports(String importStr) {
+    List<String> outgoing = new ArrayList<String>();
+    
+    if (importStr != null) {
+      String[] importList = PApplet.trim(PApplet.split(importStr, ','));
+      for (String importName : importList) {
+          outgoing.add(importName);
+      }
+    }
+    return (outgoing.size() > 0) ? outgoing : null; 
   }
 }

--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -120,7 +120,7 @@ public class ContributionListing {
           }
         }
       }
-      
+
       if (oldLib.getImports() != null) {
         for (String importName : oldLib.getImports()) {
           librariesByImportHeader.replace(importName, newLib);

--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -43,6 +43,7 @@ public class ContributionListing {
   ArrayList<ContributionChangeListener> listeners;
   ArrayList<AvailableContribution> advertisedContributions;
   Map<String, List<Contribution>> librariesByCategory;
+  Map<String, Contribution> librariesByImportHeader;
   ArrayList<Contribution> allContributions;
   boolean hasDownloadedLatestList;
   boolean hasListDownloadFailed;
@@ -53,6 +54,7 @@ public class ContributionListing {
     listeners = new ArrayList<ContributionChangeListener>();
     advertisedContributions = new ArrayList<AvailableContribution>();
     librariesByCategory = new HashMap<String, List<Contribution>>();
+    librariesByImportHeader = new HashMap<String, Contribution>();
     allContributions = new ArrayList<Contribution>();
     downloadingListingLock = new ReentrantLock();
 
@@ -118,6 +120,12 @@ public class ContributionListing {
           }
         }
       }
+      
+      if (oldLib.getImports() != null) {
+        for (String importName : oldLib.getImports()) {
+          librariesByImportHeader.replace(importName, newLib);
+        }
+      }
 
       for (int i = 0; i < allContributions.size(); i++) {
         if (allContributions.get(i) == oldLib) {
@@ -131,6 +139,11 @@ public class ContributionListing {
 
 
   private void addContribution(Contribution contribution) {
+    if (contribution.getImports() != null) {
+      for (String importName : contribution.getImports()) {
+        librariesByImportHeader.put(importName, contribution);
+      }
+    }
     for (String category : contribution.getCategories()) {
       if (librariesByCategory.containsKey(category)) {
         List<Contribution> list = librariesByCategory.get(category);
@@ -153,6 +166,11 @@ public class ContributionListing {
     for (String category : contribution.getCategories()) {
       if (librariesByCategory.containsKey(category)) {
         librariesByCategory.get(category).remove(contribution);
+      }
+    }
+    if (contribution.getImports() != null) {
+      for (String importName : contribution.getImports()) {
+        librariesByImportHeader.remove(importName);
       }
     }
     allContributions.remove(contribution);

--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -43,7 +43,7 @@ public class ContributionListing {
   ArrayList<ContributionChangeListener> listeners;
   ArrayList<AvailableContribution> advertisedContributions;
   Map<String, List<Contribution>> librariesByCategory;
-  Map<String, Contribution> librariesByImportHeader;
+  public Map<String, Contribution> librariesByImportHeader;
   ArrayList<Contribution> allContributions;
   boolean hasDownloadedLatestList;
   boolean hasListDownloadFailed;
@@ -66,7 +66,7 @@ public class ContributionListing {
   }
 
 
-  static ContributionListing getInstance() {
+  public static ContributionListing getInstance() {
     if (singleInstance == null) {
       synchronized (ContributionListing.class) {
         if (singleInstance == null) {

--- a/app/src/processing/app/contrib/ContributionManager.java
+++ b/app/src/processing/app/contrib/ContributionManager.java
@@ -334,8 +334,8 @@ public class ContributionManager {
             String statusMsg = base.getActiveEditor().getStatusMessage();
             if (statusMsg.contains("has been installed"))
               base.getActiveEditor().statusNotice(statusMsg + " "
-                                                    + "Now downloading "
-                                                    + ad.name);
+                                                    + "Downloading "
+                                                    + ad.name + "...");
             else
               base.getActiveEditor().statusNotice("Downloading " + ad.name
                                                     + "...");
@@ -377,7 +377,7 @@ public class ContributionManager {
     base.getActiveEditor().statusEmpty();
     System.out.println("The following libraries have been installed:");
     for (String l : installedLibList) {
-      System.out.println(l);
+      System.out.println("  • " + l);
     }
   }
 

--- a/app/src/processing/app/contrib/LocalContribution.java
+++ b/app/src/processing/app/contrib/LocalContribution.java
@@ -48,7 +48,6 @@ public abstract class LocalContribution extends Contribution {
   protected File folder;
   protected Map<String, String> properties;
   protected ClassLoader loader;
-  protected List<String> specifiedImports; // mylib,mylib.util;
 
   public LocalContribution(File folder) {
     this.folder = folder;

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -338,8 +338,9 @@ delete.messages.is_read_only.description = Some files are marked \"read-only\", 
 
 
 # ---------------------------------------
-# Contribution Panel
+# Contributions
 
+# Contribution Panel
 contrib = Contribution Manager
 contrib.manager_title.update = Update Manager
 contrib.manager_title.mode = Mode Manager
@@ -384,6 +385,20 @@ contrib.progress.downloading = Downloading
 contrib.download_error = An error occured while downloading the contribution.
 contrib.unsupported_operating_system = Your operating system does not appear to be supported. You should visit the %s\'s library for more info.
 
+# Install on Startup
+contrib.startup.errors.download_install = Error during download and install of %s
+contrib.startup.errors.temp_dir = Could not write to temporary directory during download and install of %s
+contrib.startup.errors.new_marker = The unupdated contribution marker seems to not like %s. You may have to install it manually to update...
+
+# Install on Import
+contrib.import.dialog.title = Missing Libraries Available
+contrib.import.dialog.primary_text = The following imported libraries  are available for download, but have not been installed.
+contrib.import.dialog.secondary_text = Would you like to install them now?
+contrib.import.progress.download = Downloading %s...
+contrib.import.progress.install = Installing %s...
+contrib.import.progress.done = %s has been installed.
+contrib.import.progress.final_list = The following libraries have been installed:
+contrib.import.errors.link = Error: The library %s has a strange looking download link.
 
 # ---------------------------------------
 # Warnings

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1875,8 +1875,19 @@ public class JavaEditor extends Editor {
           }
           ArrayList<AvailableContribution> installLibsHeaders = getNotInstalledAvailableLibs(importHeaders);
           if (!installLibsHeaders.isEmpty()) {
-            ContributionManager.downloadAndInstallOnImport(base,
-                installLibsHeaders);
+            StringBuilder libList = new StringBuilder("Would you like to install them now?");
+            for (AvailableContribution ac : installLibsHeaders) {
+              libList.append("\n  • " + ac.getName());
+            }
+            int option = Base
+                .showYesNoQuestion(this, "Missing Libraries Available",
+                                   "The following imported libraries  are available for download, but have not been installed.",
+                                   libList.toString());
+
+              if (option == JOptionPane.YES_OPTION) {
+                ContributionManager.downloadAndInstallOnImport(base,
+                    installLibsHeaders);
+              }
           }
         }
       }

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,6 +24,8 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import processing.app.*;
 import processing.app.Toolkit;
 import processing.app.contrib.AvailableContribution;
+import processing.app.contrib.Contribution;
+import processing.app.contrib.ContributionListing;
 import processing.app.contrib.ToolContribution;
 import processing.app.syntax.JEditTextArea;
 import processing.app.syntax.PdeTextAreaDefaults;
@@ -1869,20 +1872,22 @@ public class JavaEditor extends Editor {
           for (String[] importStatement : pieces) {
             importHeaders.add(importStatement[2]);
           }
-          ArrayList<String> installLibsHeaders = getUninstalledAvailableLib(importHeaders);
-          for (String s : installLibsHeaders)
-            System.out.println(s);
+          ArrayList<Contribution> installLibsHeaders = getNotInstalledAvailableLibs(importHeaders);
+          for (Contribution c : installLibsHeaders)
+            System.out.println(c.getName());
         }
       }
     }
   }
   
   /**
-   * Returns the name of the 
+   * Returns a list of AvailableContributions of those libraries that the user wants imported, 
+   * but that are not installed. 
    * @param importHeaders
    */
-  private ArrayList<String> getUninstalledAvailableLib(ArrayList<String> importHeadersList) {
-    ArrayList<String> libList = new ArrayList<String>();
+  private ArrayList<Contribution> getNotInstalledAvailableLibs(ArrayList<String> importHeadersList) {
+    Map<String, Contribution> importMap = ContributionListing.getInstance().librariesByImportHeader;
+    ArrayList<Contribution> libList = new ArrayList<Contribution>();
     for (String importHeaders : importHeadersList) {
       int dot = importHeaders.lastIndexOf('.');
       String entry = (dot == -1) ? importHeaders : importHeaders.substring(0,
@@ -1896,11 +1901,16 @@ public class JavaEditor extends Editor {
       Library library = null;
       try {
         library = this.getMode().getLibrary(entry);
-        if (library == null)
-          libList.add(importHeaders);//System.out.println(importHeaders + "not found");
+        if (library == null) {
+          Contribution c = importMap.get(importHeaders);
+          if (c!=null)
+            libList.add(c);//System.out.println(importHeaders + "not found");
+        }
       } catch (Exception e) {
         // Not gonna happen (hopefully)
-        libList.add(importHeaders);//System.out.println(importHeaders + "not found");
+        Contribution c = importMap.get(importHeaders);
+        if (c!=null)
+          libList.add(c);//System.out.println(importHeaders + "not found");
       }
     }
     return libList;

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1853,11 +1853,12 @@ public class JavaEditor extends Editor {
     super.prepareRun();
     downloadImports();
   }
-  
+
+
   /**
-   * Downloads libraries that have been imported, that aren't available as a 
-   * LocalContribution, but that have an AvailableContribution associated with 
-   * them. 
+   * Downloads libraries that have been imported, that aren't available as a
+   * LocalContribution, but that have an AvailableContribution associated with
+   * them.
    */
   protected void downloadImports() {
     String importRegex = errorCheckerService.importRegexp;
@@ -1867,7 +1868,7 @@ public class JavaEditor extends Editor {
         tabCode = sc.getProgram();
 
         String[][] pieces = PApplet.matchAll(tabCode, importRegex);
-        
+
         if (pieces != null) {
           ArrayList<String> importHeaders = new ArrayList<String>();
           for (String[] importStatement : pieces) {
@@ -1879,24 +1880,26 @@ public class JavaEditor extends Editor {
             for (AvailableContribution ac : installLibsHeaders) {
               libList.append("\n  • " + ac.getName());
             }
-            int option = Base
-                .showYesNoQuestion(this, "Missing Libraries Available",
-                                   "The following imported libraries  are available for download, but have not been installed.",
-                                   libList.toString());
+            int option = Base.showYesNoQuestion(this,
+                Language.text("contrib.import.dialog.title"),
+                Language.text("contrib.import.dialog.primary_text"),
+                libList.toString());
 
-              if (option == JOptionPane.YES_OPTION) {
-                ContributionManager.downloadAndInstallOnImport(base,
-                    installLibsHeaders);
-              }
+            if (option == JOptionPane.YES_OPTION) {
+              ContributionManager.downloadAndInstallOnImport(base,
+                  installLibsHeaders);
+            }
           }
         }
       }
     }
   }
-  
+
+
   /**
-   * Returns a list of AvailableContributions of those libraries that the user wants imported, 
-   * but that are not installed. 
+   * Returns a list of AvailableContributions of those libraries that the user
+   * wants imported, but that are not installed.
+   * 
    * @param importHeaders
    */
   private ArrayList<AvailableContribution> getNotInstalledAvailableLibs(ArrayList<String> importHeadersList) {
@@ -1917,18 +1920,23 @@ public class JavaEditor extends Editor {
         library = this.getMode().getLibrary(entry);
         if (library == null) {
           Contribution c = importMap.get(importHeaders);
-          if (c!=null && c instanceof AvailableContribution)
-            libList.add((AvailableContribution)c);//System.out.println(importHeaders + "not found");
+          if (c != null && c instanceof AvailableContribution) {
+            libList.add((AvailableContribution) c);// System.out.println(importHeaders
+                                                   // + "not found");
+          }
         }
       } catch (Exception e) {
         // Not gonna happen (hopefully)
         Contribution c = importMap.get(importHeaders);
-        if (c!=null && c instanceof AvailableContribution)
-          libList.add((AvailableContribution)c);//System.out.println(importHeaders + "not found");
+        if (c != null && c instanceof AvailableContribution) {
+          libList.add((AvailableContribution) c);// System.out.println(importHeaders
+                                                 // + "not found");
+        }
       }
     }
     return libList;
   }
+
 
   /**
    * Displays a JDialog prompting the user to save when the user hits

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -26,6 +26,7 @@ import processing.app.Toolkit;
 import processing.app.contrib.AvailableContribution;
 import processing.app.contrib.Contribution;
 import processing.app.contrib.ContributionListing;
+import processing.app.contrib.ContributionManager;
 import processing.app.contrib.ToolContribution;
 import processing.app.syntax.JEditTextArea;
 import processing.app.syntax.PdeTextAreaDefaults;
@@ -1872,9 +1873,11 @@ public class JavaEditor extends Editor {
           for (String[] importStatement : pieces) {
             importHeaders.add(importStatement[2]);
           }
-          ArrayList<Contribution> installLibsHeaders = getNotInstalledAvailableLibs(importHeaders);
-          for (Contribution c : installLibsHeaders)
-            System.out.println(c.getName());
+          ArrayList<AvailableContribution> installLibsHeaders = getNotInstalledAvailableLibs(importHeaders);
+          if (!installLibsHeaders.isEmpty()) {
+            ContributionManager.downloadAndInstallOnImport(base,
+                installLibsHeaders);
+          }
         }
       }
     }
@@ -1885,9 +1888,9 @@ public class JavaEditor extends Editor {
    * but that are not installed. 
    * @param importHeaders
    */
-  private ArrayList<Contribution> getNotInstalledAvailableLibs(ArrayList<String> importHeadersList) {
+  private ArrayList<AvailableContribution> getNotInstalledAvailableLibs(ArrayList<String> importHeadersList) {
     Map<String, Contribution> importMap = ContributionListing.getInstance().librariesByImportHeader;
-    ArrayList<Contribution> libList = new ArrayList<Contribution>();
+    ArrayList<AvailableContribution> libList = new ArrayList<AvailableContribution>();
     for (String importHeaders : importHeadersList) {
       int dot = importHeaders.lastIndexOf('.');
       String entry = (dot == -1) ? importHeaders : importHeaders.substring(0,
@@ -1903,14 +1906,14 @@ public class JavaEditor extends Editor {
         library = this.getMode().getLibrary(entry);
         if (library == null) {
           Contribution c = importMap.get(importHeaders);
-          if (c!=null)
-            libList.add(c);//System.out.println(importHeaders + "not found");
+          if (c!=null && c instanceof AvailableContribution)
+            libList.add((AvailableContribution)c);//System.out.println(importHeaders + "not found");
         }
       } catch (Exception e) {
         // Not gonna happen (hopefully)
         Contribution c = importMap.get(importHeaders);
-        if (c!=null)
-          libList.add(c);//System.out.println(importHeaders + "not found");
+        if (c!=null && c instanceof AvailableContribution)
+          libList.add((AvailableContribution)c);//System.out.println(importHeaders + "not found");
       }
     }
     return libList;


### PR DESCRIPTION
This fixes #2566. It basically checks for whether the imported libraries are already installed or not. If one or more of them aren't, and if any/all of them are available, a dialog menu is displayed to the user listing the available, not installed libraries. Selecting ```Yes``` installs the libraries and runs the sketch, while selecting ```No``` simply runs the sketch directly (which eventually displays an error due to the missing library).

Note: This adds a new field, ```imports```, to the ```library.properties``` file, where the most commonly used headers of the library are listed.