### PR TITLE
Add OSX native fullscreen

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -48,10 +48,12 @@ import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Image;
 import java.awt.Point;
+import java.awt.Window;
 import java.awt.datatransfer.*;
 import java.awt.event.*;
 import java.awt.print.*;
 import java.io.*;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -335,6 +337,19 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
     // Add a window listener to watch for changes to the files in the sketch
     addWindowFocusListener(new ChangeDetector(this));
+
+    // Try to enable fancy fullscreen on OSX
+    if (Platform.isMacOS()) {
+      try {
+        Class util = Class.forName("com.apple.eawt.FullScreenUtilities");
+        Class params[] = new Class[]{Window.class, Boolean.TYPE};
+        Method method = util.getMethod("setWindowCanFullScreen", params);
+        method.invoke(util, this, true);
+      } catch (Exception e) {
+        Messages.loge("Could not enable OSX fullscreen", e);
+      }
+    }
+
   }
 
 


### PR DESCRIPTION
Added code to let the green traffic light button on OSX activate native fullscreen mode.

Resolves #3993