### PR TITLE
Mode problems dialog now displays vertically

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -2076,8 +2076,9 @@ public class Base {
       t.printStackTrace(new PrintWriter(sw));
       // Necessary to replace \n with <br/> (even if pre) otherwise Java
       // treats it as a closed tag and reverts to plain formatting.
-      message = "<html>" + message + "<br/><font size=2><br/>" +
-        sw.toString().replaceAll("\n", "<br/>");
+      message = "<html>" + message.replaceAll("\n", "<br/>") +
+        "<br/><font size=2><br/>" +
+        sw.toString().replaceAll("\n", "<br/>") + "</html>";
 
       JOptionPane.showMessageDialog(new Frame(), message, title,
                                     fatal ?


### PR DESCRIPTION
This resolves #3369, which was occurring because the `message` passed to the `showBadnessTrace()` function had new lines in it that weren't replaced with <br/> tags.
