### PR TITLE
Potential Tab menu fix

### DIFF
--- a/app/src/processing/app/EditorHeader.java
+++ b/app/src/processing/app/EditorHeader.java
@@ -273,7 +273,9 @@ public class EditorHeader extends JComponent {
       tab.textWidth = (int)
         font.getStringBounds(tab.text, g2.getFontRenderContext()).getWidth();
     }
-
+/* TODO eliminated 279-302 because it doesn't really work to reduce the tab size (by much anyways)
+ *      and makes it confusing to find the tab you want because the name is hidden
+ *      
     // make sure everything can fit
     if (!placeTabs(MARGIN_WIDTH, tabMax, null)) {
       //System.arraycopy(tabs, 0, visitOrder, 0, tabs.length);
@@ -297,14 +299,19 @@ public class EditorHeader extends JComponent {
           break;
         }
       }
-    }
+    }*/
 
     // now actually draw the tabs
-    placeTabs(MARGIN_WIDTH, tabMax, g2);
-
-    // draw the dropdown menu target
-    menuLeft = tabs[tabs.length - 1].right + TAB_BETWEEN;
-    menuRight = menuLeft + ARROW_TAB_WIDTH;
+    if(!placeTabs(MARGIN_WIDTH, tabMax - ARROW_TAB_WIDTH, g2)){
+      // draw the dropdown menu target at the right of the window
+      menuRight = tabMax;
+      menuLeft = menuRight - ARROW_TAB_WIDTH;
+    } else {
+      // draw the dropdown menu target next to the tabs
+      menuLeft = tabs[tabs.length - 1].right + TAB_BETWEEN;
+      menuRight = menuLeft + ARROW_TAB_WIDTH;
+    }
+    
     g.setColor(tabColor[UNSELECTED]);
     drawTab(g, menuLeft, menuRight);
 //    int arrowY = (getHeight() - TAB_HEIGHT - TAB_STRETCH) + (TAB_HEIGHT - ARROW_HEIGHT)/2;
@@ -370,7 +377,7 @@ public class EditorHeader extends JComponent {
 //      }
       tab.right = x;
 
-      if (g != null) {
+      if (g != null && tab.right < right) {
         g.setColor(tabColor[state]);
         drawTab(g, tab.left, tab.right);
 //        path.lineTo(x - NOTCH, top);


### PR DESCRIPTION
This is a possible fix for #1968 and other duplicates of this issue. It causes the tab menu to lock to the right of the window when there are too many tabs to display and it doesn't render tabs which would interfere with the menu. Resulting in something that looks like this if there are too many tabs to render.
![Too many tabs](https://cloud.githubusercontent.com/assets/6956401/7440377/dcdc58c0-f07e-11e4-828d-08daae87ad44.png) 
The only potential issue I see is that there is no indication that more tabs are hidden off screen. It might make sense to add another 'tab' which indicates more tabs are hidden (an ellipses or something). 

Hope this fixes this issue