### PR TITLE
Add accelerator key (mnemonics) for Japanese environment

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2297,7 +2297,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
         Language.interpolate("close.unsaved_changes", sketch.getName());
       int result =
         JOptionPane.showConfirmDialog(this, prompt,
-                                      Language.text("menu.file.close"),
+                                      Language.text("close"),
                                       JOptionPane.YES_NO_CANCEL_OPTION,
                                       JOptionPane.QUESTION_MESSAGE);
 

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -75,7 +75,6 @@ menu.debug.disable = Disable Debugger
 menu.debug.toggle_breakpoint = Toggle Breakpoint
 #menu.debug.list_breakpoints = List breakpoints
 # ---
-# used for both menus and toolbars
 menu.debug.step = Step
 menu.debug.step_into = Step Into
 menu.debug.step_out = Step Out
@@ -292,9 +291,10 @@ toolbar.save = Save
 toolbar.add_mode = Add Mode...
 
 # [Debug] [Continue] [Step] [Stop] [Toggle Breakpoints] [Variable Inspector]
-#toolbar.debug.continue = Continue
-#toolbar.debug.step = Step
-#toolbar.debug.step_into = Step Into
+toolbar.debug.continue = Continue
+toolbar.debug.step = Step
+toolbar.debug.step_into = Step Into
+toolbar.debug.step_out = Step Out
 #toolbar.debug.stop = Stop
 #toolbar.debug.toggle_breakpoints = Toggle Breakpoint
 #toolbar.debug.variable_inspector = Variable Inspector

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -153,6 +153,7 @@ save.btn.save = Save
 save.btn.dont_save = Don't Save
 
 # Close (Frame) also used to prompt on non-OS X machines
+close = Close
 close.unsaved_changes = Save changes to %s?
 
 # Preferences (Frame)

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -35,7 +35,7 @@ menu.edit.action.addition = addition
 menu.edit.action.deletion = deletion
 menu.edit.cut = 切り取り(T)
 menu.edit.copy = コピー(C)
-menu.edit.copy_as_html = HTMLとしてコピー(H)
+menu.edit.copy_as_html = HTMLとしてコピー
 menu.edit.paste = 貼り付け(P)
 menu.edit.select_all = すべて選択(A)
 menu.edit.auto_format = 自動フォーマット(M)
@@ -51,7 +51,7 @@ menu.edit.use_selection_for_find = 選択を検索(S)
 #               | Sketch |
 menu.sketch.run = 実行(R)
 menu.sketch.present = プレゼンテーション(P)
-menu.sketch.tweak = Tweak(T)
+menu.sketch.tweak = Tweak
 menu.sketch.stop = 停止(S)
 # ---
 menu.library = ライブラリをインポート(I)...
@@ -106,7 +106,7 @@ menu.tools.add_tool = ツールを追加(T)...
 #                                        | Help |
 menu.help = ヘルプ(H)
 menu.help.welcome = Processing 3 へようこそ(W)
-menu.help.about = Processing について(P)
+menu.help.about = Processing について
 menu.help.environment = 環境(E)
 menu.help.reference = リファレンス(R)
 menu.help.find_in_reference = リファレンスから探す(F)

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -10,76 +10,76 @@
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 # | File |
-menu.file = ファイル
-menu.file.new = 新規
-menu.file.open = 開く...
-menu.file.recent = 最近開いたファイル
-menu.file.sketchbook = スケッチブック...
+menu.file = ファイル(F)
+menu.file.new = 新規(N)
+menu.file.open = 開く(O)...
+menu.file.recent = 最近開いたファイル(R)
+menu.file.sketchbook = スケッチブック(K)...
 menu.file.sketchbook.empty = 空のスケッチブック
