### PR TITLE
Prevent preprocessor from crashing when setup() has no body

### DIFF
--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -299,13 +299,14 @@ public class PdePreprocessor {
         MatchResult setupMatch = findInCurrentScope(VOID_SETUP_REGEX, uncommented);
         if (setupMatch != null) {
           int start = uncommented.indexOf("{", setupMatch.end());
-
-          // Find a closing brace
-          MatchResult match = findInCurrentScope(CLOSING_BRACE, uncommented, start);
-          if (match != null) {
-            searchArea = uncommented.substring(start + 1, match.end() - 1);
-          } else {
-            throw new SketchException("Found a { that's missing a matching }", false);
+          if (start >= 0) {
+            // Find a closing brace
+            MatchResult match = findInCurrentScope(CLOSING_BRACE, uncommented, start);
+            if (match != null) {
+              searchArea = uncommented.substring(start + 1, match.end() - 1);
+            } else {
+              throw new SketchException("Found a { that's missing a matching }", false);
+            }
           }
         }
         break;


### PR DESCRIPTION
Trying to run sketch with setup() without a body would crash the preprocessor. Now it gives correct error message.