### PR TITLE
Add warning when drawing with invalid shape constant.

### DIFF
--- a/core/src/processing/awt/PGraphicsJava2D.java
+++ b/core/src/processing/awt/PGraphicsJava2D.java
@@ -864,7 +864,12 @@ public class PGraphicsJava2D extends PGraphics {
         gpath.lineTo(x, y);
       }
       break;
+
+    default:
+      showWarning("Invalid shape type. Try calling beginShape() without a parameter.");
+      break;
     }
+
   }
 
 


### PR DESCRIPTION
Previously, Java2D renderer silently fails to render `LINE_LOOP` and `LINE_STRIP` shapes. This adds a runtime warning when an invalid shape type is specified for the renderer.

Closes #4107 
