### PR TITLE
Small fix to processing-java generation

### DIFF
--- a/app/src/processing/app/tools/InstallCommander.java
+++ b/app/src/processing/app/tools/InstallCommander.java
@@ -91,7 +91,7 @@ public class InstallCommander implements Tool {
                    "OPTION_FOR_HEADLESS_RUN=\"\"\n" +
                    "for ARG in \"$@\"\n" +
                    "do\n" +
-                   "    if [ $ARG = \"--build\" ]; then\n" +
+                   "    if [ \"$ARG\" = \"--build\" ]; then\n" +
                    "        OPTION_FOR_HEADLESS_RUN=\"-Djava.awt.headless=true\"\n" +
                    "    fi\n" +
                    "done\n\n");


### PR DESCRIPTION
Related to #3996.

Now it doesn't give an error when there is quotation in the command line args.

Related comments:
https://github.com/processing/processing/issues/3996#issuecomment-154859783
https://github.com/processing/processing/issues/3996#issuecomment-155404233

I have tested that this fixes the issue reported in the first comment.