### PR TITLE
Small usability fixes for tiny screens

### DIFF
--- a/app/src/processing/app/ui/EditorState.java
+++ b/app/src/processing/app/ui/EditorState.java
@@ -161,6 +161,10 @@ public class EditorState {
     int defaultWidth = Preferences.getInteger("editor.window.width.default");
     int defaultHeight = Preferences.getInteger("editor.window.height.default");
 
+    // go even smaller for tiny screens
+    defaultWidth = Math.min(defaultWidth, deviceBounds.width);
+    defaultHeight = Math.min(defaultHeight, deviceBounds.height);
+
     if (editors.size() == 0) {
       // If no current active editor, use default placement.
       // Center the window on ths screen, taking into account that the

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -101,6 +101,8 @@ editor.window.height.min = 500
 editor.window.height.min.macosx = 450
 # tested to be 515 on Windows XP, this leaves some room
 editor.window.height.min.windows = 530
+# tested with Raspberry Pi display
+editor.window.height.min.linux = 480
 
 # font size for editor
 #editor.font = Monospaced,plain,12

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -886,8 +886,8 @@ public class PSurfaceAWT extends PSurfaceNone {
           // if it fits inside the editor window,
           // offset slightly from upper lefthand corner
           // so that it's plunked inside the text area
-          locationX = editorLocation[0] + 66;
-          locationY = editorLocation[1] + 66;
+          locationX = editorLocation[0] + 100;
+          locationY = editorLocation[1] + 100;
 
           if ((locationX + window.width > sketch.displayWidth - 33) ||
             (locationY + window.height > sketch.displayHeight - 33)) {

--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -465,8 +465,8 @@ public class PSurfaceFX implements PSurface {
         // if it fits inside the editor window,
         // offset slightly from upper lefthand corner
         // so that it's plunked inside the text area
-        locationX = editorLocation[0] + 66;
-        locationY = editorLocation[1] + 66;
+        locationX = editorLocation[0] + 100;
+        locationY = editorLocation[1] + 100;
 
         if ((locationX + stage.getWidth() > sketch.displayWidth - 33) ||
             (locationY + stage.getHeight() > sketch.displayHeight - 33)) {

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -543,8 +543,8 @@ public class PSurfaceJOGL implements PSurface {
         // if it fits inside the editor window,
         // offset slightly from upper lefthand corner
         // so that it's plunked inside the text area
-        locationX = editorLocation[0] + 66;
-        locationY = editorLocation[1] + 66;
+        locationX = editorLocation[0] + 100;
+        locationY = editorLocation[1] + 100;
 
         if ((locationX + w > sketch.displayWidth - 33) ||
             (locationY + h > sketch.displayHeight - 33)) {


### PR DESCRIPTION
We could also resize the editor proportionally to fit inside the screen. Not sure if it's worth it though, since that means even less real estate..

Attaching before and after screenshot of the change regarding the display window position - please let me know if you have any other ideas for the exact coordinates.

![2015-10-13-120841_800x480_scrot](https://cloud.githubusercontent.com/assets/4945451/10454556/a63e54e0-71b5-11e5-8b25-e121fca245e1.png)
![2015-10-13-121248_800x480_scrot](https://cloud.githubusercontent.com/assets/4945451/10454559/ab077326-71b5-11e5-8083-10b3b7c0b618.png)
