### PR TITLE
processing-java: Run in headless mode with --build

### DIFF
--- a/app/src/processing/app/tools/InstallCommander.java
+++ b/app/src/processing/app/tools/InstallCommander.java
@@ -86,6 +86,16 @@ public class InstallCommander implements Tool {
       PrintWriter writer = PApplet.createWriter(file);
       writer.println("#!/bin/sh");
 
+
+      writer.print("\n# We don't want to steal focus for headless runs. See issue #3996.\n" +
+                   "OPTION_FOR_HEADLESS_RUN=\"\"\n" +
+                   "for ARG in \"$@\"\n" +
+                   "do\n" +
+                   "    if [ $ARG = \"--build\" ]; then\n" +
+                   "        OPTION_FOR_HEADLESS_RUN=\"-Djava.awt.headless=true\"\n" +
+                   "    fi\n" +
+                   "done\n\n");
+
       String javaRoot = Platform.getContentFile(".").getCanonicalPath();
 
       StringList jarList = new StringList();
@@ -97,6 +107,7 @@ public class InstallCommander implements Tool {
       writer.println("cd \"" + javaRoot + "\" && " +
                      Platform.getJavaPath() +
                      " -Djna.nosys=true" +
+                     " $OPTION_FOR_HEADLESS_RUN" +
       		           " -cp \"" + classPath + "\"" +
       		           " processing.mode.java.Commander \"$@\"");
       writer.flush();


### PR DESCRIPTION
Fixes #3996 

Tested both running with and without `--build`. The fix works as expected. Running processing-java with the `--build`-option doesn't steal focus anymore.

This change makes the /usr/local/bin/processing-java shell script look like this for me:

```
#!/bin/sh

# We don't want to steal focus for headless runs. See issue #3996.
OPTION_FOR_HEADLESS_RUN=""
for ARG in "$@"
do
    if [ $ARG = "--build" ]; then
        OPTION_FOR_HEADLESS_RUN="-Djava.awt.headless=true"
    fi
done

cd "/Users/martin/git/processing/build/macosx/work/Processing.app/Contents/Java" && /Users/martin/git/processing/build/macosx/work/Processing.app/Contents/PlugIns/jdk1.8.0_51.jdk/Contents/Home/jre/bin/java -Djna.nosys=true $OPTION_FOR_HEADLESS_RUN -cp "ant-launcher.jar:ant.jar:core.jar:jna.jar:pde.jar:core/library/core.jar:core/library/gluegen-rt-natives-linux-amd64.jar:core/library/gluegen-rt-natives-linux-armv6hf.jar:core/library/gluegen-rt-natives-linux-i586.jar:core/library/gluegen-rt-natives-macosx-universal.jar:core/library/gluegen-rt-natives-windows-amd64.jar:core/library/gluegen-rt-natives-windows-i586.jar:core/library/gluegen-rt.jar:core/library/jogl-all-natives-linux-amd64.jar:core/library/jogl-all-natives-linux-armv6hf.jar:core/library/jogl-all-natives-linux-i586.jar:core/library/jogl-all-natives-macosx-universal.jar:core/library/jogl-all-natives-windows-amd64.jar:core/library/jogl-all-natives-windows-i586.jar:core/library/jogl-all.jar:modes/java/mode/antlr.jar:modes/java/mode/classpath-explorer-1.0.jar:modes/java/mode/com.ibm.icu.jar:modes/java/mode/JavaMode.jar:modes/java/mode/jdi.jar:modes/java/mode/jdimodel.jar:modes/java/mode/jdtCompilerAdapter.jar:modes/java/mode/jsoup-1.7.1.jar:modes/java/mode/org.eclipse.core.contenttype.jar:modes/java/mode/org.eclipse.core.jobs.jar:modes/java/mode/org.eclipse.core.resources.jar:modes/java/mode/org.eclipse.core.runtime.jar:modes/java/mode/org.eclipse.equinox.common.jar:modes/java/mode/org.eclipse.equinox.preferences.jar:modes/java/mode/org.eclipse.jdt.core.jar:modes/java/mode/org.eclipse.osgi.jar:modes/java/mode/org.eclipse.text.jar:modes/java/mode/org.netbeans.swing.outline.jar" processing.mode.java.Commander "$@"
```