### PR TITLE
PApplet.java: disable a doc comment

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -3887,7 +3887,7 @@ public class PApplet implements PConstants {
   }
 
 
-  /**
+  /*
    * Find the minimum value in an array.
    * Throws an ArrayIndexOutOfBoundsException if the array is length 0.
    * @param list the source array


### PR DESCRIPTION
It's coming up in the wrong place on the Javadoc because its method is commented out.
Already mentioned at #3205 but you wanted it in a separate commit.