### PR TITLE
Fix delete tab shortcut

### DIFF
--- a/app/src/processing/app/ui/EditorHeader.java
+++ b/app/src/processing/app/ui/EditorHeader.java
@@ -518,7 +518,7 @@ public class EditorHeader extends JComponent {
       }
     };
     mapKey = "editor.header.delete";
-    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.SHORTCUT_ALT_KEY_MASK);
+    keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_D, Toolkit.SHORTCUT_SHIFT_KEY_MASK);
     inputMap.put(keyStroke, mapKey);
     actionMap.put(mapKey, action);
     item.addActionListener(action);


### PR DESCRIPTION
Menu says Ctrl+Shift+D, but the shortcut used Alt.