### PR TITLE
The error message in Contribution Manager is set to null on hitting retry

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -161,6 +161,9 @@ public class ContributionManagerDialog {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
+          // The message is set to null so that every time the retry button is hit
+          // no previous error is displayed in the status
+          status.setMessage(null);
           downloadAndUpdateContributionListing();
         }
       });


### PR DESCRIPTION
The message is set to null so that every time the retry button is hit no previous error is displayed in the status.

P.S - just fooling around the Contribution Manager code to get familiar with the code for GSoC.