### PR TITLE
Fixed #3147 removed the need to restart the app to update sketchbook

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -268,7 +268,7 @@ public class Base {
       Base.showError("Missing required files",
                      "Processing requires a JRE with tools.jar (or a\n" +
                      "full JDK) installed in (or linked to) a folder\n" +
-                     "named “java” next to the Processing application.\n" +
+                     "named â€œjavaâ€� next to the Processing application.\n" +
                      "More information can be found on the Wiki.", cnfe);
     }
   }
@@ -1264,7 +1264,7 @@ public class Base {
     return found;
   }
 
-
+  
   protected boolean addSketches(DefaultMutableTreeNode node, File folder) throws IOException {
     // skip .DS_Store files, etc (this shouldn't actually be necessary)
     if (!folder.isDirectory()) {

--- a/app/src/processing/app/ColorChooser.java
+++ b/app/src/processing/app/ColorChooser.java
@@ -21,8 +21,6 @@
 
 package processing.app;
 
-import processing.core.*;
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Container;
@@ -30,12 +28,37 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
-import javax.swing.text.*;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.PlainDocument;
+
+import processing.core.PApplet;
 
 
 /**
@@ -50,7 +73,7 @@ public class ColorChooser {  //extends JFrame implements DocumentListener {
 
   ColorRange range;
   ColorSlider slider;
-
+  
   JTextField hueField, saturationField, brightnessField;
   JTextField redField, greenField, blueField;
 
@@ -93,6 +116,7 @@ public class ColorChooser {  //extends JFrame implements DocumentListener {
     box.add(Box.createHorizontalStrut(10));
 
     box.add(createColorFields(buttonName, buttonListener));
+    
 //    System.out.println("1: " + hexField.getInsets());
 
     box.add(Box.createHorizontalStrut(10));
@@ -142,8 +166,9 @@ public class ColorChooser {  //extends JFrame implements DocumentListener {
 
   
   //hexField.setText("#FFFFFF");
-
   
+  
+
   public void show() {
     window.setVisible(true);
     window.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
@@ -439,7 +464,7 @@ public class ColorChooser {  //extends JFrame implements DocumentListener {
     row.add(button);
     row.add(Box.createHorizontalGlue());
     box.add(row);
-    
+       
     row = Box.createHorizontalBox();
     if (Base.isMacOS()) {
       row.add(Box.createHorizontalStrut(11));

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -528,7 +528,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     JMenuItem addLib = new JMenuItem(Language.text("toolbar.add_mode"));
     addLib.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-        base.handleOpenModeManager();
+      //  base.handleOpenModeManager(); //************************
       }
     });
     modeMenu.add(addLib);
@@ -743,6 +743,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     item.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
         handleSave(false);
+        
       }
     });
 //    saveMenuItem = item;
@@ -1489,9 +1490,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
         undoItem.setEnabled(false);
         undoItem.setText(Language.text("menu.edit.undo"));
         putValue(Action.NAME, Language.text("menu.edit.undo"));
-//        if (sketch != null) {
-//          sketch.setModified(false);  // 0107
-//        }
+        if (sketch != null) {
+          sketch.setModified(false);  // 0107
+        }
       }
     }
   }
@@ -1755,6 +1756,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
   public void startCompoundEdit() {
     stopCompoundEdit();
     compoundEdit = new CompoundEdit();
+    
   }
 
 
@@ -3002,7 +3004,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       copyItem.setEnabled(active);
       discourseItem.setEnabled(active);
 
-      referenceItem.setEnabled(referenceCheck(false) != null);
+     // referenceItem.setEnabled(referenceCheck(false) != null);
       super.show(component, x, y);
     }
   }

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -528,7 +528,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     JMenuItem addLib = new JMenuItem(Language.text("toolbar.add_mode"));
     addLib.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-      //  base.handleOpenModeManager(); //************************
+       base.handleOpenModeManager();
       }
     });
     modeMenu.add(addLib);

--- a/app/src/processing/app/Editor.java
+++ b/app/src/processing/app/Editor.java
@@ -365,7 +365,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
     
   }
 
-
   protected ArrayList<ToolContribution> getCoreTools() {
     return coreTools;
   }
@@ -610,7 +609,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
    */
   protected void applyPreferences() {
     // Update fonts and other items controllable from the prefs
-    textarea.getPainter().updateAppearance();
+    TextAreaPainter tap=textarea.getPainter();
+    tap.setBackground( Preferences.getColor("run.present.bgcolor"));
+   
     textarea.repaint();
     
     console.updateAppearance();

--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -677,7 +677,7 @@ public class PreferencesFrame {
     String oldPath = Preferences.getSketchbookPath();
     String newPath = sketchbookLocationField.getText();
     if (!newPath.equals(oldPath)) {
-      base.setSketchbookFolder(new File(newPath));
+      { base.setSketchbookFolder(new File(newPath)); base.getNextMode().rebuildTree(); }    
     }
 
 //    setBoolean("editor.external", externalEditorBox.isSelected());

--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -87,10 +87,10 @@ public class PreferencesFrame {
 
   public PreferencesFrame(Base base) {
     this.base = base;
-    //dialog = new JDialog(editor, "Preferences", true);
+   // dialog = new JDialog(editor, "Preferences", true);
     dialog = new JFrame(Language.text("preferences"));
     dialog.setResizable(false);
-
+    
     Container pain = dialog.getContentPane();
     pain.setLayout(null);
 
@@ -246,8 +246,7 @@ public class PreferencesFrame {
     presentColor.setBackground(Preferences.getColor("run.present.bgcolor"));
 
     presentColorHex = new JTextField(6);
-    presentColorHex
-        .setText(Preferences.get("run.present.bgcolor").substring(1));
+    presentColorHex.setText(Preferences.get("run.present.bgcolor").substring(1));
     presentColorHex.getDocument().addDocumentListener(new DocumentListener() {
 
       @Override
@@ -658,6 +657,9 @@ public class PreferencesFrame {
    * then send a message to the editor saying that it's time to do the same.
    */
   protected void applyFrame() {
+    //Preferred Screen Color
+   // base.getActiveEditor().textarea.getPainter().setBackground(Preferences.getColor("run.present.bg"));
+    
     Preferences.setBoolean("editor.smooth", //$NON-NLS-1$
                            editorAntialiasBox.isSelected());
 
@@ -746,13 +748,17 @@ public class PreferencesFrame {
         selection = Integer.parseInt((String) selection);
       }
       Preferences.set("console.font.size", String.valueOf(selection));
+      
 
     } catch (NumberFormatException e) {
       Base.log("Ignoring invalid font size " + consoleSizeField); //$NON-NLS-1$
       consoleSizeField.setSelectedItem(Preferences.getInteger("console.font.size"));
     }
 
+    
     Preferences.setColor("run.present.bgcolor", presentColor.getBackground());
+    
+   // Preferences.setColor("run.present.bgcolor", base.getActiveEditor().textarea.getPainter().getBackground());
 
     Preferences.setBoolean("editor.input_method_support", inputMethodBox.isSelected()); //$NON-NLS-1$
 

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -553,7 +553,7 @@ public class Sketch {
         updateInternal(sanitaryName, newFolder);
 
 //        File newMainFile = new File(newFolder, newName + ".pde");
-//        String newMainFilePath = newMainFile.getAbsolutePath();
+//       String newMainFilePath = newMainFile.getAbsolutePath();
 //
 //        // having saved everything and renamed the folder and the main .pde,
 //        // use the editor to re-open the sketch to re-init state
@@ -798,6 +798,7 @@ public class Sketch {
   protected boolean saveAs() throws IOException {
     String newParentDir = null;
     String newName = null;
+    String sketchPath="";
 	
     final String oldName2 = folder.getName();
     // TODO rewrite this to use shared version from PApplet
@@ -808,9 +809,11 @@ public class Sketch {
       if (isReadOnly() || isUntitled()) {
         // default to the sketchbook folder
         fd.setDirectory(Preferences.getSketchbookPath());
+        sketchPath=Preferences.getSketchbookPath();
       } else {
         // default to the parent folder of where this was
         fd.setDirectory(folder.getParent());
+        sketchPath=folder.getParent();
       }
       String oldName = folder.getName();
       fd.setFile(oldName);
@@ -846,7 +849,7 @@ public class Sketch {
     if (!sanitaryName.equals(newName) && newFolder.exists()) {
       Base.showMessage("Cannot Save",
                        "A sketch with the cleaned name\n" +
-                       "“" + sanitaryName + "” already exists.");
+                       "â€œ" + sanitaryName + "â€� already exists.");
       return false;
     }
     newName = sanitaryName;
@@ -1006,6 +1009,8 @@ public class Sketch {
     editor.base.rebuildSketchbookMenus();
     editor.base.handleRecentRename(editor,oldPath);
 //    editor.header.rebuild();
+    
+    mode.updateTree(sketchName,sketchFolder);
   }
 
 

--- a/app/src/processing/app/tools/CreateFont.java
+++ b/app/src/processing/app/tools/CreateFont.java
@@ -103,9 +103,11 @@ public class CreateFont extends JFrame implements Tool {
     JTextArea textarea = new JTextArea(labelText);
     textarea.setBorder(new EmptyBorder(10, 10, 20, 10));
     textarea.setBackground(null);
+    
     textarea.setEditable(false);
     textarea.setHighlighter(null);
     textarea.setFont(new Font("Dialog", Font.PLAIN, 12));
+    //textarea.setForeground(Color.green);
     pain.add(textarea);
 
     // don't care about families starting with . or #

--- a/core/src/processing/core/PSurface.java
+++ b/core/src/processing/core/PSurface.java
@@ -41,7 +41,7 @@ public interface PSurface {
   // Background default needs to be different from the default value in
   // PGraphics.backgroundColor, otherwise size(100, 100) bg spills over.
   // https://github.com/processing/processing/issues/2297
-  static final Color WINDOW_BGCOLOR = new Color(0x00, 0xAA, 0xFF);
+  static final Color WINDOW_BGCOLOR = new Color(0xAA, 0xAA, 0xAA);
 
   // renderer that doesn't draw to the screen
   public void initOffscreen();

--- a/core/src/processing/core/PSurface.java
+++ b/core/src/processing/core/PSurface.java
@@ -41,7 +41,7 @@ public interface PSurface {
   // Background default needs to be different from the default value in
   // PGraphics.backgroundColor, otherwise size(100, 100) bg spills over.
   // https://github.com/processing/processing/issues/2297
-  static final Color WINDOW_BGCOLOR = new Color(0xDD, 0xDD, 0xDD);
+  static final Color WINDOW_BGCOLOR = new Color(0x00, 0xAA, 0xFF);
 
   // renderer that doesn't draw to the screen
   public void initOffscreen();


### PR DESCRIPTION
Now the Sketchbook updates automatically when saved or when the directory is changed in preferences. Additionally the user can press Space to refresh the window. Now, the tree is refreshed by 2 functions added in mode i.e. updateTree and rebuildTree.

updateTree()--> is called from updateInternal()
updateTree()--> called when saving a new sketch. Simply adds the name of the sketch
rebuild tree()--> called when there are changes in sketchbook folder in Preferences or when the user presses space.

after the tree is updated or rebuilt, the tree model just reloads the tree without affecting any other component.
In the sketchbook frame, below there is a small indication for the user to press space for refreshing.