### PR TITLE
Graphics overlap fix in preferences

### DIFF
--- a/app/src/processing/app/PreferencesFrame.java
+++ b/app/src/processing/app/PreferencesFrame.java
@@ -390,7 +390,7 @@ public class PreferencesFrame {
       new JCheckBox(Language.text("preferences.show_warnings"));
     pain.add(warningsCheckerBox);
     d = warningsCheckerBox.getPreferredSize();
-    warningsCheckerBox.setBounds(warningLeft, top, d.width + 10, d.height);
+    warningsCheckerBox.setBounds(warningLeft + 20, top, d.width + 10, d.height);
     right = Math.max(right, warningLeft + d.width);
     top += d.height + GUI_BETWEEN;
 


### PR DESCRIPTION
the check box to "show warnings" in preferences is obscured by other
objects in the frame, making it difficult to click. This is just a quick fix for it, adding a tiny bit
of padding in between it and the setting to its left. 

