### PR TITLE
Fix ARM JDK download for 8u60

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -36,7 +36,7 @@
   <target name="check-linux-arm32" if="linux-arm32">
     <!-- there is currently no JRE available -->
     <property name="jre.download.jdk" value="true" />
-    <property name="jre.downloader" value="linux-arm-vfp-hflt.tar.gz" />
+    <property name="jre.downloader" value="linux-arm32-vfp-hflt.tar.gz" />
     <property name="linux.dist" value="linux/processing-${version}-linux-armv6hf.tgz" />
   </target>
 


### PR DESCRIPTION
ARM started offering builds for 64 bit ARM (ARMv8), which made them rename the download file.