### PR TITLE
Fix for #3129 (Incorrect Java 2D window dimensions)

### DIFF
--- a/core/src/processing/core/PSurfaceAWT.java
+++ b/core/src/processing/core/PSurfaceAWT.java
@@ -573,19 +573,6 @@ public class PSurfaceAWT implements PSurface {
 
   public void setVisible(boolean visible) {
     frame.setVisible(visible);
-
-    if (visible && PApplet.platform == PConstants.LINUX) {
-      // Linux doesn't deal with insets the same way. We get fake insets
-      // earlier, and then the window manager will slap its own insets
-      // onto things once the frame is realized on the screen. Awzm.
-      if (PApplet.platform == PConstants.LINUX) {
-        Insets insets = frame.getInsets();
-        frame.setSize(Math.max(sketchWidth, MIN_WINDOW_WIDTH) +
-                      insets.left + insets.right,
-                      Math.max(sketchHeight, MIN_WINDOW_HEIGHT) +
-                      insets.top + insets.bottom);
-      }
-    }
   }
 
 
@@ -681,6 +668,7 @@ public class PSurfaceAWT implements PSurface {
   private Dimension setFrameSize() {  //int sketchWidth, int sketchHeight) {
 //    System.out.format("setting frame size %d %d %n", sketchWidth, sketchHeight);
 //    new Exception().printStackTrace(System.out);
+    frame.show();
     Insets insets = frame.getInsets();
     int windowW = Math.max(sketchWidth, MIN_WINDOW_WIDTH) +
       insets.left + insets.right;

--- a/core/src/processing/core/PSurfaceAWT.java
+++ b/core/src/processing/core/PSurfaceAWT.java
@@ -518,6 +518,7 @@ public class PSurfaceAWT implements PSurface {
       // Did not help, and the screenRect setup seems to work fine.
       //frame.setExtendedState(Frame.MAXIMIZED_BOTH);
 
+      frame.dispose(); //Release native resources, letting us use setUndecorated().
       frame.setUndecorated(true);
       // another duplicate?
 //      if (backgroundColor != null) {
@@ -525,7 +526,7 @@ public class PSurfaceAWT implements PSurface {
 //      }
       // this may be the bounds of all screens
       frame.setBounds(screenRect);
-      frame.setVisible(true);
+      frame.setVisible(true); //Readd native resources
     }
     frame.setLayout(null);
     //frame.add(applet);


### PR DESCRIPTION
This is a fix for issue #3129.

The call to getInsets() was returning all 0s because the method requires the JFrame it is called on to have been previously shown. A call to frame.show() was added. 

This change made a small section of Linux-specific code (lines 577-588 in setVisible() ) unnecessary, so they were removed. 

These changes broke the call to setUndecorated() for present mode. A call to dispose() was added to release native resources and allow the call to setUndecorated(). The call to frame.setVisible() a few lines later re-adds the native resources.

The patch was tested with Java 1.8.0_31 on Windows 10 and Java 1.8.0_40 on Fedora Linux.