### PR TITLE
Implemented '--quiet' flag for processing-java.

### DIFF
--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -58,6 +58,7 @@ public class Commander implements RunnerListener {
   static final String noJavaArg = "--no-java";
   static final String platformArg = "--platform=";
   static final String bitsArg = "--bits=";
+  static final String quietArg = "--quiet";
 //  static final String preferencesArg = "--preferences=";
 
   static final int HELP = -1;
@@ -95,6 +96,7 @@ public class Commander implements RunnerListener {
     File outputFolder = null;
     boolean outputSet = false;  // set an output folder
     boolean force = false;  // replace that no good output folder
+    boolean quiet = false;  // print dt_socket and "Finished" by default
 //    String preferencesPath = null;
     int platform = PApplet.platform; // default to this platform
 //    int platformBits = Base.getNativeBits();
@@ -185,6 +187,9 @@ public class Commander implements RunnerListener {
 
       } else if (arg.equals(forceArg)) {
         force = true;
+ 
+      } else if (arg.equals(quietArg)) {
+        quiet = true;
 
       } else {
         complainAndQuit("I don't know anything about " + arg + ".", true);
@@ -273,7 +278,7 @@ public class Commander implements RunnerListener {
               if (task == PRESENT) {
                 runner.present(sketchArgs);
               } else {
-                runner.launch(sketchArgs);
+                runner.launch(sketchArgs, quiet);
               }
               success = !runner.vmReturnedError();
             }
@@ -296,7 +301,9 @@ public class Commander implements RunnerListener {
         if (!success) {  // error already printed
           System.exit(1);
         }
-        systemOut.println("Finished.");
+        if (!quiet) {
+          systemOut.println("Finished.");
+        }
         System.exit(0);
 
       } catch (SketchException re) {
@@ -382,6 +389,8 @@ public class Commander implements RunnerListener {
     out.println("--no-java            Do not embed Java. Use at your own risk!");
     out.println("--platform           Specify the platform (export to application only).");
     out.println("                     Should be one of 'windows', 'macosx', or 'linux'.");
+    out.println();
+    out.println("--quiet              Do not print dt_socket port number.");
 //    out.println("--bits               Must be specified if libraries are used that are");
 //    out.println("                     32- or 64-bit specific such as the OpenGL library.");
 //    out.println("                     Otherwise specify 0 or leave it out.");

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1096,7 +1096,7 @@ public class JavaEditor extends Editor {
           try {
             toolbar.activateRun();
             //runtime = jmode.handleRun(sketch, JavaEditor.this);
-            runtime = jmode.handleLaunch(sketch, JavaEditor.this, false);
+            runtime = jmode.handleLaunch(sketch, JavaEditor.this, false, false);
           } catch (Exception e) {
             statusError(e);
           }
@@ -1113,7 +1113,7 @@ public class JavaEditor extends Editor {
         try {
           toolbar.activateRun();
           //runtime = jmode.handlePresent(sketch, JavaEditor.this);
-          runtime = jmode.handleLaunch(sketch, JavaEditor.this, true);
+          runtime = jmode.handleLaunch(sketch, JavaEditor.this, true, false);
         } catch (Exception e) {
           statusError(e);
         }

--- a/java/src/processing/mode/java/JavaMode.java
+++ b/java/src/processing/mode/java/JavaMode.java
@@ -147,7 +147,8 @@ public class JavaMode extends Mode {
 
   /** Handles the standard Java "Run" or "Present" */
   public Runner handleLaunch(Sketch sketch, RunnerListener listener,
-                             final boolean present) throws SketchException {
+                             final boolean present,
+                             final boolean quiet) throws SketchException {
     JavaBuild build = new JavaBuild(sketch);
 //    String appletClassName = build.build(false);
     String appletClassName = build.build(true);
@@ -159,7 +160,7 @@ public class JavaMode extends Mode {
           if (present) {
             runtime.present(null);
           } else {
-            runtime.launch(null);
+            runtime.launch(null, quiet);
           }
         }
       }).start();
@@ -214,7 +215,7 @@ public class JavaMode extends Mode {
 //          if (present) {
 //            runtime.present(null);
 //          } else {
-          runtime.launch(null);
+          runtime.launch(null, false);
 //          }
           // next lines are executed when the sketch quits
           if (launchInteractive) {

--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -115,8 +115,8 @@ public class Runner implements MessageConsumer {
   }
 
 
-  public VirtualMachine launch(String[] args) {
-    if (launchVirtualMachine(false, args)) {
+  public VirtualMachine launch(String[] args, final boolean quiet) {
+    if (launchVirtualMachine(false, args, quiet)) {
       generateTrace();
     }
     return vm;
@@ -124,7 +124,7 @@ public class Runner implements MessageConsumer {
 
 
   public VirtualMachine present(String[] args) {
-    if (launchVirtualMachine(true, args)) {
+    if (launchVirtualMachine(true, args, false)) {
       generateTrace();
     }
     return vm;
@@ -144,7 +144,7 @@ public class Runner implements MessageConsumer {
    * @return debuggee VM or null on failure
    */
   public VirtualMachine debug(String[] args) {
-    if (launchVirtualMachine(false, args)) {  // will return null on failure
+    if (launchVirtualMachine(false, args, false)) {  // will return null on failure
       redirectStreams(vm);
     }
     return vm;
@@ -172,7 +172,7 @@ public class Runner implements MessageConsumer {
   }
 
 
-  public boolean launchVirtualMachine(boolean present, String[] args) {
+  public boolean launchVirtualMachine(boolean present, String[] args, boolean quiet) {
     StringList vmParams = getMachineParams();
     StringList sketchParams = getSketchParams(present, args);
 //    PApplet.printArray(sketchParams);
@@ -184,6 +184,9 @@ public class Runner implements MessageConsumer {
 //    String debugArg = "-Xdebug";
     // Newer (Java 1.5+) version that uses JVMTI
     String jdwpArg = "-agentlib:jdwp=transport=dt_socket,address=" + portStr + ",server=y,suspend=y";
+    if (quiet) {
+      jdwpArg = jdwpArg + ",quiet=y";
+    }
 
     // Everyone works the same under Java 7 (also on OS X)
     StringList commandArgs = new StringList();


### PR DESCRIPTION
(see issue #4098)

The --quiet flag suppresses the output of the dt_socket port number.
It also suppresses the final "Finished."-message.
The default behaviour of processing-java has not been altered.
A brief "--help"-entry for "--quiet" has been added.
All other components have not been altered.