### PR TITLE
Added socks support in Processing

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -154,6 +154,13 @@ public class Preferences {
       System.setProperty("http.proxyHost", proxyHost);
       System.setProperty("http.proxyPort", proxyPort);
     }
+    String socksProxyHost = get("socksProxy.host");
+    String socksProxyPort = get("socksProxy.port");
+    if (socksProxyHost != null && socksProxyHost.length() != 0 && socksProxyPort != null
+      && socksProxyPort.length() != 0) {
+      System.setProperty("socksProxyHost", socksProxyHost);
+      System.setProperty("socksProxyPort", socksProxyPort);
+    }
   }
 
 

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -154,13 +154,13 @@ public class Preferences {
       System.setProperty("http.proxyHost", proxyHost);
       System.setProperty("http.proxyPort", proxyPort);
     }
-    
+
     // Set socks proxy for folks that require it.
     // http://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html
     String socksProxyHost = get("socksProxy.host");
     String socksProxyPort = get("socksProxy.port");
-    if (socksProxyHost != null && socksProxyHost.length() != 0 && socksProxyPort != null
-      && socksProxyPort.length() != 0) {
+    if (socksProxyHost != null && socksProxyHost.length() != 0 &&
+      socksProxyPort != null && socksProxyPort.length() != 0) {
       System.setProperty("socksProxyHost", socksProxyHost);
       System.setProperty("socksProxyPort", socksProxyPort);
     }

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -154,6 +154,9 @@ public class Preferences {
       System.setProperty("http.proxyHost", proxyHost);
       System.setProperty("http.proxyPort", proxyPort);
     }
+    
+    // Set socks proxy for folks that require it.
+    // http://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html
     String socksProxyHost = get("socksProxy.host");
     String socksProxyPort = get("socksProxy.port");
     if (socksProxyHost != null && socksProxyHost.length() != 0 && socksProxyPort != null

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -327,6 +327,14 @@ run.present.stop.color = #cccccc
 proxy.host=
 proxy.port=
 
+# SOCKS PROXY
+# Set a proxy server for folks that require it. This will allow the update
+# checker and the contrib manager to run properly in those environments.
+#socksProxy.host=proxy.example.com
+#socksProxy.port=9150
+socksProxy.host=
+socksProxy.port=
+
 # PDE X
 pdex.autoSave.autoSaveByDefault=true
 pdex.autoSave.autoSaveEnabled=false


### PR DESCRIPTION
Fix for #2643 
This should most probably fix the issue.
@benfry the field to be added to support socks proxy is `socksProxy.host` and `socksProxy.port` in the preference.txt . This should be added somewhere in the documentation and i am not sure where.