### PR TITLE
Workaround for JRE bug freezing the PDE

### DIFF
--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -43,10 +43,10 @@
     <opt>-Djna.nounpack=true</opt>
     <!-- starting in 3.0, require Java 8 -->
     <minVersion>1.8.0_51</minVersion>
-	<!-- TODO: remove the line below as soon as we are on 1.8.0_60 or newer,
-	 see https://bugs.openjdk.java.net/browse/JDK-8060036 and
-	 http://kingsfleet.blogspot.com.br/2014/11/but-thats-impossible-or-finding-out.html -->
-	<opt>-XX:CompileCommand=exclude,javax/swing/text/GlyphView,getBreakSpot</opt>
+    <!-- TODO: remove the line below as soon as we are on 1.8.0_60 or newer,
+     see https://bugs.openjdk.java.net/browse/JDK-8060036 and
+     http://kingsfleet.blogspot.com.br/2014/11/but-thats-impossible-or-finding-out.html -->
+    <opt>-XX:CompileCommand=exclude,javax/swing/text/GlyphView,getBreakSpot</opt>
     <!-- increase available per PDE X request -->
     <maxHeapSize>256</maxHeapSize>
   </jre>

--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -43,6 +43,10 @@
     <opt>-Djna.nounpack=true</opt>
     <!-- starting in 3.0, require Java 8 -->
     <minVersion>1.8.0_51</minVersion>
+	<!-- TODO: remove the line below as soon as we are on 1.8.0_60 or newer,
+	 see https://bugs.openjdk.java.net/browse/JDK-8060036 and
+	 http://kingsfleet.blogspot.com.br/2014/11/but-thats-impossible-or-finding-out.html -->
+	<opt>-XX:CompileCommand=exclude,javax/swing/text/GlyphView,getBreakSpot</opt>
     <!-- increase available per PDE X request -->
     <maxHeapSize>256</maxHeapSize>
   </jre>

