### PR TITLE
Fix stop button not reverting to play state after closing sketch

### DIFF
--- a/app/src/processing/app/EditorToolbar.java
+++ b/app/src/processing/app/EditorToolbar.java
@@ -172,7 +172,7 @@ abstract public class EditorToolbar extends JPanel {
   
   
   public void deactivateRun() { 
-    
+    swapButton(runButton);
   }
   
   


### PR DESCRIPTION
Upon launching the sketch and closing it manually (using the X button in the window) the button in the PDE is still in the stop state. This swaps the run button back in.