-menu.file.examples = サンプル...
-menu.file.close = 閉じる
-menu.file.save = 保存
-menu.file.save_as = 名前を付けて保存...
-menu.file.export_application = アプリケーションとしてエクスポート...
-menu.file.page_setup = ページ設定
-menu.file.print = 印刷...
-menu.file.preferences = 設定...
-menu.file.quit = 終了
+menu.file.examples = サンプル(E)...
+menu.file.close = 閉じる(C)
+menu.file.save = 保存(S)
+menu.file.save_as = 名前を付けて保存(A)...
+menu.file.export_application = アプリケーションとしてエクスポート(X)...
+menu.file.page_setup = ページ設定(G)
+menu.file.print = 印刷(P)...
+menu.file.preferences = 設定(F)...
+menu.file.quit = 終了(Q)
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 #        | Edit |
-menu.edit = 編集
-menu.edit.undo = 戻す
-menu.edit.redo = やり直し
+menu.edit = 編集(E)
+menu.edit.undo = 元に戻す(U)
+menu.edit.redo = やり直し(D)
 menu.edit.action.addition = addition
 menu.edit.action.deletion = deletion
-menu.edit.cut = 切り取り
-menu.edit.copy = コピー
-menu.edit.copy_as_html = HTMLとしてコピー
-menu.edit.paste = 貼り付け
-menu.edit.select_all = すべて選択
-menu.edit.auto_format = 自動フォーマット
-menu.edit.comment_uncomment = コメント/アンコメント
-menu.edit.increase_indent = インデントを増やす
-menu.edit.decrease_indent = インデントを減らす
-menu.edit.find = 検索...
-menu.edit.find_next = 次を探す
-menu.edit.find_previous = 前を探す
-menu.edit.use_selection_for_find = 選択を検索
+menu.edit.cut = 切り取り(T)
+menu.edit.copy = コピー(C)
+menu.edit.copy_as_html = HTMLとしてコピー(H)
+menu.edit.paste = 貼り付け(P)
+menu.edit.select_all = すべて選択(A)
+menu.edit.auto_format = 自動フォーマット(M)
+menu.edit.comment_uncomment = コメント/アンコメント(O)
+menu.edit.increase_indent = インデントを増やす(I)
+menu.edit.decrease_indent = インデントを減らす(E)
+menu.edit.find = 検索(F)...
+menu.edit.find_next = 次を探す(N)
+menu.edit.find_previous = 前を探す(V)
+menu.edit.use_selection_for_find = 選択を検索(S)
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 #               | Sketch |
-menu.sketch.run = 実行
-menu.sketch.present = プレゼンテーション
-menu.sketch.tweak = Tweak
-menu.sketch.stop = 停止
+menu.sketch.run = 実行(R)
+menu.sketch.present = プレゼンテーション(P)
+menu.sketch.tweak = Tweak(T)
+menu.sketch.stop = 停止(S)
 # ---
-menu.library = ライブラリをインポート...
-menu.library.add_library = ライブラリを追加...
+menu.library = ライブラリをインポート(I)...
+menu.library.add_library = ライブラリを追加(A)...
 menu.library.contributed = 貢献
 menu.library.no_core_libraries = モードにコアライブラリがありません
 # ---
-menu.sketch = スケッチ
-menu.sketch.show_sketch_folder = スケッチフォルダーを開く
-menu.sketch.add_file = ファイルを追加...
+menu.sketch = スケッチ(S)
+menu.sketch.show_sketch_folder = スケッチフォルダーを開く(F)
+menu.sketch.add_file = ファイルを追加(A)...
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 #                        | Debug |
-menu.debug = デバッグ
-menu.debug.enable = デバッガを有効化
-menu.debug.disable = デバッガを無効化
+menu.debug = デバッグ(D)
+menu.debug.enable = デバッガを有効化(E)
+menu.debug.disable = デバッガを無効化(E)
 #menu.debug.show_debug_toolbar = Show Debug Toolbar
 #menu.debug.debug = Debug
 #menu.debug.stop = Stop
 # ---
-menu.debug.toggle_breakpoint = ブレークポイントを切り替え
+menu.debug.toggle_breakpoint = ブレークポイントを切り替え(T)
 #menu.debug.list_breakpoints = List breakpoints
 # ---
 # used for both menus and toolbars
