### PR TITLE
'key' variable is always uppercase in FX2D renderer

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -216,6 +216,13 @@ public class PApplet implements PConstants {
    */
   public int displayHeight;
 
+  /** Flag to check whether upper case is to be 'ON' or 'OFF' */
+  public boolean capsOn;
+
+  /** Flags to check status of CapsLock key and Shift key **/
+  public boolean capsFlag;
+  public boolean shiftFlag;
+
   /** A leech graphics object that is echoing all events. */
   public PGraphics recorder;
 
@@ -3046,8 +3053,28 @@ public class PApplet implements PConstants {
    */
   public void keyPressed() { }
 
+  public void keyPressed(KeyEvent event) {     
+    /* Status Check for Caps Lock key */
+    capsFlag = Toolkit.getDefaultToolkit().getLockingKeyState(
+        20); 
 
-  public void keyPressed(KeyEvent event) {
+    if(event.isShiftDown())  {
+      shiftFlag = true;
+    }
+    else {
+      shiftFlag = false;
+    }
+
+    /** Status Check For uppercase flag **/     
+    capsOn = capsFlag ^ shiftFlag;
+    
+    if( capsOn == true) {
+      key = Character.toUpperCase(key);
+    }
+    else {
+      key = Character.toLowerCase(key);
+    }   
+    
     keyPressed();
   }
 
@@ -3280,8 +3307,6 @@ public class PApplet implements PConstants {
 
 
   /**
-   * ( begin auto-generated from delay.xml )
-   *
    * The delay() function causes the program to halt for a specified time.
    * Delay times are specified in thousandths of a second. For example,
    * running delay(3000) will stop the program for three seconds and
@@ -3295,12 +3320,6 @@ public class PApplet implements PConstants {
    * a script that needs to pause a few seconds before attempting a download,
    * or a sketch that needs to wait a few milliseconds before reading from
    * the serial port).
-   *
-   * ( end auto-generated )
-   * @webref environment
-   * @param napTime milliseconds to pause before running draw() again
-   * @see PApplet#frameRate
-   * @see PApplet#draw()
    */
   public void delay(int napTime) {
     //if (frameCount != 0) {
@@ -6416,7 +6435,7 @@ public class PApplet implements PConstants {
           fileChooser.setDialogTitle(prompt);
           fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
           if (defaultSelection != null) {
-            fileChooser.setCurrentDirectory(defaultSelection);
+            fileChooser.setSelectedFile(defaultSelection);
           }
 
           int result = fileChooser.showOpenDialog(parentFrame);
@@ -11133,20 +11152,12 @@ public class PApplet implements PConstants {
   }
 
 
-  /**
-   * ( begin auto-generated from clip.xml )
-   *
-   * Limits the rendering to the boundaries of a rectangle defined 
-   * by the parameters. The boundaries are drawn based on the state 
-   * of the <b>imageMode()</b> fuction, either CORNER, CORNERS, or CENTER. 
-   *
-   * ( end auto-generated )
-   *
-   * @webref rendering
-   * @param a x-coordinate of the rectangle, by default
-   * @param b y-coordinate of the rectangle, by default
-   * @param c width of the rectangle, by default
-   * @param d height of the rectangle, by default
+  /*
+   * @webref rendering:shaders
+   * @param a x-coordinate of the rectangle by default
+   * @param b y-coordinate of the rectangle by default
+   * @param c width of the rectangle by default
+   * @param d height of the rectangle by default
    */
   public void clip(float a, float b, float c, float d) {
     if (recorder != null) recorder.clip(a, b, c, d);
@@ -11154,14 +11165,8 @@ public class PApplet implements PConstants {
   }
 
 
-  /**
-   * ( begin auto-generated from noClip.xml )
-   *
-   * Disables the clipping previously started by the <b>clip()</b> function.
-   *
-   * ( end auto-generated )
-   *
-   * @webref rendering
+  /*
+   * @webref rendering:shaders
    */
   public void noClip() {
     if (recorder != null) recorder.noClip();


### PR DESCRIPTION
This patch is fix to this issue -> https://github.com/processing/processing/issues/3938

Error - "'key' variable is always uppercase in FX2D renderer"

With this patch, key variables will be displayed in the console with changed cases depending upon the status of the CapsLock and Shift keys.