### PR TITLE
Make auto-format into a compund edit

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2207,6 +2207,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       if (formattedText.equals(source)) {
         statusNotice(Language.text("editor.status.autoformat.no_changes"));
       } else {
+        startCompoundEdit();
         // replace with new bootiful text
         // selectionEnd hopefully at least in the neighborhood
         int scrollPos = textarea.getVerticalScrollPosition();
@@ -2227,6 +2228,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
           textarea.setVerticalScrollPosition(scrollPos);
 //          }
         }
+        stopCompoundEdit();
         getSketch().setModified(true);
         // mark as finished
         statusNotice(Language.text("editor.status.autoformat.finished"));


### PR DESCRIPTION
Undoing an auto-format now happens in one step, instead of having to undo (to clear the current sketch) and undo again (to get back the pre-formatted text).

This PR fixes (or at the very least, fixes one of several possible causes of) #3003.