### PR TITLE
Implemented '--quiet' flag for processing-java (2nd attempt, fewer changes).

### DIFF
--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -58,6 +58,7 @@ public class Commander implements RunnerListener {
   static final String noJavaArg = "--no-java";
   static final String platformArg = "--platform=";
   static final String bitsArg = "--bits=";
+  static final String quietArg = "--quiet";
 //  static final String preferencesArg = "--preferences=";
 
   static final int HELP = -1;
@@ -95,6 +96,7 @@ public class Commander implements RunnerListener {
     File outputFolder = null;
     boolean outputSet = false;  // set an output folder
     boolean force = false;  // replace that no good output folder
+    boolean quiet = false;
 //    String preferencesPath = null;
     int platform = PApplet.platform; // default to this platform
 //    int platformBits = Base.getNativeBits();
@@ -186,6 +188,9 @@ public class Commander implements RunnerListener {
       } else if (arg.equals(forceArg)) {
         force = true;
 
+      } else if (arg.equals(quietArg)) {
+        quiet = true;
+
       } else {
         complainAndQuit("I don't know anything about " + arg + ".", true);
       }
@@ -273,7 +278,7 @@ public class Commander implements RunnerListener {
               if (task == PRESENT) {
                 runner.present(sketchArgs);
               } else {
-                runner.launch(sketchArgs);
+                runner.launch(sketchArgs, quiet);
               }
               success = !runner.vmReturnedError();
             }
@@ -296,7 +301,9 @@ public class Commander implements RunnerListener {
         if (!success) {  // error already printed
           System.exit(1);
         }
-        systemOut.println("Finished.");
+        if (!quiet) {
+          systemOut.println("Finished.");
+        }
         System.exit(0);
 
       } catch (SketchException re) {
@@ -382,6 +389,7 @@ public class Commander implements RunnerListener {
     out.println("--no-java            Do not embed Java. Use at your own risk!");
     out.println("--platform           Specify the platform (export to application only).");
     out.println("                     Should be one of 'windows', 'macosx', or 'linux'.");
+    out.println("--quiet              Do not print dt_socket port number.");
 //    out.println("--bits               Must be specified if libraries are used that are");
 //    out.println("                     32- or 64-bit specific such as the OpenGL library.");
 //    out.println("                     Otherwise specify 0 or leave it out.");

--- a/java/src/processing/mode/java/JavaMode.java
+++ b/java/src/processing/mode/java/JavaMode.java
@@ -148,6 +148,14 @@ public class JavaMode extends Mode {
   /** Handles the standard Java "Run" or "Present" */
   public Runner handleLaunch(Sketch sketch, RunnerListener listener,
                              final boolean present) throws SketchException {
+    return handleLaunch(sketch, listener, present, false);
+  }
+
+
+  /** Handles the standard Java "Run" or "Present" */
+  public Runner handleLaunch(Sketch sketch, RunnerListener listener,
+                             final boolean present,
+                             final boolean quiet) throws SketchException {
     JavaBuild build = new JavaBuild(sketch);
 //    String appletClassName = build.build(false);
     String appletClassName = build.build(true);
@@ -159,7 +167,7 @@ public class JavaMode extends Mode {
           if (present) {
             runtime.present(null);
           } else {
-            runtime.launch(null);
+            runtime.launch(null, quiet);
           }
         }
       }).start();

--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -116,7 +116,12 @@ public class Runner implements MessageConsumer {
 
 
   public VirtualMachine launch(String[] args) {
-    if (launchVirtualMachine(false, args)) {
+     return launch(args, false);
+  }
+
+
+  public VirtualMachine launch(String[] args, boolean quiet) {
+    if (launchVirtualMachine(false, args, quiet)) {
       generateTrace();
     }
     return vm;
@@ -173,6 +178,11 @@ public class Runner implements MessageConsumer {
 
 
   public boolean launchVirtualMachine(boolean present, String[] args) {
+    return launchVirtualMachine(present, args, false);
+  }
+
+
+  public boolean launchVirtualMachine(boolean present, String[] args, boolean quiet) {
     StringList vmParams = getMachineParams();
     StringList sketchParams = getSketchParams(present, args);
 //    PApplet.printArray(sketchParams);
@@ -184,7 +194,9 @@ public class Runner implements MessageConsumer {
 //    String debugArg = "-Xdebug";
     // Newer (Java 1.5+) version that uses JVMTI
     String jdwpArg = "-agentlib:jdwp=transport=dt_socket,address=" + portStr + ",server=y,suspend=y";
-
+    if (quiet) {
+      jdwpArg = jdwpArg + ",quiet=y";
+    }
     // Everyone works the same under Java 7 (also on OS X)
     StringList commandArgs = new StringList();
     commandArgs.append(Platform.getJavaPath());


### PR DESCRIPTION
Implemented a `--quiet` flag for processing-java.
Issue: #4098.

If processing-java is called with the `--quiet` flag, the dt_socket port number and the "Finished." message are not printed to STDOUT.

I added an optional `boolean quiet` parameter to three methods in `JavaMode.java` and `Runner.java`, as well as few lines to `Commander.java`, everything else is left untouched (in particular, this time the code in JavaEditor.java is not affected).
All methods that existed previously still have exactly the same signature as before.
The default behaviour of processing-java has not been altered.
