### PR TITLE
Prevent flickering of static sketches

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -79,7 +79,7 @@ public abstract class PGL {
    * See the code and comments involving this constant in
    * PGraphicsOpenGL.endDraw().
    */
-  protected static boolean SAVE_SURFACE_TO_PIXELS_HACK = false;
+  protected static boolean SAVE_SURFACE_TO_PIXELS_HACK = true;
 
   /** Enables/disables mipmap use. */
   protected static boolean MIPMAPS_ENABLED = true;


### PR DESCRIPTION
Re-enabled `SAVE_SURFACE_TO_PIXELS_HACK` so that front and back textures have both the same content after `setup()` and the sketch does not flicker.

Fixes #3473 OpenGL sketch flickers when draw() is missing or empty