### PR TITLE
Fix for breakpoints causing a reload prompt

### DIFF
--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1662,10 +1662,12 @@ public class JavaEditor extends Editor {
     List<LineBreakpoint> bps = debugger.getBreakpoints(tab.getFileName());
 
     // load the source file
-    File sourceFile = new File(sketch.getFolder(), tab.getFileName());
+    ////switched to using resoures provided by the SketchCode class
+    // File sourceFile = new File(sketch.getFolder(), tab.getFileName());
     //System.out.println("file: " + sourceFile);
     try {
-      String code = Base.loadFile(sourceFile);
+      tab.load();
+      String code = tab.getProgram();
       //System.out.println("code: " + code);
       String lines[] = code.split("\\r?\\n"); // newlines not included
       for (LineBreakpoint bp : bps) {
@@ -1674,7 +1676,7 @@ public class JavaEditor extends Editor {
       }
       code = PApplet.join(lines, "\n");
       //System.out.println("new code: " + code);
-      Base.saveFile(code, sourceFile);
+      tab.save();
     } catch (IOException ex) {
       Logger.getLogger(JavaEditor.class.getName()).log(Level.SEVERE, null, ex);
     }

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1662,7 +1662,7 @@ public class JavaEditor extends Editor {
     List<LineBreakpoint> bps = debugger.getBreakpoints(tab.getFileName());
 
     // load the source file
-    ////switched to using resoures provided by the SketchCode class
+    ////switched to using methods provided by the SketchCode class
     // File sourceFile = new File(sketch.getFolder(), tab.getFileName());
     //System.out.println("file: " + sourceFile);
     try {
@@ -1676,6 +1676,7 @@ public class JavaEditor extends Editor {
       }
       code = PApplet.join(lines, "\n");
       //System.out.println("new code: " + code);
+      tab.setProgram(code);
       tab.save();
     } catch (IOException ex) {
       Logger.getLogger(JavaEditor.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
Modified the Java mode to use the methods provided by the SketchCode class to access the code. This allows the times to update and fixes the issue brought up in #3222 