-menu.debug.step = ステップ
-menu.debug.step_into = ステップイン
-menu.debug.step_out = ステップアウト
-menu.debug.continue = 続行
+menu.debug.step = ステップ(S)
+menu.debug.step_into = ステップイン(I)
+menu.debug.step_out = ステップアウト(O)
+menu.debug.continue = 続行(C)
 # ---
 #menu.debug.print_stack_trace = Print Stack Trace
 #menu.debug.print_locals = Print Locals
@@ -95,35 +95,35 @@ menu.debug.hide_variables = 変数を隠す
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 #                                | Tools |
-menu.tools = ツール
-menu.tools.color_selector = 色選択...
-menu.tools.create_font = フォント作成...
-menu.tools.archive_sketch = スケッチをアーカイブ
+menu.tools = ツール(T)
+menu.tools.color_selector = 色選択(S)...
+menu.tools.create_font = フォント作成(C)...
+menu.tools.archive_sketch = スケッチをアーカイブ(A)
 menu.tools.fix_the_serial_lbrary = シリアルライブラリを修正
 menu.tools.install_processing_java = "processing-java" をインストール
-menu.tools.add_tool = ツールを追加...
+menu.tools.add_tool = ツールを追加(T)...
 
 # | File | Edit | Sketch | Debug | Tools | Help |
 #                                        | Help |
-menu.help = ヘルプ
-menu.help.welcome = Processing 3 へようこそ
-menu.help.about = Processing について
-menu.help.environment = 環境
-menu.help.reference = リファレンス
-menu.help.find_in_reference = リファレンスから探す
-menu.help.libraries_reference = ライブラリ・リファレンス
-menu.help.tools_reference = ツール・リファレンス
+menu.help = ヘルプ(H)
+menu.help.welcome = Processing 3 へようこそ(W)
+menu.help.about = Processing について(P)
+menu.help.environment = 環境(E)
+menu.help.reference = リファレンス(R)
+menu.help.find_in_reference = リファレンスから探す(F)
+menu.help.libraries_reference = ライブラリ・リファレンス(L)
+menu.help.tools_reference = ツール・リファレンス(T)
 menu.help.empty = (空)
-menu.help.online = オンライン
-menu.help.getting_started = はじめの一歩
+menu.help.online = オンライン(O)
+menu.help.getting_started = はじめの一歩(G)
 menu.help.getting_started.url = http://processing.org/learning/gettingstarted/
-menu.help.troubleshooting = 問題解決
+menu.help.troubleshooting = 問題解決(B)
 menu.help.troubleshooting.url = http://wiki.processing.org/w/Troubleshooting
-menu.help.faq = よくある質問
+menu.help.faq = よくある質問(Q)
 menu.help.faq.url = http://wiki.processing.org/w/FAQ
-menu.help.foundation = Processing Foundation
+menu.help.foundation = Processing Foundation(C)
 menu.help.foundation.url = http://processing.org/foundation/
-menu.help.visit = Processing.org にアクセスする
+menu.help.visit = Processing.org にアクセスする(V)
 menu.help.visit.url = http://processing.org/
 
 
@@ -242,7 +242,7 @@ find.btn.previous = 前
 find.btn.find = 検索
 
 # Find in reference (Frame)
-find_in_reference = リファレンスから探す
+find_in_reference = リファレンスから探す(F)
 
 # File (Frame)
 file = スケッチにコピーする画像やその他のデータファイルを選択して下さい
@@ -293,7 +293,7 @@ debugger.type = 型
 #toolbar.open = 開く
 #toolbar.save = 保存
 # toolbar.export_application = Export Application
-toolbar.add_mode = モードの追加...
+toolbar.add_mode = モードの追加(A)...
 
 # [Debug] [Continue] [Step] [Stop] [Toggle Breakpoints] [Variable Inspector]
 #toolbar.debug.continue = Continue
@@ -308,11 +308,11 @@ toolbar.add_mode = モードの追加...
 # Editor
 
 # [Tab1] [Tab2] [v]
