### PR TITLE
Minor fixes to Java Mode

### DIFF
--- a/java/src/processing/mode/java/pdex/ASTGenerator.java
+++ b/java/src/processing/mode/java/pdex/ASTGenerator.java
@@ -2495,6 +2495,7 @@ public class ASTGenerator {
 
   protected static ASTNode findLineOfNode(ASTNode node, int lineNumber,
                                         int offset, String name) {
+    if (node == null) return null;
 
     CompilationUnit root = (CompilationUnit) node.getRoot();
 //    log("Inside "+getNodeAsString(node) + " | " + root.getLineNumber(node.getStartPosition()));

--- a/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
+++ b/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
@@ -489,11 +489,9 @@ public class JavaTextAreaPainter extends TextAreaPainter
         setToolTipText(null);
         return super.getToolTipText(event);
       }
-      String s = textArea.getLineText(line);
-      if (s == "") {
-        return event.toString();
 
-      } else if (s.length() == 0) {
+      String s = textArea.getLineText(line);
+      if (s == null || s.isEmpty()) {
         setToolTipText(null);
         return super.getToolTipText(event);
 


### PR DESCRIPTION
ASTGenerator.java: Stops there being loads of red text (null pointer exceptions) when you open the context menu with the compiler broken as I reported in #4090. (I'm still not sure what caused #4090, but since it went away when I deleted my configuration files I assumed that it wasn't a real bug.)

JavaTextAreaPainter.java: I just noticed the very odd code that had two different checks for the empty string (with one unreliable and using `==`) and thought that this made more sense.