### PR TITLE
Refactor examples manager window: Fixes #3133

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1275,14 +1275,14 @@ public class Base {
       return false;  // let's not go there
     }
 
-    String[] list = folder.list();
+    String[] fileList = folder.list();
     // If a bad folder or unreadable or whatever, this will come back null
-    if (list == null) {
+    if (fileList == null) {
       return false;
     }
 
     // Alphabetize the list, since it's not always alpha order
-    Arrays.sort(list, String.CASE_INSENSITIVE_ORDER);
+    Arrays.sort(fileList, String.CASE_INSENSITIVE_ORDER);
 
 //    ActionListener listener = new ActionListener() {
 //        public void actionPerformed(ActionEvent e) {
@@ -1301,8 +1301,8 @@ public class Base {
     //menu.addActionListener(listener);
 
     boolean found = false;
-
-    for (String name : list) {
+    for (String name : fileList) {
+      //Skip hidden files
       if (name.charAt(0) == '.') {
         continue;
       }
@@ -1317,18 +1317,14 @@ public class Base {
       if (subfolder.isDirectory()) {
         File entry = checkSketchFolder(subfolder, name);
         if (entry != null) {
-//          DefaultMutableTreeNode item = new DefaultMutableTreeNode(name);
           DefaultMutableTreeNode item =
             new DefaultMutableTreeNode(new SketchReference(name, entry));
-//          item.addActionListener(listener);
-//          item.setActionCommand(entry.getAbsolutePath());
-//          menu.add(item);
+
           node.add(item);
           found = true;
 
         } else {
           // not a sketch folder, but maybe a subfolder containing sketches
-//          JMenu submenu = new JMenu(name);
           DefaultMutableTreeNode subnode = new DefaultMutableTreeNode(name);
           // needs to be separate var otherwise would set ifound to false
           boolean anything = addSketches(subnode, subfolder);

--- a/app/src/processing/app/Mode.java
+++ b/app/src/processing/app/Mode.java
@@ -650,118 +650,51 @@ public abstract class Mode {
 
 
   public DefaultMutableTreeNode buildExamplesTree() {
-    DefaultMutableTreeNode node = new DefaultMutableTreeNode("Examples");
+    DefaultMutableTreeNode root = new DefaultMutableTreeNode("Examples");
 
-//    JTree examplesTree = new JTree(node);
-//    rebuildExamplesTree(node);
-//  }
-
-    //DefaultTreeCellRenderer renderer = tree.
-//    TreeCellRenderer tcr = examplesTree.getCellRenderer();
-
-    //
-//
-//  public void rebuildExamplesTree(DefaultMutableTreeNode node) {
     try {
-      // break down the examples folder for examples
-//      File[] subfolders = examplesFolder.listFiles(new FilenameFilter() {
-//        public boolean accept(File dir, String name) {
-//          return dir.isDirectory() && name.charAt(0) != '.';
-//        }
-//      });
-      File[] subfolders = getExampleCategoryFolders();
 
-      DefaultMutableTreeNode modeExParent = new DefaultMutableTreeNode("Mode Examples");
-      
-      for (File sub : subfolders) {
-        DefaultMutableTreeNode subNode = new DefaultMutableTreeNode(sub.getName());
-        if (base.addSketches(subNode, sub)) {
-//          examplesParent.add(subNode);
-          modeExParent.add(subNode);
+      File[] examples = getExampleCategoryFolders();
+
+      for (File subFolder : examples) {
+        DefaultMutableTreeNode subNode = new DefaultMutableTreeNode(subFolder.getName());
+        if (base.addSketches(subNode, subFolder)) {
+          root.add(subNode);
         }
       }
- 
-      // get library examples
-      boolean any = false;
+
+      DefaultMutableTreeNode foundationLibraries = new DefaultMutableTreeNode("Core Libraries");
+
+      // Get examples for core libraries
       for (Library lib : coreLibraries) {
         if (lib.hasExamples()) {
           DefaultMutableTreeNode libNode = new DefaultMutableTreeNode(lib.getName());
           if (base.addSketches(libNode, lib.getExamplesFolder()))
-            modeExParent.add(libNode);
+            foundationLibraries.add(libNode);
         }
+      }
+      if(foundationLibraries.getChildCount() > 0) {
+        root.add(foundationLibraries);
       }
       
-      if (modeExParent.getChildCount() > 0)
-        node.add(modeExParent);
-
-      // get contrib library examples
-      any = false;
+      // Get examples for third party libraries
+      DefaultMutableTreeNode contributed = new DefaultMutableTreeNode("Libraries");
       for (Library lib : contribLibraries) {
         if (lib.hasExamples()) {
-          any = true;
-        }
-      }
-      if (any) {
-//        menu.addSeparator();
-        DefaultMutableTreeNode contribParent = new DefaultMutableTreeNode("Library Examples");
-//        Base.addDisabledItem(menu, "Contributed");
-        for (Library lib : contribLibraries) {
-          if (lib.hasExamples()) {
-//            JMenu libMenu = new JMenu(lib.getName());
             DefaultMutableTreeNode libNode = new DefaultMutableTreeNode(lib.getName());
-//            base.addSketches(libMenu, lib.getExamplesFolder(), replace);
             base.addSketches(libNode, lib.getExamplesFolder());
-//            menu.add(libMenu);
-            contribParent.add(libNode);
-          }
+          contributed.add(libNode);
         }
-        node.add(contribParent);
+      }
+      if(contributed.getChildCount() > 0){
+        root.add(contributed);
       }
     } catch (IOException e) {
       e.printStackTrace();
     }
-    
-    DefaultMutableTreeNode contribExampleNode = buildContributedExamplesTrees();
-    if (contribExampleNode.getChildCount() > 0)
-      node.add(contribExampleNode);
-    return node;
+
+    return root;
   }
-
-
-  public DefaultMutableTreeNode buildContributedExamplesTrees() {
-    DefaultMutableTreeNode node = new DefaultMutableTreeNode("Contributed Examples");
-
-    try {
-      File[] subfolders = ContributionType.EXAMPLES.listCandidates(examplesContribFolder);
-      if (subfolders == null) {
-        subfolders = new File[0]; //empty array
-      }
-      for (File sub : subfolders) {
-        if (!ExamplesContribution.isExamplesCompatible(base, sub))
-          continue;
-        DefaultMutableTreeNode subNode = new DefaultMutableTreeNode(sub.getName());
-        if (base.addSketches(subNode, sub)) {
-          node.add(subNode);
-          int exampleNodeNumber = -1;
-          for (int y = 0; y < subNode.getChildCount(); y++)
-            if (subNode.getChildAt(y).toString().equals("examples"))
-              exampleNodeNumber = y;
-          if (exampleNodeNumber == -1)
-            continue;
-          TreeNode exampleNode = subNode.getChildAt(exampleNodeNumber);
-          subNode.remove(exampleNodeNumber);
-          int count = exampleNode.getChildCount();
-          for (int x = 0; x < count; x++) {
-            subNode.add((DefaultMutableTreeNode) exampleNode.getChildAt(0));
-          }
-        }
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return node;//examplesTree;
-  }
-
 
   public void resetExamples() {
     if (examplesFrame != null) {
@@ -886,24 +819,19 @@ public abstract class Mode {
       examplesPanel.setLayout(new BorderLayout());
       examplesPanel.setBackground(Color.WHITE);
       
-      final JPanel openExamplesManagerPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-      JLabel openExamplesManagerLabel = new JLabel(Language.text("examples.add_examples"));
-//      openExamplesManagerLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-      openExamplesManagerPanel.add(openExamplesManagerLabel);
+      final JPanel openExamplesManagerPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+      JButton addExamplesButton = new JButton(Language.text("examples.add_examples"));
+      openExamplesManagerPanel.add(addExamplesButton);
       openExamplesManagerPanel.setOpaque(false);
       Border lineBorder = BorderFactory.createMatteBorder(0, 0, 1, 0, Color.BLACK);
       Border paddingBorder = BorderFactory.createEmptyBorder(3, 5, 1, 4);
       openExamplesManagerPanel.setBorder(BorderFactory.createCompoundBorder(lineBorder, paddingBorder));
-//      openExamplesManagerLabel.set
       openExamplesManagerPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
       openExamplesManagerPanel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-//      openExamplesManagerLabel.setForeground(new Color(0, 0, 238));
-      openExamplesManagerPanel.addMouseListener(new MouseAdapter() {
-        
+      addExamplesButton.addActionListener(new ActionListener() {
         @Override
-        public void mouseClicked(MouseEvent e) {
+        public void actionPerformed(ActionEvent e) {
           base.handleOpenExampleManager();
-//          openExamplesManagerLabel.setForeground(new Color(85, 26, 139));
         }
       });
       
@@ -916,7 +844,6 @@ public abstract class Mode {
 
       tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
       tree.setShowsRootHandles(true);
-//      tree.setToggleClickCount(2);
       // expand the root
       tree.expandRow(0);
       // now hide the root


### PR DESCRIPTION
This reorganizes the examples manager tree and changes the `Add Examples` label into a button. Also includes misc refactoring code cleanliness and readability. 

![screen shot 2015-04-04 at 8 31 57 pm](https://cloud.githubusercontent.com/assets/1526881/6995249/372ca9a4-db0a-11e4-9959-8f77feabdf50.png)
