### PR TITLE
Do not filter Ctrl+Alt+? out as menu mnemonics

### DIFF
--- a/app/src/processing/app/syntax/PdeInputHandler.java
+++ b/app/src/processing/app/syntax/PdeInputHandler.java
@@ -193,6 +193,7 @@ public class PdeInputHandler extends DefaultInputHandler {
     // non-ASCII chars, and there are no menu mnemonics to speak of
     if (!Base.isMacOS()) {
       if ((event.getModifiers() & InputEvent.ALT_MASK) != 0 &&
+          (event.getModifiers() & InputEvent.CTRL_MASK) == 0 &&
           event.getKeyChar() != KeyEvent.VK_UNDEFINED) {
         // This is probably a menu mnemonic, don't pass it through.
         // If it's an alt-NNNN sequence, those only work on the keypad


### PR DESCRIPTION
Some keyboard layouts use third level (Ctrl+Alt+?) to input important characters. They should not be filtered out as menu mnemonics, see #3536 for details.

Fixes #3536