### PR TITLE
Turn off fixed rate scheduling in OpenGL

### DIFF
--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -407,7 +407,7 @@ public class PSurfaceJOGL implements PSurface {
 
 
   protected void initAnimator() {
-    animator = new FPSAnimator(window, 60, true);
+    animator = new FPSAnimator(window, 60);
     drawException = null;
     animator.setUncaughtExceptionHandler(new GLAnimatorControl.UncaughtExceptionHandler() {
       @Override


### PR DESCRIPTION
After some testing, it appears that fixed rate scheduling tries to catch
up later when it runs slower than desired, creating weird speedups when
the load decreases. Turning it back off.