--- a/java/src/processing/mode/java/pdex/ASTGenerator.java
+++ b/java/src/processing/mode/java/pdex/ASTGenerator.java
@@ -1015,9 +1015,10 @@ public class ASTGenerator {
     if (candidates.get(0).getElementName()
         .equals(candidates.get(candidates.size() - 1).getElementName())) {
       log("All CC are methods only: " + candidates.get(0).getElementName());
-      for (CompletionCandidate candidate : candidates) {
-        candidate.regenerateCompletionString();
-        defListModel.addElement(candidate);
+      for (int i = 0; i < candidates.size(); i++) {
+        CompletionCandidate cc = candidates.get(i).withRegeneratedCompString();
+        candidates.set(i, cc);
+        defListModel.addElement(cc);
       }
     }
     else {
@@ -1030,14 +1031,15 @@ public class ASTGenerator {
             CompletionCandidate cc = candidates.get(i - 1);
             String label = cc.getLabel();
             int x = label.lastIndexOf(')');
-            if(candidates.get(i).getType() == CompletionCandidate.PREDEF_METHOD) {
-              cc.setLabel((cc.getLabel().contains("<html>") ? "<html>" : "")
-                          + cc.getElementName() + "(...)" + label.substring(x + 1));
+            String newLabel;
+            if (candidates.get(i).getType() == CompletionCandidate.PREDEF_METHOD) {
+              newLabel = (cc.getLabel().contains("<html>") ? "<html>" : "")
+                  + cc.getElementName() + "(...)" + label.substring(x + 1);
+            } else {
+              newLabel = cc.getElementName() + "(...)" + label.substring(x + 1);
             }
-            else {
-              cc.setLabel(cc.getElementName() + "(...)" + label.substring(x + 1));
-            }
-            cc.setCompletionString(cc.getElementName() + "(");
+            String newCompString = cc.getElementName() + "(";
+            candidates.set(i - 1, cc.withLabelAndCompString(newLabel, newCompString));
             ignoredSome = true;
             continue;
           }

--- a/java/src/processing/mode/java/pdex/CompletionCandidate.java
+++ b/java/src/processing/mode/java/pdex/CompletionCandidate.java
@@ -33,11 +33,11 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 
 
 public class CompletionCandidate implements Comparable<CompletionCandidate>{
-  private String elementName;
-  private String label; // the toString value
-  private String completionString;
-  private Object wrappedObject;
-  private int type;
+  private final String elementName;
+  private final String label; // the toString value
+  private final String completionString;
+  private final Object wrappedObject;
+  private final int type;
 
   static final int PREDEF_CLASS = 0;
   static final int PREDEF_FIELD = 1;
@@ -158,6 +158,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
     label = labelStr;
     completionString = completionStr;
     this.type = type;
+    wrappedObject = null;
   }
 
   public CompletionCandidate(String name, int type) {
@@ -165,6 +166,17 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
     label = name;
     completionString = name;
     this.type = type;
+    wrappedObject = null;
+  }
+
+  private CompletionCandidate(String elementName, String label,
+                              String completionString, int type,
+                              Object wrappedObject) {
+    this.elementName = elementName;
+    this.label = label;
+    this.completionString = completionString;
+    this.type = type;
+    this.wrappedObject = wrappedObject;
   }
 
   public String getElementName() {
@@ -204,14 +216,13 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
     }
   }
 
-  public void setLabel(String label) {
-    this.label = label;
+  public CompletionCandidate withLabelAndCompString(String label,
+                                                    String completionString) {
+    return new CompletionCandidate(this.elementName, label, completionString,
+                                   this.type, this.wrappedObject);
   }
 
-  public void setCompletionString(String completionString) {
-    this.completionString = completionString;
-  }
-
+  @Override
   public int compareTo(CompletionCandidate cc) {
     if(type != cc.getType()){
       return cc.getType() - type;
@@ -219,7 +230,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
     return (elementName.compareTo(cc.getElementName()));
   }
 
-  public void regenerateCompletionString(){
+  public CompletionCandidate withRegeneratedCompString() {
     if (wrappedObject instanceof MethodDeclaration) {
       MethodDeclaration method = (MethodDeclaration)wrappedObject;
 
@@ -243,8 +254,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
       if (method.getReturnType2() != null)
         label.append(" : " + method.getReturnType2());
       cstr.append(")");
-      this.label = label.toString();
-      this.completionString = cstr.toString();
+      return this.withLabelAndCompString(label.toString(), cstr.toString());
     }
    else if (wrappedObject instanceof Method) {
      Method method = (Method)wrappedObject;
@@ -265,8 +275,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
        label.append(" : " + method.getReturnType().getSimpleName());
      label.append(" - <font color=#777777>" + method.getDeclaringClass().getSimpleName() + "</font></html>");
      cstr.append(")");
-     this.label = label.toString();
-     this.completionString = cstr.toString();
+     return this.withLabelAndCompString(label.toString(), cstr.toString());
      /*
       * StringBuilder label = new StringBuilder("<html>"+method.getName() + "(");
     StringBuilder cstr = new StringBuilder(method.getName() + "(");
@@ -286,6 +295,7 @@ public class CompletionCandidate implements Comparable<CompletionCandidate>{
     label.append(" - <font color=#777777>" + method.getDeclaringClass().getSimpleName() + "</font></html>");
       * */
    }
+    return this;
   }
 
 }


### PR DESCRIPTION
Because of a JRE bug, code completion will occasionally freeze the PDE. Never seen this one before, however, it happened to me three times in a row while I was giving a lecture today and I had to kill the PDE and write all the code again. I can reproduce it back to beta 7. It is caused by JIT compiler, workaround is to disable it for this particular method. See https://bugs.openjdk.java.net/browse/JDK-8060036 and http://kingsfleet.blogspot.com.br/2014/11/but-thats-impossible-or-finding-out.html