### PR TITLE
Breakpoints don't 'jump' after hitting Enter on blank line

### DIFF
--- a/java/src/processing/mode/java/debug/LineID.java
+++ b/java/src/processing/mode/java/debug/LineID.java
@@ -147,7 +147,9 @@ public class LineID implements DocumentListener {
                 return; // line doesn't exist
             }
             String lineText = doc.getText(line.getStartOffset(), line.getEndOffset() - line.getStartOffset());
-            // set tracking position at (=before) first non-white space character on line
+            // set tracking position at (=before) first non-white space character on line,
+            // or, if the line consists of entirely white spaces, just before the newline
+            // character
             pos = doc.createPosition(line.getStartOffset() + nonWhiteSpaceOffset(lineText));
             this.doc = doc;
             doc.addDocumentListener(this);
@@ -222,7 +224,14 @@ public class LineID implements DocumentListener {
                 return i;
             }
         }
-        return str.length();
+        
+        /* If we've reached here, that implies the line consists of purely white 
+         * space. So return at a position just after the whitespace (i.e., 
+         * just before the newline).
+         * 
+         * The " - 1" part resolves issue #3552
+         */
+        return str.length() - 1;
     }
 
     /**


### PR DESCRIPTION
This PR resolves #3552.

The issue was an off-by-one-error when a line consists purely of white-spaces.