### PR TITLE
Feature: depth reading

### DIFF
--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -514,5 +514,8 @@ public interface PConstants {
   static final int ENABLE_STROKE_PURE         =  9;
   static final int DISABLE_STROKE_PURE        = -9;
 
-  static final int HINT_COUNT                 = 10;
+  static final int ENABLE_DEPTH_READING       =  10;
+  static final int DISABLE_DEPTH_READING      = -10;
+
+  static final int HINT_COUNT                 =  11;
 }

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1110,6 +1110,15 @@ public class PGraphics extends PImage implements PConstants {
    * hint(DISABLE_OPENGL_ERROR_REPORT) - Speeds up the P3D renderer setting
    * by not checking for errors while running. Undo with hint(ENABLE_OPENGL_ERROR_REPORT).
    * <br/> <br/>
+   * hint(ENABLE_DEPTH_READING) - Depth and stencil buffers in P2D/P3D will be
+   * downsampled to make PGL#getDepthValue, PGL#getStencilValue and PGL#readPixels
+   * work with multisampling. Enabling this introduces some overhead, so if you
+   * experience bad performance, disable multisampling with noSmooth() instead.
+   * This hint is not intended to be enabled and disabled repeatedely, so call this
+   * once in setup() or after creating your PGraphics2D/3D. You can restore the
+   * default with hint(DISABLE_DEPTH_READING) if you don't plan to read depth from
+   * this PGraphics anymore.
+   * <br/> <br/>
    * As of release 0149, unhint() has been removed in favor of adding
    * additional ENABLE/DISABLE constants to reset the default behavior. This
    * prevents the double negatives, and also reinforces which hints can be

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1111,12 +1111,12 @@ public class PGraphics extends PImage implements PConstants {
    * by not checking for errors while running. Undo with hint(ENABLE_OPENGL_ERROR_REPORT).
    * <br/> <br/>
    * hint(ENABLE_DEPTH_READING) - Depth and stencil buffers in P2D/P3D will be
-   * downsampled to make PGL#getDepthValue, PGL#getStencilValue and PGL#readPixels
-   * work with multisampling. Enabling this introduces some overhead, so if you
-   * experience bad performance, disable multisampling with noSmooth() instead.
-   * This hint is not intended to be enabled and disabled repeatedely, so call this
-   * once in setup() or after creating your PGraphics2D/3D. You can restore the
-   * default with hint(DISABLE_DEPTH_READING) if you don't plan to read depth from
+   * downsampled to make PGL#readPixels work with multisampling. Enabling this
+   * introduces some overhead, so if you experience bad performance, disable
+   * multisampling with noSmooth() instead. This hint is not intended to be
+   * enabled and disabled repeatedely, so call this once in setup() or after
+   * creating your PGraphics2D/3D. You can restore the default with
+   * hint(DISABLE_DEPTH_READING) if you don't plan to read depth from
    * this PGraphics anymore.
    * <br/> <br/>
    * As of release 0149, unhint() has been removed in favor of adding

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -1301,6 +1301,7 @@ public abstract class PGL {
     if (stencilBuffer == null) {
       stencilBuffer = ByteBuffer.allocate(1);
     }
+    stencilBuffer.rewind();
     readPixels(scrX, pg.height - scrY - 1, 1, 1, STENCIL_INDEX,
                UNSIGNED_BYTE, stencilBuffer);
     return stencilBuffer.get(0);

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2716,7 +2716,7 @@ public abstract class PGL {
   // to glReadPixels() should be done in readPixelsImpl().
 
   public void readPixels(int x, int y, int width, int height, int format, int type, Buffer buffer){
-    boolean multisampled = isMultisampled();
+    boolean multisampled = isMultisampled() || pg.offscreenMultisample;
     boolean depthReadingEnabled = pg.getHint(PConstants.ENABLE_DEPTH_READING);
     boolean depthRequested = format == STENCIL_INDEX || format == DEPTH_COMPONENT || format == DEPTH_STENCIL;
 

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -785,6 +785,28 @@ public abstract class PGL {
                               RENDERBUFFER, glColorBuf.get(0));
     }
 
+    createDepthAndStencilBuffer(multisample, depthBits, stencilBits, packed);
+
+    validateFramebuffer();
+
+    // Clear all buffers.
+    clearDepth(1);
+    clearStencil(0);
+    int argb = pg.backgroundColor;
+    float a = ((argb >> 24) & 0xff) / 255.0f;
+    float r = ((argb >> 16) & 0xff) / 255.0f;
+    float g = ((argb >> 8) & 0xff) / 255.0f;
+    float b = ((argb) & 0xff) / 255.0f;
+    clearColor(r, g, b, a);
+    clear(DEPTH_BUFFER_BIT | STENCIL_BUFFER_BIT | COLOR_BUFFER_BIT);
+
+    bindFramebufferImpl(FRAMEBUFFER, 0);
+
+    fboLayerCreated = true;
+  }
+
+  private void createDepthAndStencilBuffer(boolean multisample, int depthBits,
+                                           int stencilBits, boolean packed) {
     // Creating depth and stencil buffers
     if (packed && depthBits == 24 && stencilBits == 8) {
       // packed depth+stencil buffer
@@ -849,23 +871,6 @@ public abstract class PGL {
                                 RENDERBUFFER, glStencil.get(0));
       }
     }
-
-    validateFramebuffer();
-
-    // Clear all buffers.
-    clearDepth(1);
-    clearStencil(0);
-    int argb = pg.backgroundColor;
-    float a = ((argb >> 24) & 0xff) / 255.0f;
-    float r = ((argb >> 16) & 0xff) / 255.0f;
-    float g = ((argb >> 8) & 0xff) / 255.0f;
-    float b = ((argb) & 0xff) / 255.0f;
-    clearColor(r, g, b, a);
-    clear(DEPTH_BUFFER_BIT | STENCIL_BUFFER_BIT | COLOR_BUFFER_BIT);
-
-    bindFramebufferImpl(FRAMEBUFFER, 0);
-
-    fboLayerCreated = true;
   }
 
 

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -142,13 +142,16 @@ public abstract class PGL {
   protected boolean firstFrame = true;
   public int reqNumSamples;
   protected int numSamples;
+
   protected IntBuffer glColorFbo;
-  protected IntBuffer glMultiFbo;
-  protected IntBuffer glColorBuf;
   protected IntBuffer glColorTex;
   protected IntBuffer glDepthStencil;
   protected IntBuffer glDepth;
   protected IntBuffer glStencil;
+
+  protected IntBuffer glMultiFbo;
+  protected IntBuffer glColorBuf;
+
   protected int fboWidth, fboHeight;
   protected int backTex, frontTex;
 
@@ -333,13 +336,14 @@ public abstract class PGL {
   public PGL(PGraphicsOpenGL pg) {
     this.pg = pg;
     if (glColorTex == null) {
-      glColorTex = allocateIntBuffer(2);
       glColorFbo = allocateIntBuffer(1);
-      glMultiFbo = allocateIntBuffer(1);
-      glColorBuf = allocateIntBuffer(1);
+      glColorTex = allocateIntBuffer(2);
       glDepthStencil = allocateIntBuffer(1);
       glDepth = allocateIntBuffer(1);
       glStencil = allocateIntBuffer(1);
+
+      glMultiFbo = allocateIntBuffer(1);
+      glColorBuf = allocateIntBuffer(1);
 
       fboLayerCreated = false;
       fboLayerInUse = false;
@@ -387,13 +391,14 @@ public abstract class PGL {
 
   protected void deleteSurface() {
     if (threadIsCurrent() && fboLayerCreated) {
-      deleteTextures(2, glColorTex);
       deleteFramebuffers(1, glColorFbo);
-      deleteFramebuffers(1, glMultiFbo);
-      deleteRenderbuffers(1, glColorBuf);
+      deleteTextures(2, glColorTex);
       deleteRenderbuffers(1, glDepthStencil);
       deleteRenderbuffers(1, glDepth);
       deleteRenderbuffers(1, glStencil);
+
+      deleteFramebuffers(1, glMultiFbo);
+      deleteRenderbuffers(1, glColorBuf);
     }
 
     fboLayerCreated = false;

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -150,7 +150,7 @@ public abstract class PGL {
   protected IntBuffer glStencil;
 
   protected IntBuffer glMultiFbo;
-  protected IntBuffer glColorBuf;
+  protected IntBuffer glMultiColor;
 
   protected int fboWidth, fboHeight;
   protected int backTex, frontTex;
@@ -343,7 +343,7 @@ public abstract class PGL {
       glStencil = allocateIntBuffer(1);
 
       glMultiFbo = allocateIntBuffer(1);
-      glColorBuf = allocateIntBuffer(1);
+      glMultiColor = allocateIntBuffer(1);
 
       fboLayerCreated = false;
       fboLayerInUse = false;
@@ -398,7 +398,7 @@ public abstract class PGL {
       deleteRenderbuffers(1, glStencil);
 
       deleteFramebuffers(1, glMultiFbo);
-      deleteRenderbuffers(1, glColorBuf);
+      deleteRenderbuffers(1, glMultiColor);
     }
 
     fboLayerCreated = false;
@@ -782,12 +782,12 @@ public abstract class PGL {
       bindFramebufferImpl(FRAMEBUFFER, glMultiFbo.get(0));
 
       // color render buffer...
-      genRenderbuffers(1, glColorBuf);
-      bindRenderbuffer(RENDERBUFFER, glColorBuf.get(0));
+      genRenderbuffers(1, glMultiColor);
+      bindRenderbuffer(RENDERBUFFER, glMultiColor.get(0));
       renderbufferStorageMultisample(RENDERBUFFER, numSamples,
                                      RGBA8, fboWidth, fboHeight);
       framebufferRenderbuffer(FRAMEBUFFER, COLOR_ATTACHMENT0,
-                              RENDERBUFFER, glColorBuf.get(0));
+                              RENDERBUFFER, glMultiColor.get(0));
     }
 
     createDepthAndStencilBuffer(multisample, depthBits, stencilBits, packed);


### PR DESCRIPTION
Adds new hint ENABLE_DEPTH_READING, which will cause multisampled PGraphics to also downsample their depth and stencil buffers (apart from color buffer).