### PR TITLE
Async saveFrame

### DIFF
--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -520,5 +520,8 @@ public interface PConstants {
   static final int DISABLE_KEY_REPEAT         =  11;
   static final int ENABLE_KEY_REPEAT          = -11;
 
-  static final int HINT_COUNT                 =  12;
+  static final int DISABLE_ASYNC_SAVEFRAME    =  12;
+  static final int ENABLE_ASYNC_SAVEFRAME     = -12;
+
+  static final int HINT_COUNT                 =  13;
 }

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -36,6 +36,12 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.WeakHashMap;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import processing.opengl.PGL;
 import processing.opengl.PShader;
@@ -796,6 +802,10 @@ public class PGraphics extends PImage implements PConstants {
    * endRaw(), in order to shut things off.
    */
   public void dispose() {  // ignore
+    if (primaryGraphics && asyncImageSaver != null) {
+      asyncImageSaver.dispose();
+      asyncImageSaver = null;
+    }
   }
 
 
@@ -8231,4 +8241,158 @@ public class PGraphics extends PImage implements PConstants {
   public boolean is2X() {
     return pixelDensity == 2;
   }
+
+
+  //////////////////////////////////////////////////////////////
+
+  // ASYNC IMAGE SAVING
+
+
+  @Override
+  public boolean save(String filename) {
+
+    if (hints[DISABLE_ASYNC_SAVEFRAME]) {
+      return super.save(filename);
+    }
+
+    if (asyncImageSaver == null) {
+      asyncImageSaver = new AsyncImageSaver();
+    }
+
+    if (!loaded) loadPixels();
+    PImage target = asyncImageSaver.getAvailableTarget(pixelWidth, pixelHeight,
+                                                       format);
+    if (target == null) return false;
+    int count = PApplet.min(pixels.length, target.pixels.length);
+    System.arraycopy(pixels, 0, target.pixels, 0, count);
+    asyncImageSaver.saveTargetAsync(this, target, filename);
+
+    return true;
+  }
+
+  protected void processImageBeforeAsyncSave(PImage image) { }
+
+
+  protected static AsyncImageSaver asyncImageSaver;
+
+  protected static class AsyncImageSaver {
+
+    static final int TARGET_COUNT =
+        Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+
+    BlockingQueue<PImage> targetPool = new ArrayBlockingQueue<>(TARGET_COUNT);
+    ExecutorService saveExecutor = Executors.newFixedThreadPool(TARGET_COUNT);
+
+    int targetsCreated = 0;
+
+
+    static final int TIME_AVG_FACTOR = 32;
+
+    volatile long avgNanos = 0;
+    long lastTime = 0;
+    int lastFrameCount = 0;
+
+
+    public AsyncImageSaver() { }
+
+
+    public void dispose() {
+      saveExecutor.shutdown();
+      try {
+        saveExecutor.awaitTermination(5000, TimeUnit.SECONDS);
+      } catch (InterruptedException e) { }
+    }
+
+
+    public boolean hasAvailableTarget() {
+      return targetsCreated < TARGET_COUNT || targetPool.isEmpty();
+    }
+
+
+    /**
+     * After taking a target, you must call saveTargetAsync() or
+     * returnUnusedTarget(), otherwise one thread won't be able to run
+     */
+    public PImage getAvailableTarget(int requestedWidth, int requestedHeight,
+                                     int format) {
+      try {
+        PImage target;
+        if (targetsCreated < TARGET_COUNT && targetPool.isEmpty()) {
+          target = new PImage(requestedWidth, requestedHeight);
+          targetsCreated++;
+        } else {
+          target = targetPool.take();
+          if (target.width != requestedWidth ||
+              target.height != requestedHeight) {
+            target.width = requestedWidth;
+            target.height = requestedHeight;
+            // TODO: this kills performance when saving different sizes
+            target.pixels = new int[requestedWidth * requestedHeight];
+          }
+        }
+        target.format = format;
+        return target;
+      } catch (InterruptedException e) {
+        return null;
+      }
+    }
+
+
+    public void returnUnusedTarget(PImage target) {
+      targetPool.offer(target);
+    }
+
+
+    public void saveTargetAsync(final PGraphics renderer, final PImage target,
+                                final String filename) {
+      target.parent = renderer.parent;
+
+      // if running every frame, smooth the framerate
+      if (target.parent.frameCount - 1 == lastFrameCount && TARGET_COUNT > 1) {
+
+        // count with one less thread to reduce jitter
+        // 2 cores - 1 save thread - no wait
+        // 4 cores - 3 save threads - wait 1/2 of save time
+        // 8 cores - 7 save threads - wait 1/6 of save time
+        long avgTimePerFrame = avgNanos / (Math.max(1, TARGET_COUNT - 1));
+        long now = System.nanoTime();
+        long delay = PApplet.round((lastTime + avgTimePerFrame - now) / 1e6f);
+        try {
+          if (delay > 0) Thread.sleep(delay);
+        } catch (InterruptedException e) { }
+      }
+
+      lastFrameCount = target.parent.frameCount;
+      lastTime = System.nanoTime();
+
+      try {
+        saveExecutor.submit(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              long startTime = System.nanoTime();
+              renderer.processImageBeforeAsyncSave(target);
+              target.save(filename);
+              long saveNanos = System.nanoTime() - startTime;
+              synchronized (AsyncImageSaver.this) {
+                if (avgNanos == 0) {
+                  avgNanos = saveNanos;
+                } else if (saveNanos < avgNanos) {
+                  avgNanos = (avgNanos * (TIME_AVG_FACTOR - 1) + saveNanos) /
+                      (TIME_AVG_FACTOR);
+                } else {
+                  avgNanos = saveNanos;
+                }
+              }
+            } finally {
+              targetPool.offer(target);
+            }
+          }
+        });
+      } catch (RejectedExecutionException e) {
+        // the executor service was probably shut down, no more saving for us
+      }
+    }
+  }
+
 }

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1112,18 +1112,18 @@ public class PGraphics extends PImage implements PConstants {
    * hint(DISABLE_OPENGL_ERROR_REPORT) - Speeds up the P3D renderer setting
    * by not checking for errors while running. Undo with hint(ENABLE_OPENGL_ERROR_REPORT).
    * <br/> <br/>
-   * hint(ENABLE_DEPTH_READING) - Depth and stencil buffers in P2D/P3D will be
+   * hint(ENABLE_BUFFER_READING) - Depth and stencil buffers in P2D/P3D will be
    * downsampled to make PGL#readPixels work with multisampling. Enabling this
    * introduces some overhead, so if you experience bad performance, disable
    * multisampling with noSmooth() instead. This hint is not intended to be
    * enabled and disabled repeatedely, so call this once in setup() or after
    * creating your PGraphics2D/3D. You can restore the default with
-   * hint(DISABLE_DEPTH_READING) if you don't plan to read depth from
+   * hint(DISABLE_BUFFER_READING) if you don't plan to read depth from
    * this PGraphics anymore.
    * <br/> <br/>
-   * hint(ENABLE_KEY_AUTO_REPEAT) - Auto-repeating key events are discarded
+   * hint(ENABLE_KEY_REPEAT) - Auto-repeating key events are discarded
    * by default (works only in P2D/P3D); use this hint to get all the key events
-   * (including auto-repeated). Call hint(DISABLE_KEY_AUTO_REPEAT) to get events
+   * (including auto-repeated). Call hint(DISABLE_KEY_REPEAT) to get events
    * only when the key goes physically up or down.
    * <br/> <br/>
    * As of release 0149, unhint() has been removed in favor of adding

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -1126,6 +1126,11 @@ public class PGraphics extends PImage implements PConstants {
    * (including auto-repeated). Call hint(DISABLE_KEY_REPEAT) to get events
    * only when the key goes physically up or down.
    * <br/> <br/>
+   * hint(DISABLE_ASYNC_SAVEFRAME) - P2D/P3D only - save() and saveFrame()
+   * will not use separate threads for saving and will block until the image
+   * is written to the drive. This was the default behavior in 3.0b7 and before.
+   * To enable, call hint(ENABLE_ASYNC_SAVEFRAME).
+   * <br/> <br/>
    * As of release 0149, unhint() has been removed in favor of adding
    * additional ENABLE/DISABLE constants to reset the default behavior. This
    * prevents the double negatives, and also reinforces which hints can be

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2117,6 +2117,24 @@ public abstract class PGL {
   }
 
 
+  protected boolean hasSynchronization() {
+    int[] version = getGLVersion();
+    if (isES()) {
+      return version[0] >= 3;
+    }
+    return (version[0] > 3) || (version[0] == 3 && version[1] >= 2);
+  }
+
+
+  protected boolean hasPBOs() {
+    int[] version = getGLVersion();
+    if (isES()) {
+      return version[0] >= 3;
+    }
+    return (version[0] > 2) || (version[0] == 2 && version[1] >= 1);
+  }
+
+
   protected int maxSamples() {
     intBuffer.rewind();
     getIntegerv(MAX_SAMPLES, intBuffer);

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2666,12 +2666,14 @@ public abstract class PGL {
 
   public static int ARRAY_BUFFER;
   public static int ELEMENT_ARRAY_BUFFER;
+  public static int PIXEL_PACK_BUFFER;
 
   public static int MAX_VERTEX_ATTRIBS;
 
   public static int STATIC_DRAW;
   public static int DYNAMIC_DRAW;
   public static int STREAM_DRAW;
+  public static int STREAM_READ;
 
   public static int BUFFER_SIZE;
   public static int BUFFER_USAGE;
@@ -2886,6 +2888,10 @@ public abstract class PGL {
   public static int LINE_SMOOTH;
   public static int POLYGON_SMOOTH;
 
+  public static int SYNC_GPU_COMMANDS_COMPLETE;
+  public static int ALREADY_SIGNALED;
+  public static int CONDITION_SATISFIED;
+
   ///////////////////////////////////////////////////////////
 
   // Special Functions
@@ -2930,6 +2936,14 @@ public abstract class PGL {
 
   //////////////////////////////////////////////////////////////////////////////
 
+  // Synchronization
+
+  public abstract long fenceSync(int condition, int flags);
+  public abstract void deleteSync(long sync);
+  public abstract int clientWaitSync(long sync, int flags, long timeout);
+
+  //////////////////////////////////////////////////////////////////////////////
+
   // Viewport and Clipping
 
   public abstract void depthRangef(float n, float f);
@@ -2959,7 +2973,23 @@ public abstract class PGL {
     graphics.endReadPixels();
   }
 
+  public void readPixels(int x, int y, int width, int height, int format, int type, long offset){
+    boolean multisampled = isMultisampled() || graphics.offscreenMultisample;
+    boolean depthReadingEnabled = graphics.getHint(PConstants.ENABLE_BUFFER_READING);
+    boolean depthRequested = format == STENCIL_INDEX || format == DEPTH_COMPONENT || format == DEPTH_STENCIL;
+
+    if (multisampled && depthRequested && !depthReadingEnabled) {
+      PGraphics.showWarning(DEPTH_READING_NOT_ENABLED_ERROR);
+      return;
+    }
+
+    graphics.beginReadPixels();
+    readPixelsImpl(x, y, width, height, format, type, offset);
+    graphics.endReadPixels();
+  }
+
   protected abstract void readPixelsImpl(int x, int y, int width, int height, int format, int type, Buffer buffer);
+  protected abstract void readPixelsImpl(int x, int y, int width, int height, int format, int type, long offset);
 
   //////////////////////////////////////////////////////////////////////////////
 

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -1992,9 +1992,19 @@ public abstract class PGL {
     return false;
   }
 
+  protected boolean isES() {
+    return getString(VERSION).trim().toLowerCase().contains("opengl es");
+  }
 
   protected int[] getGLVersion() {
-    String version = getString(VERSION).trim();
+    String version = getString(VERSION).trim().toLowerCase();
+
+    String ES = "opengl es";
+    int esPosition = version.indexOf(ES);
+    if (esPosition >= 0) {
+      version = version.substring(esPosition + ES.length()).trim();
+    }
+
     int[] res = {0, 0, 0};
     String[] parts = version.split(" ");
     for (int i = 0; i < parts.length; i++) {

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -5768,7 +5768,7 @@ public class PGraphicsOpenGL extends PGraphics {
       }
 
       pgl.bindBuffer(PGL.PIXEL_PACK_BUFFER, pbos[head]);
-      pgl.readPixels(0, 0, width, height, PGL.RGBA, PGL.UNSIGNED_BYTE, 0);
+      pgl.readPixels(0, 0, pixelWidth, pixelHeight, PGL.RGBA, PGL.UNSIGNED_BYTE, 0);
       pgl.bindBuffer(PGL.PIXEL_PACK_BUFFER, 0);
 
       fences[head] = pgl.fenceSync(PGL.SYNC_GPU_COMMANDS_COMPLETE, 0);

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -673,7 +673,7 @@ public class PGraphicsOpenGL extends PGraphics {
   @Override
   // Java only
   public PSurface createSurface() {  // ignore
-    return new PSurfaceJOGL(this);
+    return surface = new PSurfaceJOGL(this);
   }
 
 

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -44,6 +44,7 @@ import com.jogamp.opengl.GL2;
 import com.jogamp.opengl.GL2ES2;
 import com.jogamp.opengl.GL2ES3;
 import com.jogamp.opengl.GL2GL3;
+import com.jogamp.opengl.GL3ES3;
 import com.jogamp.opengl.GLAutoDrawable;
 import com.jogamp.opengl.GLCapabilities;
 import com.jogamp.opengl.GLCapabilitiesImmutable;
@@ -108,6 +109,9 @@ public class PJOGL extends PGL {
   /** GL2 desktop functionality (blit framebuffer, map buffer range,
    * multisampled renderbuffers) */
   protected GL2 gl2x;
+
+  /** GL3ES3 interface */
+  protected GL3ES3 gl3es3;
 
   /** Stores exceptions that ocurred during drawing */
   protected Exception drawException;
@@ -233,6 +237,7 @@ public class PJOGL extends PGL {
     this.gl2 = pjogl.gl2;
     this.gl2x = pjogl.gl2x;
     this.gl3 = pjogl.gl3;
+    this.gl3es3 = pjogl.gl3es3;
   }
 
 
@@ -252,6 +257,11 @@ public class PJOGL extends PGL {
       gl3 = gl.getGL2GL3();
     } catch (com.jogamp.opengl.GLException e) {
       gl3 = null;
+    }
+    try {
+      gl3es3 = gl.getGL3ES3();
+    } catch (com.jogamp.opengl.GLException e) {
+      gl3es3 = null;
     }
   }
 
@@ -736,12 +746,14 @@ public class PJOGL extends PGL {
 
     ARRAY_BUFFER         = GL.GL_ARRAY_BUFFER;
     ELEMENT_ARRAY_BUFFER = GL.GL_ELEMENT_ARRAY_BUFFER;
+    PIXEL_PACK_BUFFER    = GL3ES3.GL_PIXEL_PACK_BUFFER;
 
     MAX_VERTEX_ATTRIBS  = GL2ES2.GL_MAX_VERTEX_ATTRIBS;
 
     STATIC_DRAW  = GL.GL_STATIC_DRAW;
     DYNAMIC_DRAW = GL.GL_DYNAMIC_DRAW;
     STREAM_DRAW  = GL2ES2.GL_STREAM_DRAW;
+    STREAM_READ  = GL3ES3.GL_STREAM_READ;
 
     BUFFER_SIZE  = GL.GL_BUFFER_SIZE;
     BUFFER_USAGE = GL.GL_BUFFER_USAGE;
@@ -956,6 +968,10 @@ public class PJOGL extends PGL {
     MULTISAMPLE    = GL.GL_MULTISAMPLE;
     LINE_SMOOTH    = GL.GL_LINE_SMOOTH;
     POLYGON_SMOOTH = GL2GL3.GL_POLYGON_SMOOTH;
+
+    SYNC_GPU_COMMANDS_COMPLETE = GL3ES3.GL_SYNC_GPU_COMMANDS_COMPLETE;
+    ALREADY_SIGNALED           = GL3ES3.GL_ALREADY_SIGNALED;
+    CONDITION_SATISFIED        = GL3ES3.GL_CONDITION_SATISFIED;
   }
 
   ///////////////////////////////////////////////////////////
@@ -1114,6 +1130,37 @@ public class PJOGL extends PGL {
 
   //////////////////////////////////////////////////////////////////////////////
 
+  // Synchronization
+
+  @Override
+  public long fenceSync(int condition, int flags) {
+    if (gl3es3 != null) {
+      return gl3es3.glFenceSync(condition, flags);
+    } else {
+      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "fenceSync()"));
+    }
+  }
+
+  @Override
+  public void deleteSync(long sync) {
+    if (gl3es3 != null) {
+      gl3es3.glDeleteSync(sync);
+    } else {
+      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "deleteSync()"));
+    }
+  }
+
+  @Override
+  public int clientWaitSync(long sync, int flags, long timeout) {
+    if (gl3es3 != null) {
+      return gl3es3.glClientWaitSync(sync, flags, timeout);
+    } else {
+      throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "clientWaitSync()"));
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+
   // Viewport and Clipping
 
   @Override
@@ -1139,6 +1186,11 @@ public class PJOGL extends PGL {
   @Override
   protected void readPixelsImpl(int x, int y, int width, int height, int format, int type, Buffer buffer) {
     gl.glReadPixels(x, y, width, height, format, type, buffer);
+  }
+
+  @Override
+  protected void readPixelsImpl(int x, int y, int width, int height, int format, int type, long offset) {
+    gl.glReadPixels(x, y, width, height, format, type, 0);
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -406,7 +406,7 @@ public class PSurfaceJOGL implements PSurface {
 
 
   protected void initAnimator() {
-    animator = new FPSAnimator(window, 60);
+    animator = new FPSAnimator(window, 60, true);
     drawException = null;
     animator.setUncaughtExceptionHandler(new GLAnimatorControl.UncaughtExceptionHandler() {
       @Override

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -69,8 +69,6 @@ import processing.core.PImage;
 import processing.core.PSurface;
 import processing.event.KeyEvent;
 import processing.event.MouseEvent;
-import processing.opengl.PGraphicsOpenGL;
-import processing.opengl.PGL;
 
 
 public class PSurfaceJOGL implements PSurface {
@@ -762,7 +760,11 @@ public class PSurfaceJOGL implements PSurface {
         pgl.endRender(sketch.sketchWindowColor());
       }
 
+      PGraphicsOpenGL.completeFinishedPixelTransfers();
+
       if (sketch.exitCalled()) {
+        PGraphicsOpenGL.completeAllPixelTransfers();
+
         sketch.dispose(); // calls stopThread(), which stops the animator.
         sketch.exitActual();
       }


### PR DESCRIPTION
- Asnychronous image saving for all renderers
- Asynchronous pixel download for OpenGL renderers
- both enabled by default, use DISABLE_ASYNC_SAVEFRAME and ENABLE_ASYNC_SAVEFRAME hints
- small OpenGL fixes

fixes #3569