### PR TITLE
Remove mode parameters from createShape(), fixes parameter collision issues

### DIFF
--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1789,7 +1789,7 @@ public class PGraphics extends PImage implements PConstants {
       return createShapePrimitive(kind, p);
 
     } else if (kind == RECT) {
-      if (len != 4 && len != 5 && len != 8 && len != 9) {
+      if (len != 4 && len != 5 && len != 8) {
         throw new IllegalArgumentException("Wrong number of parameters for createShape(RECT), see the reference");
       }
       return createShapePrimitive(kind, p);

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1802,7 +1802,7 @@ public class PGraphics extends PImage implements PConstants {
 
     } else if (kind == ARC) {
       if (len != 6 && len != 7) {
-        throw new IllegalArgumentException("Use createShape(ARC, x, y, w, h, start, stop)");
+        throw new IllegalArgumentException("Use createShape(ARC, x, y, w, h, start, stop) or createShape(ARC, x, y, w, h, start, stop, arcMode)");
       }
       return createShapePrimitive(kind, p);
 

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1795,8 +1795,8 @@ public class PGraphics extends PImage implements PConstants {
       return createShapePrimitive(kind, p);
 
     } else if (kind == ELLIPSE) {
-      if (len != 4 && len != 5) {
-        throw new IllegalArgumentException("Use createShape(ELLIPSE, x, y, w, h) or createShape(ELLIPSE, x, y, w, h, mode)");
+      if (len != 4) {
+        throw new IllegalArgumentException("Use createShape(ELLIPSE, x, y, w, h)");
       }
       return createShapePrimitive(kind, p);
 

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1654,9 +1654,8 @@ public class PShape implements PConstants {
         }
       }
     } else if (kind == ELLIPSE) {
-      g.ellipseMode(CORNER);
-      g.ellipse(params[0], params[1], params[2], params[3]);
-
+      g.ellipse(params[0], params[1],
+                params[2], params[3]);
     } else if (kind == ARC) {
       if (params.length == 6) {
         g.arc(params[0], params[1],

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1654,9 +1654,16 @@ public class PShape implements PConstants {
       g.ellipse(params[0], params[1], params[2], params[3]);
 
     } else if (kind == ARC) {
-      g.ellipseMode(CORNER);
-      g.arc(params[0], params[1], params[2], params[3], params[4], params[5]);
-
+      if (params.length == 6) {
+        g.arc(params[0], params[1],
+              params[2], params[3],
+              params[4], params[5]);
+      } else if (params.length == 7) {
+        g.arc(params[0], params[1],
+              params[2], params[3],
+              params[4], params[5],
+              (int) params[6]);
+      }
     } else if (kind == BOX) {
       if (params.length == 1) {
         g.box(params[0]);

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1637,18 +1637,22 @@ public class PShape implements PConstants {
 
     } else if (kind == RECT) {
       if (image != null) {
-        g.imageMode(CORNER);
         g.image(image, params[0], params[1], params[2], params[3]);
       } else {
-        if(params.length != 5){
-          g.rectMode(CORNER);
+        if (params.length == 4) {
+          g.rect(params[0], params[1],
+                 params[2], params[3]);
+        } else if (params.length == 5) {
+          g.rect(params[0], params[1],
+                 params[2], params[3],
+                 params[4]);
+        } else if (params.length == 8) {
+          g.rect(params[0], params[1],
+                 params[2], params[3],
+                 params[4], params[5],
+                 params[6], params[7]);
         }
-        else{
-          g.rectMode((int) params[4]);
-        }
-        g.rect(params[0], params[1], params[2], params[3]);
       }
-
     } else if (kind == ELLIPSE) {
       g.ellipseMode(CORNER);
       g.ellipse(params[0], params[1], params[2], params[3]);

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -331,10 +331,8 @@ public class PShape implements PConstants {
 //    curveDetail = pg.curveDetail;
 //    curveTightness = pg.curveTightness;
 
-    // The rect and ellipse modes are set to CORNER since it is the expected
-    // mode for svg shapes.
-    rectMode = CORNER;
-    ellipseMode = CORNER;
+    rectMode = g.rectMode;
+    ellipseMode = g.ellipseMode;
 
 //    normalX = normalY = 0;
 //    normalZ = 1;

--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -266,6 +266,11 @@ public class PShapeSVG extends PShape {
 
       opacity = parent.opacity;
     }
+
+    // The rect and ellipse modes are set to CORNER since it is the expected
+    // mode for svg shapes.
+    rectMode = CORNER;
+    ellipseMode = CORNER;
   }
 
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -899,8 +899,8 @@ public class PGraphicsOpenGL extends PGraphics {
 
     @Override
     public boolean equals(Object obj) {
-      GLResourceTexture other = (GLResourceTexture)obj;
-      return other.glName == glId &&
+      GLResourceVertexBuffer other = (GLResourceVertexBuffer)obj;
+      return other.glId == glId &&
              other.context == context;
     }
 

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -3257,6 +3257,7 @@ public class PShapeOpenGL extends PShape {
     float a = 0, b = 0, c = 0, d = 0;
     float start = 0, stop = 0;
     int mode = ellipseMode;
+    int arcMode = 0;
 
     if (6 <= params.length) {
       a = params[0];
@@ -3266,7 +3267,7 @@ public class PShapeOpenGL extends PShape {
       start = params[4];
       stop = params[5];
       if (params.length == 7) {
-        mode = (int)(params[6]);
+        arcMode = (int)(params[6]);
       }
     }
 
@@ -3301,13 +3302,13 @@ public class PShapeOpenGL extends PShape {
         }
 
         if (stop - start > TWO_PI) {
-          start = 0;
-          stop = TWO_PI;
+          // don't change start, it is visible in PIE mode
+          stop = start + TWO_PI;
         }
         inGeo.setMaterial(fillColor, strokeColor, strokeWeight,
                           ambientColor, specularColor, emissiveColor, shininess);
         inGeo.setNormal(normalX, normalY, normalZ);
-        inGeo.addArc(x, y, w, h, start, stop, fill, stroke, mode);
+        inGeo.addArc(x, y, w, h, start, stop, fill, stroke, arcMode);
         tessellator.tessellateTriangleFan();
       }
     }

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -395,10 +395,8 @@ public class PShapeOpenGL extends PShape {
     curveDetail = pg.curveDetail;
     curveTightness = pg.curveTightness;
 
-    // The rect and ellipse modes are set to CORNER since it is the expected
-    // mode for svg shapes.
-    rectMode = CORNER;
-    ellipseMode = CORNER;
+    rectMode = pg.rectMode;
+    ellipseMode = pg.ellipseMode;
 
     normalX = normalY = 0;
     normalZ = 1;

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -3211,9 +3211,6 @@ public class PShapeOpenGL extends PShape {
       b = params[1];
       c = params[2];
       d = params[3];
-      if (params.length == 5) {
-        mode = (int)(params[4]);
-      }
     }
 
     float x = a;

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -3129,11 +3129,15 @@ public class PShapeOpenGL extends PShape {
       b = params[1];
       c = params[2];
       d = params[3];
-      if (params.length == 5) {
-        mode = (int)(params[4]);
-      }
       rounded = false;
-    } else if (params.length == 8 || params.length == 9) {
+      if (params.length == 5) {
+        tl = params[4];
+        tr = params[4];
+        br = params[4];
+        bl = params[4];
+        rounded = true;
+      }
+    } else if (params.length == 8) {
       a = params[0];
       b = params[1];
       c = params[2];
@@ -3142,9 +3146,6 @@ public class PShapeOpenGL extends PShape {
       tr = params[5];
       br = params[6];
       bl = params[7];
-      if (params.length == 9) {
-        mode = (int)(params[8]);
-      }
       rounded = true;
     }
 


### PR DESCRIPTION
Load rectMode and ellipseMode from parent.
Unify signatures and make them all work. This is the full list of available signatures:
```
createShape(POINT, x, y);

createShape(LINE, x1, y1, x2, y2);
createShape(LINE, x1, y1, z1, x2, y2, z2);

createShape(TRIANGLE, x1, y1, x2, y2, x3, y3);

createShape(QUAD, x1, y1, x2, y2, x3, y3, x4, y4);

createShape(RECT, a, b, c, d);
createShape(RECT, a, b, c, d, radius);
createShape(RECT, a, b, c, d, tl, tr, br, bl);

createShape(ELLIPSE, a, b, c, d);

createShape(ARC, a, b, c, d, start, stop);
createShape(ARC, a, b, c, d, start, stop, arcMode);

createShape(BOX, a);
createShape(BOX, a, b, c);

createShape(SPHERE, r);
```

Fixes #2646
Fixes #3018