### PR TITLE
Contributed library's import statements now gets added correctly

### DIFF
--- a/app/src/processing/app/contrib/LocalContribution.java
+++ b/app/src/processing/app/contrib/LocalContribution.java
@@ -543,10 +543,12 @@ public abstract class LocalContribution extends Contribution {
   }
   */
   /**
-   * Returns the imports (package-names) for a library, as specified in its library.properties
+   * Returns the imports (package-names) for a library, as specified in its 
+   * library.properties
    * (e.g., imports=libname.*,libname.support.*) 
    * 
-   * @return String[] packageNames (without wildcards) or null if none are specified
+   * @return String[] packageNames (without wildcards) or null if 
+   * none are specified
    */
   public String[] getSpecifiedImports() {
     
@@ -554,8 +556,8 @@ public abstract class LocalContribution extends Contribution {
   }
 
   /**
-   * @return the list of Java imports to be added to the sketch when the library is imported
-   * or null if none are specified
+   * @return the list of Java imports to be added to the sketch when the 
+   * library is imported or null if none are specified
    */
   protected static List<String> parseImports(String importsStr) {
     
@@ -576,7 +578,13 @@ public abstract class LocalContribution extends Contribution {
       }
     }
     
-    return (outgoing.size() > 0) ? outgoing : null; 
+    if (outgoing.size() > 1 || (outgoing.size() == 1 && 
+        !outgoing.get(0).isEmpty())) {
+      return outgoing;
+    }
+    else {
+      return null;
+    }
   }
   
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .


### PR DESCRIPTION
Adding in import statements corresponding to a contributed library via `Sketch>Import Library...>(contributed library)` now adds in the correct import statement(s). The error was because of the relatively new `specifiedImports` field in the `.properties` file, which is blank for most library contributions at present. The import statements were getting read from here, and null was being returned only if the field was null. However, the field was being parsed and stored as an empty string if the field was not present/was blank, which caused an import statement of the form `import (blank string).*` to be added.
  
This resolves #3403.