### PR TITLE
Show the current line number and tab location of the cursor in the Ed…

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -297,6 +297,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
       String lastText = textarea.getText();
       public void caretUpdate(CaretEvent e) {
         String newText = textarea.getText();
+        //Updates the Cursor Index Location values in the EditorStatus Bar
+        status.updateCursorIndexValues();
+
         if (lastText.equals(newText) && isDirectEdit()) {
           endTextEditHistory();
         }

--- a/app/src/processing/app/ui/EditorStatus.java
+++ b/app/src/processing/app/ui/EditorStatus.java
@@ -81,6 +81,10 @@ public class EditorStatus extends BasicSplitPaneDivider {  //JPanel {
   Image offscreen;
   int sizeW, sizeH;
 
+  int cursorRowNumber;
+  int cursorColumnNumber;
+  String cursorValues;
+
 //  JButton cancelButton;
 //  JButton okButton;
 //  JTextField editField;
@@ -96,6 +100,8 @@ public class EditorStatus extends BasicSplitPaneDivider {  //JPanel {
     this.editor = editor;
     empty();
     updateMode();
+    cursorRowNumber = 0;
+    cursorColumnNumber = 0;
 
     addMouseListener(new MouseAdapter() {
       public void mouseEntered(MouseEvent e) {
@@ -226,6 +232,21 @@ public class EditorStatus extends BasicSplitPaneDivider {  //JPanel {
     repaint();
   }
 
+  // Calculates and updates the LineNumber and ColumnNumber of the cursor
+  public void updateCursorIndexValues() {
+    // We create a try catch to catch any exceptions.
+    try {
+      int caretpos = editor.textarea.getCaretPosition();
+      cursorRowNumber = editor.textarea.getLineOfOffset(caretpos);
+      cursorColumnNumber = caretpos - 
+                             editor.textarea.getLineStartOffset(cursorRowNumber);
+      cursorRowNumber += 1;
+      }
+      catch(Exception ex) {
+      }
+      repaint();
+  }
+
 
   //public void paintComponent(Graphics screen) {
   public void paint(Graphics screen) {
@@ -266,6 +287,17 @@ public class EditorStatus extends BasicSplitPaneDivider {  //JPanel {
     if (message != null) {
       g.setFont(font); // needs to be set each time on osx
       g.drawString(message, LEFT_MARGIN, (sizeH + ascent) / 2);
+      System.out.println();
+    }
+
+    // Updates the cursor Row & ColumnNumber and displays them
+    // on the right side of the EditorStatusBar
+    updateCursorIndexValues(); // Updating CaretPosition values
+    if (cursorRowNumber > 0) {
+      cursorValues = String.valueOf(cursorRowNumber) + ":" +
+                                    String.valueOf(cursorColumnNumber);
+      g.drawString(cursorValues, getWidth() - RIGHT_MARGIN -
+                   g.getFontMetrics().stringWidth(cursorValues), (sizeH + ascent) / 2);
     }
 
     if (indeterminate) {


### PR DESCRIPTION
This PR adds a feature to the Processing Editor -> https://github.com/processing/processing/issues/4135

With this feature, the user will be able to see the current line and tab index location of the cursor right below the text editor area in the EditorStatus bar as show in the screenshow below.
![scrren](https://cloud.githubusercontent.com/assets/6258810/11133268/e4c1b186-89ba-11e5-9662-3ae45a08ebf0.png)
