### PR TITLE
ScrollPane gets the focus by default

### DIFF
--- a/app/src/processing/app/contrib/ContributionManagerDialog.java
+++ b/app/src/processing/app/contrib/ContributionManagerDialog.java
@@ -194,6 +194,7 @@ public class ContributionManagerDialog {
           updateTabPanel.setBackground(new Color(0xe0fffd));
           updateTabLabel.setForeground(Color.BLACK);
         }
+        getActiveTab().contributionListPanel.scrollPane.requestFocusInWindow();
 //        // When the tab is changed update status to the current selected panel
 //        ContributionPanel currentPanel = getActiveTab().contributionListPanel
 //          .getSelectedPanel();

--- a/app/src/processing/app/contrib/UpdateContributionTab.java
+++ b/app/src/processing/app/contrib/UpdateContributionTab.java
@@ -146,7 +146,7 @@ public class UpdateContributionTab extends ContributionTab {
 //          return super.isRowSelected(row);
 //        }
       };
-      JScrollPane scrollPane = new JScrollPane(table);
+      scrollPane = new JScrollPane(table);
       table.setFillsViewportHeight(true);
       table.setSelectionBackground(new Color(0xe0fffd));
       table.setSelectionForeground(table.getForeground());


### PR DESCRIPTION
Fix for #3689 
@alignedleft @benfry 
The scrollPane gets the focus by default. You can see the effect this is causing by opening the CM, then switching to Libraries tab, then pressing the `Down Arrow` key.  
Should scrollPane be the item getting the default focus in a tab ?