### PR TITLE
Removed extra edges in sphere tesselation (#3193)

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -8863,9 +8863,6 @@ public class PGraphicsOpenGL extends PGraphics {
         indices[indCount + 1] = vert1 - detailU;
         indices[indCount + 2] = vert1 - 1;
         indCount += 3;
-
-        addEdge(vert1 - detailU, vert1 - 1, true, true);
-        addEdge(vert1 - 1, vert1, true, true);
       }
 
       // Northern cap -------------------------------------------------------


### PR DESCRIPTION
Tested in 3.0a5, latest does not run for me.

Fixes #3193.
