### PR TITLE
FX - fix rect size

### DIFF
--- a/core/src/processing/javafx/PGraphicsFX2D.java
+++ b/core/src/processing/javafx/PGraphicsFX2D.java
@@ -658,8 +658,8 @@ public class PGraphicsFX2D extends PGraphics {
   protected void rectImpl(float x1, float y1, float x2, float y2) {
 //    rect.setFrame(x1, y1, x2-x1, y2-y1);
 //    drawShape(rect);
-    if (fill) context.fillRect(x1, y1, x2, y2);
-    if (stroke) context.strokeRect(x1, y1, x2, y2);
+    if (fill) context.fillRect(x1, y1, x2 - x1, y2 - y1);
+    if (stroke) context.strokeRect(x1, y1, x2 - x1, y2 - y1);
   }
 
 


### PR DESCRIPTION
Rect was using coordinates of it's second corner as its width/height