### PR TITLE
Render text starting with space properly

### DIFF
--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -4708,7 +4708,11 @@ public class PGraphics extends PImage implements PConstants {
       // boundary of a word or end of this sentence
       if ((buffer[index] == ' ') || (index == stop)) {
 //        System.out.println((index == stop) + " " + wordStart + " " + index);
-        float wordWidth = textWidthImpl(buffer, wordStart, index);
+        float wordWidth = 0;
+        if (index > wordStart) {
+          // we have a non-empty word, measure it
+          wordWidth = textWidthImpl(buffer, wordStart, index);
+        }
 
         if (runningX + wordWidth >= boxWidth) {
           if (runningX != 0) {

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -4708,9 +4708,6 @@ public class PGraphics extends PImage implements PConstants {
       // boundary of a word or end of this sentence
       if ((buffer[index] == ' ') || (index == stop)) {
 //        System.out.println((index == stop) + " " + wordStart + " " + index);
-        if (start != stop && wordStart == index) {  // end of line, nothing is fitting
-          return false;
-        }
         float wordWidth = textWidthImpl(buffer, wordStart, index);
 
         if (runningX + wordWidth >= boxWidth) {


### PR DESCRIPTION
This block seems to be out of place. It is entered when the current word
has zero length. It's not possible to tell whether the string fits on
the line or not at this place. Besides, the same condition is already
handled below.