### PR TITLE
Contribution Manager buttons are no longer broken

### DIFF
--- a/app/src/processing/app/contrib/ContributionPanel.java
+++ b/app/src/processing/app/contrib/ContributionPanel.java
@@ -237,6 +237,24 @@ class ContributionPanel extends JPanel {
 
     setExpandListener(this, new MouseAdapter() {
       public void mousePressed(MouseEvent e) {
+        // TODO: Fix Contribution Manager buttons
+        // The following is a temporary solution that calls all the ActionListeners 
+        // associated with a button when a user clicks on it
+        if (ContributionPanel.this.installRemoveButton.contains(e.getPoint())
+          && installRemoveButton.isVisible()) {
+          JButton irButton = ContributionPanel.this.installRemoveButton;
+          for (ActionListener a : irButton.getActionListeners()) {
+            a.actionPerformed(new ActionEvent(e.getSource(), e.getID(), e.paramString()));
+          }
+        }
+        else if (ContributionPanel.this.updateButton.contains(e.getPoint())
+          && updateButton.isVisible()) {
+          JButton upButton = ContributionPanel.this.updateButton;
+          for (ActionListener a : upButton.getActionListeners()) {
+            a.actionPerformed(new ActionEvent(e.getSource(), e.getID(), e.paramString()));
+          }
+        }
+        
         if (contrib.isCompatible(Base.getRevision()))
           listPanel.setSelectedPanel(ContributionPanel.this);
         else


### PR DESCRIPTION
This aims to provide a temporary fix to #3172. Right now, I've modified the mouse listener added to each ContributionPanel to pass on any clicks it receives to either the button dealing with installs, removes and undos, or the one dealing with updates (depending on where the user clicked and whether or not the button was visible).  
  
NB: Although it is bug-free, I think this is a temporary fix, since the Contribution Manager ran fine without this up until 2 months ago. I, however, am afraid that I have no clue about what changed, since, as far as I can tell, even the git logs don't seem to show any changes between 2-6 moths ago.