### PR TITLE
Make the error message for stack overflows clearer

### DIFF
--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -749,6 +749,12 @@ public class Runner implements MessageConsumer {
       // This shouldn't happen, but if it does, print the exception in case
       // it's something that needs to be debugged separately.
       e.printStackTrace(sketchErr);
+    } catch (Exception e) {
+      // stack overflows seem to trip in frame.location() above
+      // ignore this case so that the actual error gets reported to the user
+      if ("StackOverflowError".equals(message) == false) {
+        e.printStackTrace(sketchErr);
+      }
     }
     // before giving up, try to extract from the throwable object itself
     // since sometimes exceptions are re-thrown from a different context
@@ -780,7 +786,11 @@ public class Runner implements MessageConsumer {
       or.invokeMethod(thread, method, new ArrayList<Value>(), ObjectReference.INVOKE_SINGLE_THREADED);
 
     } catch (Exception e) {
-      e.printStackTrace(sketchErr);
+      // stack overflows will make the exception handling above trip again
+      // ignore this case so that the actual error gets reported to the user
+      if ("StackOverflowError".equals(message) == false) {
+        e.printStackTrace(sketchErr);
+      }
     }
     // Give up, nothing found inside the pile of stack frames
     SketchException rex = new SketchException(message);


### PR DESCRIPTION
Regarding #4149 and against the better advice of #2623

Currently recursive functions only output this:

    crashed in event thread due to Timeout occurred while waiting for packet 29.
    org.eclipse.jdi.TimeoutException: Timeout occurred while waiting for packet 29.
	at org.eclipse.jdi.internal.connect.PacketReceiveManager.getReply(PacketReceiveManager.java:186)
	at org.eclipse.jdi.internal.connect.PacketReceiveManager.getReply(PacketReceiveManager.java:197)
	at org.eclipse.jdi.internal.MirrorImpl.requestVM(MirrorImpl.java:191)
	at org.eclipse.jdi.internal.MirrorImpl.requestVM(MirrorImpl.java:226)
	at org.eclipse.jdi.internal.ThreadReferenceImpl.frames(ThreadReferenceImpl.java:257)
	at org.eclipse.jdi.internal.ThreadReferenceImpl.frames(ThreadReferenceImpl.java:240)
	at processing.mode.java.runner.Runner.findException(Runner.java:726)
	at processing.mode.java.runner.Runner.reportException(Runner.java:709)
	at processing.mode.java.runner.Runner.exceptionEvent(Runner.java:631)
	at processing.mode.java.runner.Runner$2.run(Runner.java:523)
    org.eclipse.jdi.TimeoutException: Timeout occurred while waiting for packet 30.
	at org.eclipse.jdi.internal.connect.PacketReceiveManager.getReply(PacketReceiveManager.java:186)
	at org.eclipse.jdi.internal.connect.PacketReceiveManager.getReply(PacketReceiveManager.java:197)
	at org.eclipse.jdi.internal.MirrorImpl.requestVM(MirrorImpl.java:191)
	at org.eclipse.jdi.internal.MirrorImpl.requestVM(MirrorImpl.java:226)
	at org.eclipse.jdi.internal.VirtualMachineImpl.exit(VirtualMachineImpl.java:716)
	at processing.mode.java.runner.Runner.close(Runner.java:801)
	at processing.mode.java.JavaEditor.handleStop(JavaEditor.java:1156)
	at processing.mode.java.JavaToolbar.handleStop(JavaToolbar.java:146)
	at processing.mode.java.JavaToolbar$4.actionPerformed(JavaToolbar.java:104)
	at processing.app.ui.EditorButton.mousePressed(EditorButton.java:181)
	at java.awt.Component.processMouseEvent(Component.java:6522)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at java.awt.Component.processEvent(Component.java:6290)
	at java.awt.Container.processEvent(Container.java:2234)
	at java.awt.Component.dispatchEventImpl(Component.java:4881)
	at java.awt.Container.dispatchEventImpl(Container.java:2292)
	at java.awt.Component.dispatchEvent(Component.java:4703)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4898)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4530)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4462)
	at java.awt.Container.dispatchEventImpl(Container.java:2278)
	at java.awt.Window.dispatchEventImpl(Window.java:2750)
	at java.awt.Component.dispatchEvent(Component.java:4703)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.awt.EventQueue$4.run(EventQueue.java:729)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$1.doIntersectionPrivilege(ProtectionDomain.java:75)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)"

with the patch this becomes

    A StackOverflowError means that you have a bug that's causing a function
    to be called recursively (it's calling itself and going in circles),
    or you're intentionally calling a recursive function too much,
    and your code should be rewritten in a more efficient manner."

(and the TimeoutException once you click the stop button)