### PR TITLE
Remove legacy GL functions from PGL

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2663,7 +2663,6 @@ public abstract class PGL {
   public static int STENCIL_TEST;
   public static int DEPTH_TEST;
   public static int DEPTH_WRITEMASK;
-  public static int ALPHA_TEST;
 
   public static int COLOR_BUFFER_BIT;
   public static int DEPTH_BUFFER_BIT;
@@ -2719,7 +2718,6 @@ public abstract class PGL {
   public static int RENDERBUFFER_INTERNAL_FORMAT;
 
   public static int MULTISAMPLE;
-  public static int POINT_SMOOTH;
   public static int LINE_SMOOTH;
   public static int POLYGON_SMOOTH;
 
@@ -2811,12 +2809,10 @@ public abstract class PGL {
   public abstract void vertexAttrib3fv(int index, FloatBuffer values);
   public abstract void vertexAttri4fv(int index, FloatBuffer values);
   public abstract void vertexAttribPointer(int index, int size, int type, boolean normalized, int stride, int offset);
-  public abstract void vertexAttribPointer(int index, int size, int type, boolean normalized, int stride, Buffer data);
   public abstract void enableVertexAttribArray(int index);
   public abstract void disableVertexAttribArray(int index);
   public abstract void drawArrays(int mode, int first, int count);
   public abstract void drawElements(int mode, int count, int type, int offset);
-  public abstract void drawElements(int mode, int count, int type, Buffer indices);
 
   //////////////////////////////////////////////////////////////////////////////
 
@@ -2956,7 +2952,6 @@ public abstract class PGL {
   public abstract void blendFunc(int src, int dst);
   public abstract void blendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha);
   public abstract void blendColor(float red, float green, float blue, float alpha);
-  public abstract void alphaFunc(int func, float ref);
 
   ///////////////////////////////////////////////////////////
 

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2807,7 +2807,7 @@ public abstract class PGL {
   public abstract void vertexAttrib1fv(int index, FloatBuffer values);
   public abstract void vertexAttrib2fv(int index, FloatBuffer values);
   public abstract void vertexAttrib3fv(int index, FloatBuffer values);
-  public abstract void vertexAttri4fv(int index, FloatBuffer values);
+  public abstract void vertexAttrib4fv(int index, FloatBuffer values);
   public abstract void vertexAttribPointer(int index, int size, int type, boolean normalized, int stride, int offset);
   public abstract void enableVertexAttribArray(int index);
   public abstract void disableVertexAttribArray(int index);

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1956,7 +1956,7 @@ public class PJOGL extends PGL {
   }
 
   @Override
-  public void vertexAttri4fv(int index, FloatBuffer values) {
+  public void vertexAttrib4fv(int index, FloatBuffer values) {
     gl2.glVertexAttrib4fv(index, values);
   }
 

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -40,7 +40,6 @@ import java.nio.IntBuffer;
 import com.jogamp.common.util.VersionNumber;
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2;
-import com.jogamp.opengl.GL2ES1;
 import com.jogamp.opengl.GL2ES2;
 import com.jogamp.opengl.GL2ES3;
 import com.jogamp.opengl.GL2GL3;
@@ -55,8 +54,6 @@ import com.jogamp.opengl.glu.GLUtessellatorCallbackAdapter;
 
 import processing.core.PApplet;
 import processing.core.PGraphics;
-import processing.opengl.PGL;
-import processing.opengl.PGraphicsOpenGL;
 
 
 public class PJOGL extends PGL {
@@ -1676,7 +1673,6 @@ public class PJOGL extends PGL {
     STENCIL_TEST    = GL.GL_STENCIL_TEST;
     DEPTH_TEST      = GL.GL_DEPTH_TEST;
     DEPTH_WRITEMASK = GL.GL_DEPTH_WRITEMASK;
-    ALPHA_TEST      = GL2ES1.GL_ALPHA_TEST;
 
     COLOR_BUFFER_BIT   = GL.GL_COLOR_BUFFER_BIT;
     DEPTH_BUFFER_BIT   = GL.GL_DEPTH_BUFFER_BIT;
@@ -1733,7 +1729,6 @@ public class PJOGL extends PGL {
     RENDERBUFFER_INTERNAL_FORMAT = GL.GL_RENDERBUFFER_INTERNAL_FORMAT;
 
     MULTISAMPLE    = GL.GL_MULTISAMPLE;
-    POINT_SMOOTH   = GL2ES1.GL_POINT_SMOOTH;
     LINE_SMOOTH    = GL.GL_LINE_SMOOTH;
     POLYGON_SMOOTH = GL2GL3.GL_POLYGON_SMOOTH;
   }
@@ -1971,15 +1966,6 @@ public class PJOGL extends PGL {
   }
 
   @Override
-  public void vertexAttribPointer(int index, int size, int type, boolean normalized, int stride, Buffer data) {
-    if (gl2x != null) {
-      gl2x.glVertexAttribPointer(index, size, type, normalized, stride, data);
-    } else {
-      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glVertexAttribPointer()"));
-    }
-  }
-
-  @Override
   public void enableVertexAttribArray(int index) {
     gl2.glEnableVertexAttribArray(index);
   }
@@ -1997,15 +1983,6 @@ public class PJOGL extends PGL {
   @Override
   public void drawElements(int mode, int count, int type, int offset) {
     gl.glDrawElements(mode, count, type, offset);
-  }
-
-  @Override
-  public void drawElements(int mode, int count, int type, Buffer indices) {
-    if (gl2x != null) {
-      gl2x.glDrawElements(mode, count, type, indices);
-    } else {
-      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glDrawElements()"));
-    }
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -2489,15 +2466,6 @@ public class PJOGL extends PGL {
   @Override
   public void blendColor(float red, float green, float blue, float alpha) {
     gl2.glBlendColor(red, green, blue, alpha);
-  }
-
-  @Override
-  public void alphaFunc(int func, float ref) {
-    if (gl2x != null) {
-      gl2x.glAlphaFunc(func, ref);
-    } else {
-      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glAlphaFunc()"));
-    }
   }
 
   ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Remove legacy functions and constants which are available only in GL2, because we are not getting GL2 compatible implementations anymore. Users who want to use these functions can still get the GL2 interface from PGL, but it's going to be null most of the time.

Yeah, and since we are breaking things, I corrected a typo in a function name.

Fixes #3674