### PR TITLE
Added a comment in LargePage

### DIFF
--- a/java/libraries/pdf/examples/LargePage/LargePage.pde
+++ b/java/libraries/pdf/examples/LargePage/LargePage.pde
@@ -5,6 +5,7 @@
  * than the screen. When PDF is used as the renderer
  * (the third parameter of size) the display window 
  * does not open. The file is saved to the sketch folder.
+ * You can open it by "Sketch->Show Sketch Folder."
  */
 
 


### PR DESCRIPTION
Environment: Ubuntu 14.10
Version: 3.0 alpha 0238

I tried an example of PDF library named "LargePage," and I had difficulty in finding the generated PDF file.
The comment in LargePage says "The file is saved to the sketch folder," but I think this is unfriendly because we usually open examples from "File->Examples..." so we don't care about where the sketch folder is.
Fortunately, we can open the sketch folder by "Sketch->Show Sketch Folder." I added a comment about this.