### PR TITLE
OpenGL key event improvements

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -372,6 +372,11 @@ public class PApplet implements PConstants {
   public int pixelHeight;
 
   /**
+   * Keeps track of ENABLE_KEY_AUTO_REPEAT hint
+   */
+  protected boolean isKeyAutoRepeatEnabled = false;
+
+  /**
    * ( begin auto-generated from mouseX.xml )
    *
    * The system variable <b>mouseX</b> always contains the current horizontal
@@ -2911,6 +2916,10 @@ public class PApplet implements PConstants {
 
 
   protected void handleKeyEvent(KeyEvent event) {
+
+    // Get rid of auto-repeating keys if desired and supported
+    if (!isKeyAutoRepeatEnabled && event.isAutoRepeat()) return;
+
     keyEvent = event;
     key = event.getKey();
     keyCode = event.getKeyCode();

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -517,8 +517,8 @@ public interface PConstants {
   static final int ENABLE_BUFFER_READING      =  10;
   static final int DISABLE_BUFFER_READING     = -10;
 
-  static final int DISABLE_KEY_AUTO_REPEAT     =  11;
-  static final int ENABLE_KEY_AUTO_REPEAT    = -11;
+  static final int DISABLE_KEY_AUTO_REPEAT    =  11;
+  static final int ENABLE_KEY_AUTO_REPEAT     = -11;
 
   static final int HINT_COUNT                 =  12;
 }

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -514,8 +514,11 @@ public interface PConstants {
   static final int ENABLE_STROKE_PURE         =  9;
   static final int DISABLE_STROKE_PURE        = -9;
 
-  static final int ENABLE_BUFFER_READING       =  10;
-  static final int DISABLE_BUFFER_READING      = -10;
+  static final int ENABLE_BUFFER_READING      =  10;
+  static final int DISABLE_BUFFER_READING     = -10;
 
-  static final int HINT_COUNT                 =  11;
+  static final int DISABLE_KEY_AUTO_REPEAT     =  11;
+  static final int ENABLE_KEY_AUTO_REPEAT    = -11;
+
+  static final int HINT_COUNT                 =  12;
 }

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1119,6 +1119,11 @@ public class PGraphics extends PImage implements PConstants {
    * hint(DISABLE_DEPTH_READING) if you don't plan to read depth from
    * this PGraphics anymore.
    * <br/> <br/>
+   * hint(ENABLE_KEY_AUTO_REPEAT) - Auto-repeating key events are discarded
+   * by default (works only in P2D/P3D); use this hint to get all the key events
+   * (including auto-repeated). Call hint(DISABLE_KEY_AUTO_REPEAT) to get events
+   * only when the key goes physically up or down.
+   * <br/> <br/>
    * As of release 0149, unhint() has been removed in favor of adding
    * additional ENABLE/DISABLE constants to reset the default behavior. This
    * prevents the double negatives, and also reinforces which hints can be
@@ -1138,6 +1143,11 @@ public class PGraphics extends PImage implements PConstants {
         which == DISABLE_NATIVE_FONTS) {
       showWarning("hint(ENABLE_NATIVE_FONTS) no longer supported. " +
                   "Use createFont() instead.");
+    }
+    if (which == ENABLE_KEY_AUTO_REPEAT) {
+      parent.isKeyAutoRepeatEnabled = true;
+    } else if (which == DISABLE_KEY_AUTO_REPEAT) {
+      parent.isKeyAutoRepeatEnabled = false;
     }
     if (which > 0) {
       hints[which] = true;

--- a/core/src/processing/event/KeyEvent.java
+++ b/core/src/processing/event/KeyEvent.java
@@ -31,6 +31,8 @@ public class KeyEvent extends Event {
   char key;
   int keyCode;
 
+  boolean isAutoRepeat;
+
 
   public KeyEvent(Object nativeObject,
                   long millis, int action, int modifiers,
@@ -41,6 +43,16 @@ public class KeyEvent extends Event {
     this.keyCode = keyCode;
   }
 
+  public KeyEvent(Object nativeObject,
+                  long millis, int action, int modifiers,
+                  char key, int keyCode, boolean isAutoRepeat) {
+    super(nativeObject, millis, action, modifiers);
+    this.flavor = KEY;
+    this.key = key;
+    this.keyCode = keyCode;
+    this.isAutoRepeat = isAutoRepeat;
+  }
+
 
   public char getKey() {
     return key;
@@ -49,5 +61,10 @@ public class KeyEvent extends Event {
 
   public int getKeyCode() {
     return keyCode;
+  }
+
+
+  public boolean isAutoRepeat() {
+    return isAutoRepeat;
   }
 }

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -936,7 +936,7 @@ public class PSurfaceJOGL implements PSurface {
         KeyEvent tke = new KeyEvent(nativeEvent, nativeEvent.getWhen(),
                                     KeyEvent.TYPE, peModifiers,
                                     keyChar,
-                                    keyCode,
+                                    0,
                                     nativeEvent.isAutoRepeat());
 
         sketch.postEvent(tke);

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -927,6 +927,19 @@ public class PSurfaceJOGL implements PSurface {
                                keyCode);
 
     sketch.postEvent(ke);
+
+    if (!isPCodedKey(code) && !isHackyKey(code)) {
+      if (peAction == KeyEvent.PRESS) {
+        // Create key typed event
+        // TODO: combine dead keys with the following key
+        KeyEvent tke = new KeyEvent(nativeEvent, nativeEvent.getWhen(),
+                                    KeyEvent.TYPE, peModifiers,
+                                    keyChar,
+                                    0);
+
+        sketch.postEvent(tke);
+      }
+    }
   }
 
   private static boolean isPCodedKey(short code) {

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -924,7 +924,8 @@ public class PSurfaceJOGL implements PSurface {
     KeyEvent ke = new KeyEvent(nativeEvent, nativeEvent.getWhen(),
                                peAction, peModifiers,
                                keyChar,
-                               keyCode);
+                               keyCode,
+                               nativeEvent.isAutoRepeat());
 
     sketch.postEvent(ke);
 
@@ -935,7 +936,8 @@ public class PSurfaceJOGL implements PSurface {
         KeyEvent tke = new KeyEvent(nativeEvent, nativeEvent.getWhen(),
                                     KeyEvent.TYPE, peModifiers,
                                     keyChar,
-                                    0);
+                                    keyCode,
+                                    nativeEvent.isAutoRepeat());
 
         sketch.postEvent(tke);
       }


### PR DESCRIPTION
P2D and P3D:
- keyTyped events are now generated (dead keys do not combine and fire separate event though)
- key auto-repeat is disabled by default (you can enable it by new ENABLE_KEY_AUTO_REPEAT hint)

Fixes #3582
Related #1622

