### PR TITLE
Extended support of SVG format

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -22,8 +22,23 @@
 
 package processing.core;
 
+import java.awt.Image;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Base64.Decoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.nio.charset.StandardCharsets;
+import javax.swing.ImageIcon;
+import javax.xml.bind.DatatypeConverter;
+
+
 
 import processing.core.PApplet;
 
@@ -106,6 +121,7 @@ public class PShape implements PConstants {
 
   /** Texture or image data associated with this shape. */
   protected PImage image;
+  protected String imagePath = null;
 
   public static final String OUTSIDE_BEGIN_END_ERROR =
     "%1$s can only be called between beginShape() and endShape()";
@@ -1645,6 +1661,10 @@ public class PShape implements PConstants {
              params[6], params[7]);
 
     } else if (kind == RECT) {
+
+      if (imagePath != null){
+          loadImage(g);
+      }
       if (image != null) {
         int oldMode = g.imageMode;
         g.imageMode(CORNER);
@@ -1879,6 +1899,63 @@ public class PShape implements PConstants {
     g.endShape(close ? CLOSE : OPEN);
   }
 
+  private void loadImage(PGraphics g){
+
+      if(this.imagePath.startsWith("data:image")){
+          loadBase64Image();
+      }
+
+      if(this.imagePath.startsWith("file://")){
+          loadFileSystemImage(g);
+      }
+      this.imagePath = null;
+  }
+  
+  private void loadFileSystemImage(PGraphics g){
+    imagePath = imagePath.substring(7);
+    PImage loadedImage = g.parent.loadImage(imagePath);
+    if(loadedImage == null){
+      System.err.println("Error loading image file: " + imagePath);
+    }else{
+      setTexture(loadedImage);
+    }
+  }
+
+ private void loadBase64Image(){
+    String[] parts = this.imagePath.split(";base64,");
+    String extension = parts[0].substring(11);
+    String encodedData = parts[1];
+
+    byte[] decodedBytes = DatatypeConverter.parseBase64Binary(encodedData);
+
+    if(decodedBytes == null){
+      System.err.println("Decode Error on image: " + imagePath.substring(0, 20));
+      return;
+    }
+    
+    Image awtImage = new ImageIcon(decodedBytes).getImage();
+
+    if (awtImage instanceof BufferedImage) {
+      BufferedImage buffImage = (BufferedImage) awtImage;
+      int space = buffImage.getColorModel().getColorSpace().getType();
+      if (space == ColorSpace.TYPE_CMYK) {
+       return;
+      }
+    }
+
+    PImage loadedImage = new PImage(awtImage);
+    if (loadedImage.width == -1) {
+      // error...
+    }
+
+    // if it's a .gif image, test to see if it has transparency
+    if (extension.equals("gif") || extension.equals("png") ||
+      extension.equals("unknown")) {
+    loadedImage.checkAlpha();
+    }
+    
+    setTexture(loadedImage);
+  }
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
@@ -2387,14 +2464,14 @@ public class PShape implements PConstants {
  /**
    * ( begin auto-generated from PShape_setFill.xml )
    *
-   * The <b>setFill()</b> method defines the fill color of a <b>PShape</b>. 
-   * This method is used after shapes are created or when a shape is defined explicitly 
-   * (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in the above example. 
-   * When a shape is created with <b>beginShape()</b> and <b>endShape()</b>, its 
-   * attributes may be changed with <b>fill()</b> and <b>stroke()</b> within 
-   * <b>beginShape()</b> and <b>endShape()</b>. However, after the shape is 
-   * created, only the <b>setFill()</b> method can define a new fill value for 
-   * the <b>PShape</b>. 
+   * The <b>setFill()</b> method defines the fill color of a <b>PShape</b>.
+   * This method is used after shapes are created or when a shape is defined explicitly
+   * (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in the above example.
+   * When a shape is created with <b>beginShape()</b> and <b>endShape()</b>, its
+   * attributes may be changed with <b>fill()</b> and <b>stroke()</b> within
+   * <b>beginShape()</b> and <b>endShape()</b>. However, after the shape is
+   * created, only the <b>setFill()</b> method can define a new fill value for
+   * the <b>PShape</b>.
    *
    * ( end auto-generated )
    *
@@ -2543,14 +2620,14 @@ public class PShape implements PConstants {
   /**
    * ( begin auto-generated from PShape_setStroke.xml )
    *
-   * The <b>setStroke()</b> method defines the outline color of a <b>PShape</b>. 
-   * This method is used after shapes are created or when a shape is defined 
-   * explicitly (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in 
-   * the above example. When a shape is created with <b>beginShape()</b> and 
-   * <b>endShape()</b>, its attributes may be changed with <b>fill()</b> and 
-   * <b>stroke()</b> within <b>beginShape()</b> and <b>endShape()</b>. 
-   * However, after the shape is created, only the <b>setStroke()</b> method 
-   * can define a new stroke value for the <b>PShape</b>. 
+   * The <b>setStroke()</b> method defines the outline color of a <b>PShape</b>.
+   * This method is used after shapes are created or when a shape is defined
+   * explicitly (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in
+   * the above example. When a shape is created with <b>beginShape()</b> and
+   * <b>endShape()</b>, its attributes may be changed with <b>fill()</b> and
+   * <b>stroke()</b> within <b>beginShape()</b> and <b>endShape()</b>.
+   * However, after the shape is created, only the <b>setStroke()</b> method
+   * can define a new stroke value for the <b>PShape</b>.
    *
    * ( end auto-generated )
    *


### PR DESCRIPTION
Hello Processing maintainers !

I work on a side project called [Soby](https://github.com/poqudrof/Soby) in which I do slideshows based on SVGs, it is based on an older [Sozi](https://github.com/senshu/Sozi). 
I extended a little bit the support of SVGs and now with Java 8 and stuff like the Base64 decoder I have a rather clean solution. 
#### Here are the good parts : 
- Support of embedded images in SVGs, linked images are supported but should not be avoided if possible.
- Text and image locations are identical to SVG visualized in Inkscape. 
  When the font works, it fits perfectly. 
- Low modification of current code except for new parsing functions. 
#### Here are the bad parts : 
- I introduce some code duplication in :

``` java
private void loadBase64Image() 
```
- I have no idea how to handle text quality in a clean way... :

``` java
 public static float TEXT_QUALITY = 1;   
```

Although is seems `2` is a good «guess» for most applications. 
- Inline styles are not supported.
- Not all fonts are supported (depending on your OS).
- Tested only on Inkscape SVGs.
