### PR TITLE
Remove fixed-function pipeline

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -1666,44 +1666,77 @@ public abstract class PGL {
   }
 
 
-  protected static String[] convertFragmentSource(String[] fragSrc0,
-                                                  int version0, int version1) {
-    if (version0 == 120 && version1 == 150) {
-      String[] fragSrc = new String[fragSrc0.length + 2];
-      fragSrc[0] = "#version 150";
+  protected static String[] preprocessFragmentSource(String[] fragSrc0,
+                                                     int version) {
+    if (version >= 130) {
+      // We need to replace 'texture' uniform by 'texMap' uniform and
+      // 'textureXXX()' functions by 'texture()' functions. Order of these
+      // replacements is important to prevent collisions between these two.
+      String[] search = new String[] {
+          "varying", "attibute",
+          "texture",
+          "texMap2D", "texMap3D", "texMap2DRect",
+          "texMapCube", "gl_FragColor"
+      };
+      String[] replace = new String[] {
+          "in", "in",
+          "texMap",
+          "texture", "texture", "texture", "texture",
+          "fragColor"
+      };
+
+      String[] fragSrc = preprocessShaderSource(fragSrc0, search, replace, 2);
+      fragSrc[0] = "#version " + version;
       fragSrc[1] = "out vec4 fragColor;";
-      for (int i = 0; i < fragSrc0.length; i++) {
-        String line = fragSrc0[i];
-        line = line.replace("varying", "in");
-        line = line.replace("attribute", "in");
-        line = line.replace("gl_FragColor", "fragColor");
-        line = line.replace("texture", "texMap");
-        line = line.replace("texMap2D(", "texture(");
-        line = line.replace("texMap2DRect(", "texture(");
-        fragSrc[i + 2] = line;
-      }
+
       return fragSrc;
     }
     return fragSrc0;
   }
 
+  protected static String[] preprocessVertexSource(String[] vertSrc0,
+                                                   int version) {
+    if (version >= 130) {
+      // We need to replace 'texture' uniform by 'texMap' uniform and
+      // 'textureXXX()' functions by 'texture()' functions. Order of these
+      // replacements is important to prevent collisions between these two.
+      String[] search = new String[] {
+          "varying", "attibute",
+          "texture",
+          "texMap2D", "texMap3D", "texMap2DRect", "texMapCube"
+      };
+      String[] replace = new String[] {
+          "out", "in",
+          "texMap",
+          "texture", "texture", "texture", "texture"
+      };
 
+      String[] vertSrc = preprocessShaderSource(vertSrc0, search, replace, 1);
+      vertSrc[0] = "#version " + version;
 
-  protected static String[] convertVertexSource(String[] vertSrc0,
-                                                int version0, int version1) {
-    if (version0 == 120 && version1 == 150) {
-      String[] vertSrc = new String[vertSrc0.length + 1];
-      vertSrc[0] = "#version 150";
-      for (int i = 0; i < vertSrc0.length; i++) {
-        String line = vertSrc0[i];
-        line = line.replace("attribute", "in");
-        line = line.replace("varying", "out");
-        vertSrc[i + 1] = line;
-      }
       return vertSrc;
     }
     return vertSrc0;
   }
+
+  protected static String[] preprocessShaderSource(String[] src0,
+                                                   String[] search,
+                                                   String[] replace,
+                                                   int offset) {
+    String[] src = new String[src0.length+offset];
+    for (int i = 0; i < src0.length; i++) {
+      String line = src0[i];
+      if (line.contains("#version")) {
+        line = "";
+      }
+      for (int j = 0; j < search.length; j++) {
+        line = line.replace(search[j], replace[j]);
+      }
+      src[i+offset] = line;
+    }
+    return src;
+  }
+
 
   protected int createShader(int shaderType, String source) {
     int shader = createShader(shaderType);

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -459,18 +459,10 @@ public abstract class PGL {
   }
 
 
-  protected int getDepthBits()  {
-    intBuffer.rewind();
-    getIntegerv(DEPTH_BITS, intBuffer);
-    return intBuffer.get(0);
-  }
+  abstract protected int getDepthBits();
 
 
-  protected int getStencilBits()  {
-    intBuffer.rewind();
-    getIntegerv(STENCIL_BITS, intBuffer);
-    return intBuffer.get(0);
-  }
+  abstract protected int getStencilBits();
 
 
   protected boolean getDepthTest() {

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1174,7 +1174,6 @@ public class PJOGL extends PGL {
 
   @Override
   protected void enableTexturing(int target) {
-    if (profile == 2) enable(target);
     if (target == TEXTURE_2D) {
       texturingTargets[0] = true;
     } else if (target == TEXTURE_RECTANGLE) {
@@ -1185,7 +1184,6 @@ public class PJOGL extends PGL {
 
   @Override
   protected void disableTexturing(int target) {
-    if (profile == 2) disable(target);
     if (target == TEXTURE_2D) {
       texturingTargets[0] = false;
     } else if (target == TEXTURE_RECTANGLE) {

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -500,7 +500,7 @@ public class PJOGL extends PGL {
   protected boolean isFBOBacked() {
     return super.isFBOBacked() || capabilities.isFBO();
   }
-
+*/
 
   @Override
   protected int getDepthBits() {
@@ -512,7 +512,7 @@ public class PJOGL extends PGL {
   protected int getStencilBits() {
     return capabilities.getStencilBits();
   }
-
+/*
 
   @Override
   protected Texture wrapBackTexture(Texture texture) {

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -53,6 +53,7 @@ import com.jogamp.opengl.glu.GLUtessellator;
 import com.jogamp.opengl.glu.GLUtessellatorCallbackAdapter;
 
 import processing.core.PApplet;
+import processing.core.PConstants;
 import processing.core.PGraphics;
 import processing.opengl.PGL;
 import processing.opengl.PGraphicsOpenGL;
@@ -1241,9 +1242,9 @@ public class PJOGL extends PGL {
 
   @Override
   protected String[] loadVertexShader(String filename, int version) {
-    if (2 < profile && version < 150) {
+    if (PApplet.platform == PConstants.MACOSX) {
       String[] fragSrc0 = pg.parent.loadStrings(filename);
-      return convertFragmentSource(fragSrc0, version, 150);
+      return preprocessFragmentSource(fragSrc0, 130);
     } else {
       return pg.parent.loadStrings(filename);
     }
@@ -1252,9 +1253,9 @@ public class PJOGL extends PGL {
 
   @Override
   protected String[] loadFragmentShader(String filename, int version) {
-    if (2 < profile && version < 150) {
+    if (PApplet.platform == PConstants.MACOSX) {
       String[] vertSrc0 = pg.parent.loadStrings(filename);
-      return convertVertexSource(vertSrc0, version, 150);
+      return preprocessVertexSource(vertSrc0, 130);
     } else {
       return pg.parent.loadStrings(filename);
     }
@@ -1264,9 +1265,9 @@ public class PJOGL extends PGL {
   @Override
   protected String[] loadFragmentShader(URL url, int version) {
     try {
-      if (2 < profile && version < 150) {
+      if (PApplet.platform == PConstants.MACOSX) {
         String[] fragSrc0 = PApplet.loadStrings(url.openStream());
-        return convertFragmentSource(fragSrc0, version, 150);
+        return preprocessFragmentSource(fragSrc0, 130);
       } else {
         return PApplet.loadStrings(url.openStream());
       }
@@ -1280,9 +1281,9 @@ public class PJOGL extends PGL {
   @Override
   protected String[] loadVertexShader(URL url, int version) {
     try {
-      if (2 < profile && version < 150) {
+      if (PApplet.platform == PConstants.MACOSX) {
         String[] vertSrc0 = PApplet.loadStrings(url.openStream());
-        return convertVertexSource(vertSrc0, version, 150);
+        return preprocessVertexSource(vertSrc0, 130);
       } else {
         return PApplet.loadStrings(url.openStream());
       }

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -195,15 +195,9 @@ public class PSurfaceJOGL implements PSurface {
     if (profile == null) {
       if (PJOGL.profile == 2) {
         try {
-          if ("arm".equals(System.getProperty("os.arch"))) {
-            // request at least GL2 or GLES2
-            profile = GLProfile.getGL2ES2();
-          } else {
-            // stay compatible with previous versions for now
-            profile = GLProfile.getGL2ES1();
-          }
+          profile = GLProfile.getGL2ES2();
         } catch (GLException ex) {
-          profile = GLProfile.getMaxFixedFunc(true);
+          profile = GLProfile.getMaxProgrammable(true);
         }
       } else if (PJOGL.profile == 3) {
         try {

--- a/core/src/processing/opengl/shaders/LightVert.glsl
+++ b/core/src/processing/opengl/shaders/LightVert.glsl
@@ -47,7 +47,8 @@ varying vec4 backVertColor;
 
 const float zero_float = 0.0;
 const float one_float = 1.0;
-const vec3 zero_vec3 = vec3(0);
+const vec3 zero_vec3 = vec3(0.0);
+const vec3 minus_one_vec3 = vec3(0.0-1.0);
 
 float falloffFactor(vec3 lightPos, vec3 vertPos, vec3 coeff) {
   vec3 lpv = lightPos - vertPos;
@@ -59,7 +60,7 @@ float falloffFactor(vec3 lightPos, vec3 vertPos, vec3 coeff) {
 
 float spotFactor(vec3 lightPos, vec3 vertPos, vec3 lightNorm, float minCos, float spotExp) {
   vec3 lpv = normalize(lightPos - vertPos);
-  vec3 nln = -one_float * lightNorm;
+  vec3 nln = minus_one_vec3 * lightNorm;
   float spotCos = dot(nln, lpv);
   return spotCos <= minCos ? zero_float : pow(spotCos, spotExp);
 }
@@ -83,7 +84,7 @@ void main() {
   
   // Normal vector in eye coordinates
   vec3 ecNormal = normalize(normalMatrix * normal);
-  vec3 ecNormalInv = ecNormal * -one_float;
+  vec3 ecNormalInv = ecNormal * minus_one_vec3;
   
   // Light calculations
   vec3 totalAmbient = vec3(0, 0, 0);
@@ -108,7 +109,7 @@ void main() {
       
     if (isDir) {
       falloff = one_float;
-      lightDir = -one_float * lightNormal[i];
+      lightDir = minus_one_vec3 * lightNormal[i];
     } else {
       falloff = falloffFactor(lightPos, ecVertex, lightFalloff[i]);  
       lightDir = normalize(lightPos - ecVertex);

--- a/core/src/processing/opengl/shaders/TexLightVert.glsl
+++ b/core/src/processing/opengl/shaders/TexLightVert.glsl
@@ -50,7 +50,8 @@ varying vec4 vertTexCoord;
 
 const float zero_float = 0.0;
 const float one_float = 1.0;
-const vec3 zero_vec3 = vec3(0);
+const vec3 zero_vec3 = vec3(0.0);
+const vec3 minus_one_vec3 = vec3(0.0-1.0);
 
 float falloffFactor(vec3 lightPos, vec3 vertPos, vec3 coeff) {
   vec3 lpv = lightPos - vertPos;
@@ -62,7 +63,7 @@ float falloffFactor(vec3 lightPos, vec3 vertPos, vec3 coeff) {
 
 float spotFactor(vec3 lightPos, vec3 vertPos, vec3 lightNorm, float minCos, float spotExp) {
   vec3 lpv = normalize(lightPos - vertPos);
-  vec3 nln = -one_float * lightNorm;
+  vec3 nln = minus_one_vec3 * lightNorm;
   float spotCos = dot(nln, lpv);
   return spotCos <= minCos ? zero_float : pow(spotCos, spotExp);
 }
@@ -86,7 +87,7 @@ void main() {
   
   // Normal vector in eye coordinates
   vec3 ecNormal = normalize(normalMatrix * normal);
-  vec3 ecNormalInv = ecNormal * -one_float;
+  vec3 ecNormalInv = ecNormal * minus_one_vec3;
   
   // Light calculations
   vec3 totalAmbient = vec3(0, 0, 0);
@@ -111,7 +112,7 @@ void main() {
       
     if (isDir) {
       falloff = one_float;
-      lightDir = -one_float * lightNormal[i];
+      lightDir = minus_one_vec3 * lightNormal[i];
     } else {
       falloff = falloffFactor(lightPos, ecVertex, lightFalloff[i]);  
       lightDir = normalize(lightPos - ecVertex);


### PR DESCRIPTION
- Now using at least OpenGL ES 2.0
- Getting depth and stencil bits is now done through capabilities
- Enabling and disabling textures was deprecated with fixed-function pipeline, removing
- Shaders on MACOSX now have to use GLSL 1.30, doing a little bit of preprocessing to get our shaders there
- Minor adjustments to shader code so it does not throw warnings on pedantic Intel cards
