### PR TITLE
System proxy getting used by deafult

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -140,7 +140,9 @@ public class Preferences {
 
     PApplet.useNativeSelect =
       Preferences.getBoolean("chooser.files.native"); //$NON-NLS-1$
-
+    
+    System.setProperty("java.net.useSystemProxies","true");
+    
     // Set http proxy for folks that require it.
     // http://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html
     String proxyHost = get("proxy.host");

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -141,6 +141,8 @@ public class Preferences {
     PApplet.useNativeSelect =
       Preferences.getBoolean("chooser.files.native"); //$NON-NLS-1$
     
+    // So that the system proxy setting are used by default
+    // https://github.com/processing/processing/issues/2643
     System.setProperty("java.net.useSystemProxies","true");
     
     // Set http proxy for folks that require it.


### PR DESCRIPTION
Fix for #1476 
Another important feature could be to add a new tab or something like that in the preference window so that user can set proxy at any time.  
This would particularly be useful for those people whose proxy server allows connection for only a specific period of time and then they have to switch to another proxy. As going to preference.txt and changing it doesn't look cool.
I will file a separate issue in this regard , meanwhile this works for system proxy as well as if proxy is set in preferences.txt.