### PR TITLE
Add option to save JSON in compact form

### DIFF
--- a/core/src/processing/data/JSONObject.java
+++ b/core/src/processing/data/JSONObject.java
@@ -1554,12 +1554,19 @@ public class JSONObject {
 
 
   public boolean save(File file, String options) {
-    return write(PApplet.createWriter(file));
+    return write(PApplet.createWriter(file), options);
   }
 
-
   public boolean write(PrintWriter output) {
-    output.print(format(2));
+    return write(output, null);
+  }
+
+  public boolean write(PrintWriter output, String options) {
+    int indentFactor = 2;
+    if (options != null && options.equals("compact")) {
+      indentFactor = -1;
+    }
+    output.print(format(indentFactor));
     output.flush();
     return true;
   }


### PR DESCRIPTION
This puts the third parameter in `saveJSONObject(json, filename, options)` to some use. Main use case is storing big amounts of JSON data without wasting space on disk.