-editor.header.new_tab = 新規タブ
-editor.header.rename = 名前の変更
-editor.header.delete = 削除
-editor.header.previous_tab = 前のタブ
-editor.header.next_tab = 次のタブ
+editor.header.new_tab = 新規タブ(N)
+editor.header.rename = 名前の変更(R)
+editor.header.delete = 削除(D)
+editor.header.previous_tab = 前のタブ(P)
+editor.header.next_tab = 次のタブ(T)
 editor.header.delete.warning.title = いや、うん。
 editor.header.delete.warning.text = 開いただけのスケッチのメインタブは削除できません。
 

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -153,6 +153,7 @@ save.btn.save = 保存する
 save.btn.dont_save = 保存しない
 
 # Close (Frame) also used to prompt on non-OS X machines
+close = 閉じる
 close.unsaved_changes = %s への変更を保存しますか?
 
 # Preferences (Frame)

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -75,7 +75,6 @@ menu.debug.disable = デバッガを無効化(E)
 menu.debug.toggle_breakpoint = ブレークポイントを切り替え(T)
 #menu.debug.list_breakpoints = List breakpoints
 # ---
-# used for both menus and toolbars
 menu.debug.step = ステップ(S)
 menu.debug.step_into = ステップイン(I)
 menu.debug.step_out = ステップアウト(O)
@@ -280,10 +279,10 @@ debugger.type = 型
 
 # ---------------------------------------
 # Toolbars
+# FIXME: この部分は文字化けするため、英語のままにする
+#        https://github.com/processing/processing/issues/2886
 
 # [Run/Present] [Stop] [New] [Open] [Save]
-# FIXME: スケッチのメニュー部分は日本語が表示できないため、英語のままにする
-#        https://github.com/processing/processing/issues/2886
 #toolbar.run = 実行
 #toolbar.present = プレゼンテーション
 #toolbar.stop = 停止
@@ -296,9 +295,10 @@ debugger.type = 型
 toolbar.add_mode = モードの追加(A)...
 
 # [Debug] [Continue] [Step] [Stop] [Toggle Breakpoints] [Variable Inspector]
-#toolbar.debug.continue = Continue
-#toolbar.debug.step = Step
-#toolbar.debug.step_into = Step Into
+#toolbar.debug.continue = 続行
+#toolbar.debug.step = ステップ
+#toolbar.debug.step_into = ステップイン
+#toolbar.debug.step_out = ステップアウト
 #toolbar.debug.stop = Stop
 #toolbar.debug.toggle_breakpoints = Toggle Breakpoint
 #toolbar.debug.variable_inspector = Variable Inspector

--- a/java/src/processing/mode/java/JavaToolbar.java
+++ b/java/src/processing/mode/java/JavaToolbar.java
@@ -74,9 +74,9 @@ public class JavaToolbar extends EditorToolbar {
     if (debug) {
       stepButton = new EditorButton(this,
                                     "/lib/toolbar/step",
-                                    Language.text("menu.debug.step"),
-                                    Language.text("menu.debug.step_into"),
-                                    Language.text("menu.debug.step_out")) {
+                                    Language.text("toolbar.debug.step"),
+                                    Language.text("toolbar.debug.step_into"),
+                                    Language.text("toolbar.debug.step_out")) {
         @Override
         public void actionPerformed(ActionEvent e) {
           final int mask = KeyEvent.SHIFT_DOWN_MASK | KeyEvent.ALT_DOWN_MASK;
@@ -87,7 +87,7 @@ public class JavaToolbar extends EditorToolbar {
 
       continueButton = new EditorButton(this,
                                         "/lib/toolbar/continue",
-                                        Language.text("menu.debug.continue")) {
+                                        Language.text("toolbar.debug.continue")) {
         @Override
         public void actionPerformed(ActionEvent e) {
           jeditor.handleContinue();


### PR DESCRIPTION
This will be able to apply other Asian languages.

ref: [Accelerator Keys — Localization Guide 0.9.0 documentation](http://docs.translatehouse.org/projects/localization-guide/en/latest/guide/translation/accelerators.html)

> No available character. Usually in Asian languages where a keyboard is Western. Translate the word into your language and use the original English accelerator. Ie “&File” –> “XXXX(&F)”.
