### PR TITLE
Fix error messages from Javadocs

### DIFF
--- a/app/src/processing/app/contrib/ExamplesContribution.java
+++ b/app/src/processing/app/contrib/ExamplesContribution.java
@@ -52,7 +52,7 @@ public class ExamplesContribution extends LocalContribution {
    * exampleLocation directory is compatible with the current mode.
    *
    * @param base
-   * @param exampleFolder
+   * @param props
    * @return true if the example is compatible with the mode of the currently
    *         active editor
    */

--- a/app/src/processing/app/syntax/SyntaxStyle.java
+++ b/app/src/processing/app/syntax/SyntaxStyle.java
@@ -30,9 +30,9 @@ public class SyntaxStyle {
   /**
    * Creates a new SyntaxStyle.
    * @param color The text color
-   * @param italic True if the text should be italics
    * @param bold True if the text should be bold
    */
+// * @param italic True if the text should be italics
 //  public SyntaxStyle(Color color, boolean italic, boolean bold) {
   public SyntaxStyle(Color color, boolean bold) {
     this.color = color;

--- a/app/src/processing/app/syntax/im/CompositionTextManager.java
+++ b/app/src/processing/app/syntax/im/CompositionTextManager.java
@@ -77,7 +77,7 @@ public class CompositionTextManager {
    * This method initializes text manager.
    *
    * @param text Text from InputMethodEvent.
-   * @param commited_count Numbers of committed characters in text.
+   * @param committed_count Numbers of committed characters in text.
    */
   public void beginCompositionText(AttributedCharacterIterator text, int committed_count) {
     isInputProcess = true;
@@ -91,7 +91,7 @@ public class CompositionTextManager {
    * select candidates from input method.
    *
    * @param text Text from InputMethodEvent.
-   * @param commited_count Numbers of committed characters in text.
+   * @param committed_count Numbers of committed characters in text.
    */
   public void processCompositionText(AttributedCharacterIterator text, int committed_count) {
     int layoutCaretPosition = initialCaretPosition + committed_count;
@@ -129,7 +129,7 @@ public class CompositionTextManager {
    * composition text. This method resets CompositionTextPainter.
    *
    * @param text Text from InputMethodEvent.
-   * @param commited_count Numbers of committed characters in text.
+   * @param committed_count Numbers of committed characters in text.
    */
   public void endCompositionText(AttributedCharacterIterator text, int committed_count) {
     /*

--- a/app/src/processing/app/syntax/im/CompositionTextPainter.java
+++ b/app/src/processing/app/syntax/im/CompositionTextPainter.java
@@ -43,7 +43,6 @@ public class CompositionTextPainter {
   /**
    * Check the painter has TextLayout.
    * If a user input via InputMethod, this result will return true.
-   * @param textarea textarea used by PDE.
    */
   public boolean hasComposedTextLayout() {
     return (composedTextLayout != null);
@@ -55,7 +54,6 @@ public class CompositionTextPainter {
    * TextLayout will be created and set by CompositionTextManager.
    * 
    * @see CompositionTextManager
-   * @param textarea textarea used by PDE.
    */
   public void setComposedTextLayout(TextLayout composedTextLayout, int composedStartCaretPosition) {
     this.composedTextLayout = composedTextLayout;

--- a/app/src/processing/app/syntax/im/InputMethodSupport.java
+++ b/app/src/processing/app/syntax/im/InputMethodSupport.java
@@ -32,8 +32,9 @@ import processing.app.syntax.TextAreaPainter;
  *
  * @see <a href="https://processing.org/bugs/bugzilla/854.html">Bug 854 : implement input method support for Japanese (and other languages)</a>
  * @see <a href="https://processing.org/bugs/bugzilla/1531.html">Bug 1531 : Can't input full-width space when Japanese IME is on.</a>
- * @see http://docs.oracle.com/javase/8/docs/technotes/guides/imf/index.html
- * @see http://docs.oracle.com/javase/tutorial/2d/text/index.html
+ * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/imf/index.html">Java Input Method Framework
+ * (IMF) Technology</a>
+ * @see <a href="http://docs.oracle.com/javase/tutorial/2d/text/index.html">The Java Tutorials</a>
  *
  * @author Takashi Maekawa (takachin@generative.info)
  * @author Satoshi Okita

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,1 +1,2 @@
 work
+javadoc

--- a/build/build.xml
+++ b/build/build.xml
@@ -1269,6 +1269,11 @@ remove the spaces for depth since it should be double dash, but screws up commen
 
   <target name="doc">
 
+    <mkdir dir="javadoc" />
+
+    <!-- Core is in the classpath, so we must build it. -->
+    <subant buildpath="../core" target="build" failonerror="false" />
+
     <!-- build doc for core -->
     <exec executable="find" dir="javadoc" errorproperty="ignored">
       <arg line="core -type f -exec rm -rf {} ';'" />
@@ -1284,6 +1289,16 @@ remove the spaces for depth since it should be double dash, but screws up commen
       <arg value="-notimestamp" />
 
       <arg value="-quiet" />
+
+      <!-- Suppress errors and display some information. -->
+      <tag name="webref" enabled="false" />
+      <tag name="nowebref" enabled="false" />
+      <tag name="generate" enabled="false" />
+      <tag name="instanceName" enabled="false" />
+      <tag name="see_external" enabled="false" />
+      <tag name="brief" description="In brief:" />
+      <tag name="usage" />
+      <arg value="-Xdoclint:reference,accessibility" />
 
       <packageset dir="../core/src">
         <include name="processing/**" />
@@ -1303,7 +1318,7 @@ remove the spaces for depth since it should be double dash, but screws up commen
       <arg line="everything -type f -exec rm -rf {} ';'" />
     </exec>
 
-    <javadoc access="public" author="false" classpath="../app/lib/ant.jar:../app/lib/ant-launcher.jar:../app/lib/antlr.jar:../app/lib/apple.jar:../app/lib/jna.jar:../app/lib/jna-platform.jar:../core/bin:../core/library/gluegen-rt.jar:../core/library/jogl-all.jar:../java/libraries/svg/bin:../java/libraries/pdf/bin:../java/libraries/pdf/library/itext.jar:../java/libraries/dxf/bin:../java/libraries/io/bin:../java/libraries/net/bin:../java/libraries/serial/bin:${java.home}/lib/tools.jar" destdir="javadoc/everything" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.8" splitindex="false" use="false" version="false" noqualifier="all">
+    <javadoc access="public" author="false" classpath="../app/lib/ant.jar:../app/lib/ant-launcher.jar:../app/lib/antlr.jar:../app/lib/apple.jar:../app/lib/jna.jar:../app/lib/jna-platform.jar:../core/bin:../core/library/gluegen-rt.jar:../core/library/jogl-all.jar:../java/libraries/svg:../java/libraries/pdf/library/itext.jar:../java/libraries/dxf:../java/libraries/serial/library:${java.home}/lib/tools.jar" destdir="javadoc/everything" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.8" splitindex="false" use="false" version="false" noqualifier="all">
 
       <arg value="-notimestamp" />
 
@@ -1317,6 +1332,14 @@ remove the spaces for depth since it should be double dash, but screws up commen
       </packageset>
 
 
+      <tag name="webref" enabled="false" />
+      <tag name="nowebref" enabled="false" />
+      <tag name="generate" enabled="false" />
+      <tag name="instanceName" enabled="false" />
+      <tag name="see_external" enabled="false" />
+      <tag name="brief" description="In brief:" />
+      <tag name="usage" />
+      <arg value="-Xdoclint:reference,accessibility" />
 
       <!--<packageset dir="../app/generated">
         <include name="processing/**" />
@@ -1336,14 +1359,25 @@ remove the spaces for depth since it should be double dash, but screws up commen
       <arg line="libraries -type f -exec rm -rf {} ';'" />
     </exec>
 
-    <javadoc access="public" author="false" classpath="../app/lib/ant.jar:../app/lib/ant-launcher.jar:../app/lib/antlr.jar:../app/lib/apple.jar:../app/lib/jna.jar:../app/lib/jna-platform.jar:../core/bin:../core/library/gluegen-rt.jar:../core/library/jogl-all.jar:../java/libraries/svg/bin:../java/libraries/pdf/bin:../java/libraries/pdf/library/itext.jar:../java/libraries/dxf/bin:../java/libraries/net/bin:../java/libraries/serial/bin:${java.home}/lib/tools.jar" destdir="javadoc/libraries" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.8" splitindex="false" use="false" version="false" noqualifier="all">
+    <javadoc access="public" author="false" classpath="../app/lib/ant.jar:../app/lib/ant-launcher.jar:../app/lib/antlr.jar:../app/lib/apple.jar:../app/lib/jna.jar:../app/lib/jna-platform.jar:../core/bin:../core/library/gluegen-rt.jar:../core/library/jogl-all.jar:../java/libraries/svg/library/batik-dom-1.8.jar:../java/libraries/svg/library/batik-svggen-1.8.jar:../java/libraries/pdf/library/itext.jar:../java/libraries/dxf:../java/libraries/serial/library/jssc.jar:${java.home}/lib/tools.jar" destdir="javadoc/libraries" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.8" splitindex="false" use="false" version="false" noqualifier="all">
 
       <arg value="-notimestamp" />
 
       <arg value="-quiet" />
 
       <link href="http://docs.oracle.com/javase/7/docs/api/" />
+      <link href="../../javadoc/core/" />
       
+      <tag name="webref" enabled="false" />
+      <tag name="nowebref" enabled="false" />
+      <tag name="generate" enabled="false" />
+      <tag name="instanceName" enabled="false" />
+      <tag name="see_external" enabled="false" />
+      <tag name="brief" description="In brief:" />
+      <tag name="usage" />
+      <arg value="-Xdoclint:reference,accessibility" />
+
+
       <packageset dir="../java/libraries/dxf/src">
         <include name="antlr/**" />
         <include name="processing/**" />

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -339,8 +339,8 @@ public class PApplet implements PConstants {
    *
    * @webref environment
    * @see PApplet#pixelHeight
-   * @see pixelDensity()
-   * @see displayDensity()
+   * @see #pixelDensity(int)
+   * @see #displayDensity()
    */
   public int pixelWidth;
 
@@ -363,8 +363,8 @@ public class PApplet implements PConstants {
    *
    * @webref environment
    * @see PApplet#pixelWidth
-   * @see pixelDensity()
-   * @see displayDensity()
+   * @see #pixelDensity(int)
+   * @see #displayDensity()
    */
   public int pixelHeight;
 
@@ -1019,7 +1019,7 @@ public class PApplet implements PConstants {
   * @webref environment
   * @see PApplet#fullScreen()
   * @see PApplet#setup()
-  * @see PApplet#size()
+  * @see PApplet#size(int,int)
   * @see PApplet#smooth()
   */
   public void settings() {
@@ -1116,8 +1116,8 @@ public class PApplet implements PConstants {
   * ( end auto-generated )
   *
   * @webref environment
-  * @see PApplet#pixelDensity()
-  * @see PApplet#size()
+  * @see PApplet#pixelDensity(int)
+  * @see PApplet#size(int,int)
   */
   public int displayDensity() {
     if (display == SPAN) {
@@ -1855,7 +1855,7 @@ public class PApplet implements PConstants {
   * @param renderer the renderer to use, e.g. P2D, P3D, JAVA2D (default)
   * @see PApplet#settings()
   * @see PApplet#setup()
-  * @see PApplet#size()
+  * @see PApplet#size(int,int)
   * @see PApplet#smooth()
   */
   public void fullScreen(String renderer) {
@@ -3412,7 +3412,7 @@ public class PApplet implements PConstants {
    *
    * ( end auto-generated )
    * @webref input:files
-   * @param filename name of the file
+   * @param args arguments to the launcher, eg. a filename.
    * @usage Application
    */
   static public Process launch(String... args) {
@@ -4349,12 +4349,12 @@ public class PApplet implements PConstants {
   }
 
 
-  /**
-   * Find the maximum value in an array.
-   * Throws an ArrayIndexOutOfBoundsException if the array is length 0.
-   * @param list the source array
-   * @return The maximum value
-   */
+//  /**
+//   * Find the maximum value in an array.
+//   * Throws an ArrayIndexOutOfBoundsException if the array is length 0.
+//   * @param list the source array
+//   * @return The maximum value
+//   */
   /*
   static public final double max(double[] list) {
     if (list.length == 0) {
@@ -5134,7 +5134,6 @@ public class PApplet implements PConstants {
    * ( end auto-generated )
    * @webref math:random
    * @param lod number of octaves to be used by the noise
-   * @param falloff falloff factor for each octave
    * @see PApplet#noise(float, float, float)
    */
   public void noiseDetail(int lod) {
@@ -5142,6 +5141,8 @@ public class PApplet implements PConstants {
   }
 
   /**
+   * @see #noiseDetail(int)
+   * @param lod number of octaves to be used by the noise
    * @param falloff falloff factor for each octave
    */
   public void noiseDetail(int lod, float falloff) {
@@ -5796,7 +5797,7 @@ public class PApplet implements PConstants {
   /**
    * @webref input:files
    * @brief Converts String content to an XML object
-   * @param data the content to be parsed as XML
+   * @param xmlString the content to be parsed as XML
    * @return an XML object, or null
    * @see XML
    * @see PApplet#loadXML(String)
@@ -6687,8 +6688,8 @@ public class PApplet implements PConstants {
    * @webref input:files
    * @param filename the name of the file to use as input
    * @see PApplet#createOutput(String)
-   * @see PApplet#selectOutput(String)
-   * @see PApplet#selectInput(String)
+   * @see PApplet#selectOutput(String,String)
+   * @see PApplet#selectInput(String,String)
    *
    */
   public InputStream createInput(String filename) {
@@ -7121,7 +7122,7 @@ public class PApplet implements PConstants {
    * @webref output:files
    * @param filename name of the file to open
    * @see PApplet#createInput(String)
-   * @see PApplet#selectOutput()
+   * @see PApplet#selectOutput(String,String)
    */
   public OutputStream createOutput(String filename) {
     return createOutput(saveFile(filename));
@@ -9327,7 +9328,7 @@ public class PApplet implements PConstants {
    * @see PApplet#nfs(float, int, int)
    * @see PApplet#nfp(float, int, int)
    * @see PApplet#nfc(float, int)
-   * @see PApplet#int(float)
+   * @see <a href="https://processing.org/reference/intconvert_.html">int(float)</a>
    */
   static public String nf(int num, int digits) {
     if ((int_nf != null) &&
@@ -10024,9 +10025,9 @@ public class PApplet implements PConstants {
    * sketch, rather than having to wrap it into a String array, and appending
    * the 'args' array when not null.
    * @param mainClass name of the class to load (with package if any)
-   * @param args command line arguments to pass to the sketch's 'args' array.
-   *             Note that this is *not* the same as the args passed to (and
-   *             understood by) PApplet such as --display.
+   * @param sketchArgs command line arguments to pass to the sketch's 'args'
+   *             array. Note that this is <i>not</i> the same as the args passed
+   *             to (and understood by) PApplet such as --display.
    */
   static public void main(final String mainClass, final String[] sketchArgs) {
     String[] args = new String[] { mainClass };
@@ -15005,8 +15006,8 @@ public class PApplet implements PConstants {
    *
    * @webref pimage:method
    * @usage web_application
+   * @param img image to use as the mask
    * @brief Masks part of an image with another image as an alpha channel
-   * @param maskArray array of integers used as the alpha channel, needs to be the same length as the image's pixel array
    */
   public void mask(PImage img) {
     if (recorder != null) recorder.mask(img);

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -937,6 +937,10 @@ public class PImage implements PConstants, Cloneable {
 
 
   @Deprecated
+  /**
+   * @param maskArray array of integers used as the alpha channel, needs to be
+   * the same length as the image's pixel array.
+   */
   public void mask(int maskArray[]) {  // ignore
     loadPixels();
     // don't execute if mask image is different size
@@ -983,8 +987,8 @@ public class PImage implements PConstants, Cloneable {
    *
    * @webref pimage:method
    * @usage web_application
+   * @param img image to use as the mask
    * @brief Masks part of an image with another image as an alpha channel
-   * @param maskArray array of integers used as the alpha channel, needs to be the same length as the image's pixel array
    */
   public void mask(PImage img) {
     img.loadPixels();

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2940,8 +2940,8 @@ public class PShape implements PConstants {
    * @webref pshape:method
    * @usage web_application
    * @brief Displaces the shape
-   * @param tx left/right translation
-   * @param ty up/down translation
+   * @param x left/right translation
+   * @param y up/down translation
    * @see PShape#rotate(float)
    * @see PShape#scale(float)
    * @see PShape#resetMatrix()
@@ -2952,7 +2952,7 @@ public class PShape implements PConstants {
   }
 
   /**
-   * @param tz forward/back translation
+   * @param z forward/back translation
    */
   public void translate(float x, float y, float z) {
     checkMatrix(3);

--- a/core/src/processing/core/PSurface.java
+++ b/core/src/processing/core/PSurface.java
@@ -97,14 +97,14 @@ public interface PSurface {
 
   public void setSize(int width, int height);
 
-  /**
-   * Called by {@link PApplet#createGraphics} to initialize the
-   * {@link PGraphics#image} object with an image that's compatible with this
-   * drawing surface/display/hardware.
-   * @param gr PGraphics object whose image will be set
-   * @param wide
-   * @param high
-   */
+//  /**
+//   * Called by {@link PApplet#createGraphics} to initialize the
+//   * {@link PGraphics#image} object with an image that's compatible with this
+//   * drawing surface/display/hardware.
+//   * @param gr PGraphics object whose image will be set
+//   * @param wide
+//   * @param high
+//   */
   // create pixel buffer (pulled out for offscreen graphics)
   //public void initImage(PGraphics gr, int wide, int high);
   // create pixel buffer, called from allocate() to produce a compatible image for rendering efficiently

--- a/core/src/processing/data/JSONArray.java
+++ b/core/src/processing/data/JSONArray.java
@@ -125,7 +125,7 @@ public class JSONArray {
    * Construct a JSONArray from a JSONTokener.
    *
    * @param x A JSONTokener
-   * @throws JSONException If there is a syntax error.
+   * @throws RuntimeException If there is a syntax error.
    * @nowebref
    */
   protected JSONArray(JSONTokener x) {
@@ -199,7 +199,7 @@ public class JSONArray {
    * @param source     A string that begins with
    * <code>[</code>&nbsp;<small>(left bracket)</small>
    *  and ends with <code>]</code>&nbsp;<small>(right bracket)</small>.
-   *  @throws JSONException If there is a syntax error.
+   *  @return {@code null} if there is a syntax error.
    */
   static public JSONArray parse(String source) {
     try {
@@ -228,7 +228,7 @@ public class JSONArray {
   // TODO not decided whether we keep this one, but used heavily by JSONObject
   /**
    * Construct a JSONArray from an array
-   * @throws JSONException If not an array.
+   * @throws RuntimeException If not an array.
    */
   protected JSONArray(Object array) {
     this();
@@ -261,7 +261,7 @@ public class JSONArray {
    * Get the object value associated with an index.
    * @param index must be between 0 and length() - 1
    * @return An object value.
-   * @throws JSONException If there is no value for the index.
+   * @throws RuntimeException If there is no value for the index.
    */
   private Object get(int index) {
     Object object = opt(index);
@@ -279,7 +279,7 @@ public class JSONArray {
    * @brief Gets the String value associated with an index
    * @param index must be between 0 and length() - 1
    * @return      A string value.
-   * @throws JSONException If there is no string value for the index.
+   * @throws RuntimeException If there is no string value for the index.
    * @see JSONArray#getInt(int)
    * @see JSONArray#getFloat(int)
    * @see JSONArray#getBoolean(int)
@@ -314,7 +314,7 @@ public class JSONArray {
    * @brief Gets the int value associated with an index
    * @param index must be between 0 and length() - 1
    * @return The value.
-   * @throws JSONException If the key is not found or if the value is not a number.
+   * @throws RuntimeException If the key is not found or if the value is not a number.
    * @see JSONArray#getFloat(int)
    * @see JSONArray#getString(int)
    * @see JSONArray#getBoolean(int)
@@ -353,7 +353,7 @@ public class JSONArray {
    *
    * @param index The index must be between 0 and length() - 1
    * @return      The value.
-   * @throws   JSONException If the key is not found or if the value cannot
+   * @throws   RuntimeException If the key is not found or if the value cannot
    *  be converted to a number.
    */
   public long getLong(int index) {
@@ -415,7 +415,7 @@ public class JSONArray {
    *
    * @param index must be between 0 and length() - 1
    * @return      The value.
-   * @throws   JSONException If the key is not found or if the value cannot
+   * @throws   RuntimeException If the key is not found or if the value cannot
    *  be converted to a number.
    */
   public double getDouble(int index) {
@@ -456,7 +456,7 @@ public class JSONArray {
    * @brief Gets the boolean value associated with an index
    * @param index must be between 0 and length() - 1
    * @return      The truth.
-   * @throws JSONException If there is no value for the index or if the
+   * @throws RuntimeException If there is no value for the index or if the
    *  value is not convertible to boolean.
    * @see JSONArray#getInt(int)
    * @see JSONArray#getFloat(int)
@@ -502,7 +502,7 @@ public class JSONArray {
    * @brief Gets the JSONArray associated with an index value
    * @param index must be between 0 and length() - 1
    * @return A JSONArray value.
-   * @throws JSONException If there is no value for the index. or if the
+   * @throws RuntimeException If there is no value for the index. or if the
    * value is not a JSONArray
    * @see JSONArray#getJSONObject(int)
    * @see JSONArray#setJSONObject(int, JSONObject)
@@ -533,7 +533,7 @@ public class JSONArray {
    * @brief Gets the JSONObject associated with an index value
    * @param index the index value of the object to get
    * @return A JSONObject value.
-   * @throws JSONException If there is no value for the index or if the
+   * @throws RuntimeException If there is no value for the index or if the
    * value is not a JSONObject
    * @see JSONArray#getJSONArray(int)
    * @see JSONArray#setJSONObject(int, JSONObject)
@@ -740,7 +740,7 @@ public class JSONArray {
    * This will store the value as a double, since there are no floats in JSON.
    *
    * @param value a float value
-   * @throws JSONException if the value is not finite.
+   * @throws RuntimeException if the value is not finite.
    * @return this.
    */
   public JSONArray append(float value) {
@@ -753,7 +753,7 @@ public class JSONArray {
    *
    * @nowebref
    * @param value A double value.
-   * @throws JSONException if the value is not finite.
+   * @throws RuntimeException if the value is not finite.
    * @return this.
    */
   public JSONArray append(double value) {
@@ -837,7 +837,7 @@ public class JSONArray {
 //   * @param index The subscript.
 //   * @param value A Collection value.
 //   * @return      this.
-//   * @throws JSONException If the index is negative or if the value is
+//   * @throws RuntimeException If the index is negative or if the value is
 //   * not finite.
 //   */
 //  public JSONArray set(int index, Collection value) {
@@ -856,7 +856,7 @@ public class JSONArray {
    * @param index an index value
    * @param value the value to assign
    * @return this.
-   * @throws JSONException If the index is negative.
+   * @throws RuntimeException If the index is negative.
    * @see JSONArray#setInt(int, int)
    * @see JSONArray#setFloat(int, float)
    * @see JSONArray#setBoolean(int, boolean)
@@ -877,7 +877,7 @@ public class JSONArray {
    * @param index an index value
    * @param value the value to assign
    * @return this.
-   * @throws JSONException If the index is negative.
+   * @throws RuntimeException If the index is negative.
    * @see JSONArray#setFloat(int, float)
    * @see JSONArray#setString(int, String)
    * @see JSONArray#setBoolean(int, boolean)
@@ -895,7 +895,7 @@ public class JSONArray {
    * @param index The subscript.
    * @param value A long value.
    * @return this.
-   * @throws JSONException If the index is negative.
+   * @throws RuntimeException If the index is negative.
    */
   public JSONArray setLong(int index, long value) {
     return set(index, Long.valueOf(value));
@@ -931,7 +931,7 @@ public class JSONArray {
    * @param index The subscript.
    * @param value A double value.
    * @return this.
-   * @throws JSONException If the index is negative or if the value is
+   * @throws RuntimeException If the index is negative or if the value is
    * not finite.
    */
   public JSONArray setDouble(int index, double value) {
@@ -949,7 +949,7 @@ public class JSONArray {
    * @param index an index value
    * @param value the value to assign
    * @return this.
-   * @throws JSONException If the index is negative.
+   * @throws RuntimeException If the index is negative.
    * @see JSONArray#setInt(int, int)
    * @see JSONArray#setFloat(int, float)
    * @see JSONArray#setString(int, String)
@@ -965,7 +965,7 @@ public class JSONArray {
 //   * @param index The subscript.
 //   * @param value The Map value.
 //   * @return      this.
-//   * @throws JSONException If the index is negative or if the the value is
+//   * @throws RuntimeException If the index is negative or if the the value is
 //   *  an invalid number.
 //   */
 //  public JSONArray set(int index, Map value) {
@@ -1011,7 +1011,7 @@ public class JSONArray {
    *  Boolean, Double, Integer, JSONArray, JSONObject, Long, or String, or the
    *  JSONObject.NULL object.
    * @return this.
-   * @throws JSONException If the index is negative or if the the value is
+   * @throws RuntimeException If the index is negative or if the the value is
    *  an invalid number.
    */
   private JSONArray set(int index, Object value) {
@@ -1192,7 +1192,7 @@ public class JSONArray {
    * @param indent
    *            The indention of the top level.
    * @return The writer.
-   * @throws JSONException
+   * @throws RuntimeException
    */
   protected Writer writeInternal(Writer writer, int indentFactor, int indent) {
     try {
@@ -1243,7 +1243,7 @@ public class JSONArray {
    * Warning: This method assumes that the data structure is acyclic.
    * @param separator A string that will be inserted between the elements.
    * @return a string.
-   * @throws JSONException If the array contains an invalid number.
+   * @throws RuntimeException If the array contains an invalid number.
    */
   public String join(String separator) {
     int len = this.size();

--- a/core/src/processing/data/JSONObject.java
+++ b/core/src/processing/data/JSONObject.java
@@ -95,7 +95,7 @@ import processing.core.PApplet;
  * <code>{ } [ ] / \ : , = ; #</code> and if they do not look like numbers and
  * if they are not the reserved words <code>true</code>, <code>false</code>, or
  * <code>null</code>.</li>
- * <li>Keys can be followed by <code>=</code> or <code>=></code> as well as by
+ * <li>Keys can be followed by <code>=</code> or {@code =>} as well as by
  * <code>:</code>.</li>
  * <li>Values can be followed by <code>;</code> <small>(semicolon)</small> as
  * well as by <code>,</code> <small>(comma)</small>.</li>
@@ -207,8 +207,6 @@ public class JSONObject {
 //   * Missing keys are ignored.
 //   * @param jo A JSONObject.
 //   * @param names An array of strings.
-//   * @throws JSONException
-//   * @exception JSONException If a value is a non-finite number or if a name is duplicated.
 //   */
 //  public JSONObject(JSONObject jo, String[] names) {
 //    this();
@@ -232,7 +230,7 @@ public class JSONObject {
   /**
    * Construct a JSONObject from a JSONTokener.
    * @param x A JSONTokener object containing the source string.
-   * @throws JSONException If there is a syntax error in the source string
+   * @throws RuntimeException If there is a syntax error in the source string
    *  or a duplicated key.
    */
   protected JSONObject(JSONTokener x) {
@@ -291,7 +289,6 @@ public class JSONObject {
    *
    * @param map A map object that can be used to initialize the contents of
    *  the JSONObject.
-   * @throws JSONException
    */
   protected JSONObject(HashMap<String, Object> map) {
     this.map = new HashMap<String, Object>();
@@ -397,7 +394,7 @@ public class JSONObject {
    * @param source    A string beginning
    *  with <code>{</code>&nbsp;<small>(left brace)</small> and ending
    *  with <code>}</code>&nbsp;<small>(right brace)</small>.
-   * @exception JSONException If there is a syntax error in the source
+   * @exception RuntimeException If there is a syntax error in the source
    *  string or a duplicated key.
    */
   static public JSONObject parse(String source) {
@@ -538,7 +535,7 @@ public class JSONObject {
    *
    * @param key   A key string.
    * @return      The object associated with the key.
-   * @throws      JSONException if the key is not found.
+   * @throws      RuntimeException if the key is not found.
    */
   private Object get(String key) {
     if (key == null) {
@@ -559,7 +556,7 @@ public class JSONObject {
    * @brief Gets the string value associated with a key
    * @param key a key string
    * @return A string which is the value.
-   * @throws JSONException if there is no string value for the key.
+   * @throws RuntimeException if there is no string value for the key.
    * @see JSONObject#getInt(String)
    * @see JSONObject#getFloat(String)
    * @see JSONObject#getBoolean(String)
@@ -594,7 +591,7 @@ public class JSONObject {
    * @brief Gets the int value associated with a key
    * @param key A key string.
    * @return The integer value.
-   * @throws JSONException if the key is not found or if the value cannot
+   * @throws RuntimeException if the key is not found or if the value cannot
    *  be converted to an integer.
    * @see JSONObject#getFloat(String)
    * @see JSONObject#getString(String)
@@ -636,7 +633,7 @@ public class JSONObject {
    *
    * @param key   A key string.
    * @return      The long value.
-   * @throws   JSONException if the key is not found or if the value cannot
+   * @throws   RuntimeException if the key is not found or if the value cannot
    *  be converted to a long.
    */
   public long getLong(String key) {
@@ -696,7 +693,7 @@ public class JSONObject {
    * Get the double value associated with a key.
    * @param key   A key string.
    * @return      The numeric value.
-   * @throws JSONException if the key is not found or
+   * @throws RuntimeException if the key is not found or
    *  if the value is not a Number object and cannot be converted to a number.
    */
   public double getDouble(String key) {
@@ -737,7 +734,7 @@ public class JSONObject {
    * @brief Gets the boolean value associated with a key
    * @param key a key string
    * @return The truth.
-   * @throws JSONException if the value is not a Boolean or the String "true" or "false".
+   * @throws RuntimeException if the value is not a Boolean or the String "true" or "false".
    * @see JSONObject#getInt(String)
    * @see JSONObject#getFloat(String)
    * @see JSONObject#getString(String)
@@ -782,7 +779,7 @@ public class JSONObject {
    * @brief Gets the JSONArray value associated with a key
    * @param key a key string
    * @return A JSONArray which is the value.
-   * @throws JSONException if the key is not found or if the value is not a JSONArray.
+   * @throws RuntimeException if the key is not found or if the value is not a JSONArray.
    * @see JSONObject#getJSONObject(String)
    * @see JSONObject#setJSONObject(String, JSONObject)
    * @see JSONObject#setJSONArray(String, JSONArray)
@@ -803,7 +800,7 @@ public class JSONObject {
    * @brief Gets the JSONObject value associated with a key
    * @param key a key string
    * @return A JSONObject which is the value.
-   * @throws JSONException if the key is not found or if the value is not a JSONObject.
+   * @throws RuntimeException if the key is not found or if the value is not a JSONObject.
    * @see JSONObject#getJSONArray(String)
    * @see JSONObject#setJSONObject(String, JSONObject)
    * @see JSONObject#setJSONArray(String, JSONArray)
@@ -964,7 +961,7 @@ public class JSONObject {
    * Produce a string from a Number.
    * @param  number A Number
    * @return A String.
-   * @throws JSONException If n is a non-finite number.
+   * @throws RuntimeException If number is null or a non-finite number.
    */
   private static String numberToString(Number number) {
     if (number == null) {
@@ -1164,7 +1161,7 @@ public class JSONObject {
    * @param key a key string
    * @param value the value to assign
    * @return this.
-   * @throws JSONException If the key is null.
+   * @throws RuntimeException If the key is null.
    * @see JSONObject#setFloat(String, float)
    * @see JSONObject#setString(String, String)
    * @see JSONObject#setBoolean(String, boolean)
@@ -1181,7 +1178,7 @@ public class JSONObject {
    * @param key   A key string.
    * @param value A long which is the value.
    * @return this.
-   * @throws JSONException If the key is null.
+   * @throws RuntimeException If the key is null.
    */
   public JSONObject setLong(String key, long value) {
     this.put(key, Long.valueOf(value));
@@ -1193,6 +1190,7 @@ public class JSONObject {
    * @brief Put a key/float pair in the JSONObject
    * @param key a key string
    * @param value the value to assign
+   * @throws RuntimeException If the key is null or if the number is NaN or infinite.
    * @see JSONObject#setInt(String, int)
    * @see JSONObject#setString(String, String)
    * @see JSONObject#setBoolean(String, boolean)
@@ -1209,7 +1207,7 @@ public class JSONObject {
    * @param key   A key string.
    * @param value A double which is the value.
    * @return this.
-   * @throws JSONException If the key is null or if the number is invalid.
+   * @throws RuntimeException If the key is null or if the number is NaN or infinite.
    */
   public JSONObject setDouble(String key, double value) {
     this.put(key, new Double(value));
@@ -1225,7 +1223,7 @@ public class JSONObject {
    * @param key a key string
    * @param value the value to assign
    * @return this.
-   * @throws JSONException If the key is null.
+   * @throws RuntimeException If the key is null.
    * @see JSONObject#setInt(String, int)
    * @see JSONObject#setFloat(String, float)
    * @see JSONObject#setString(String, String)
@@ -1299,7 +1297,7 @@ public class JSONObject {
    *  types: Boolean, Double, Integer, JSONArray, JSONObject, Long, String,
    *  or the JSONObject.NULL object.
    * @return this.
-   * @throws JSONException If the value is non-finite number
+   * @throws RuntimeException If the value is non-finite number
    *  or if the key is null.
    */
   private JSONObject put(String key, Object value) {
@@ -1332,8 +1330,9 @@ public class JSONObject {
    * with that name.
    * @param key
    * @param value
-   * @return his.
-   * @throws JSONException if the key is a duplicate
+   * @return {@code this}.
+   * @throws RuntimeException if the key is a duplicate, or if
+   * {@link #put(String,Object)} throws.
    */
   private JSONObject putOnce(String key, Object value) {
     if (key != null && value != null) {
@@ -1510,8 +1509,9 @@ public class JSONObject {
 
   /**
    * Throw an exception if the object is a NaN or infinite number.
-   * @param o The object to test.
-   * @throws JSONException If o is a non-finite number.
+   * @param o The object to test. If not Float or Double, accepted without
+   *    exceptions.
+   * @throws RuntimeException If o is infinite or NaN.
    */
   static protected void testValidity(Object o) {
     if (o != null) {
@@ -1616,7 +1616,7 @@ public class JSONObject {
    *  representation of the object, beginning
    *  with <code>{</code>&nbsp;<small>(left brace)</small> and ending
    *  with <code>}</code>&nbsp;<small>(right brace)</small>.
-   * @throws JSONException If the object contains an invalid number.
+   * @throws RuntimeException If the object contains an invalid number.
    */
   public String format(int indentFactor) {
     StringWriter w = new StringWriter();
@@ -1644,7 +1644,7 @@ public class JSONObject {
    *  representation of the object, beginning
    *  with <code>{</code>&nbsp;<small>(left brace)</small> and ending
    *  with <code>}</code>&nbsp;<small>(right brace)</small>.
-   * @throws JSONException If the value is or contains an invalid number.
+   * @throws RuntimeException If the value is or contains an invalid number.
    */
   static protected String valueToString(Object value) {
     if (value == null || value.equals(null)) {
@@ -1797,7 +1797,7 @@ public class JSONObject {
    * Warning: This method assumes that the data structure is acyclical.
    *
    * @return The writer.
-   * @throws JSONException
+   * @throws RuntimeException
    */
   protected Writer writeInternal(Writer writer, int indentFactor, int indent) {
     try {

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -3577,7 +3577,7 @@ public class Table {
   /**
    * Return a list of rows that contain the String passed in. If there are no
    * matches, a zero length array will be returned (not a null array).
-   * @param what the String to match
+   * @param regexp the String to match
    * @param column ID number of the column to search
    */
   public int[] matchRowIndices(String regexp, int column) {
@@ -3762,7 +3762,7 @@ public class Table {
   /**
    * Run String.replaceAll() on all entries in a column.
    * Only works with columns that are already String values.
-   * @param what the String to match
+   * @param regex the String to match
    * @param columnName title of the column to search
    */
   public void replaceAll(String regex, String replacement, String columnName) {

--- a/core/src/processing/data/XML.java
+++ b/core/src/processing/data/XML.java
@@ -45,7 +45,6 @@ import processing.core.PApplet;
  * representing a single node of an XML tree.
  *
  * @webref data:composite
- * @see PApplet#createXML(String)
  * @see PApplet#loadXML(String)
  * @see PApplet#parseXML(String)
  * @see PApplet#saveXML(XML, String)

--- a/core/src/processing/opengl/LinePath.java
+++ b/core/src/processing/opengl/LinePath.java
@@ -159,7 +159,7 @@ public class LinePath {
    *
    * @param rule
    *          the winding rule
-   * @param initialTypes
+   * @param initialCapacity
    *          the size to make the initial array to store the path segment types
    */
   public LinePath(int rule, int initialCapacity) {
@@ -415,7 +415,7 @@ public class LinePath {
    *          the original path to be stroked
    * @param weight
    *          the weight of the stroked path
-   * @param cap
+   * @param caps
    *          the decoration of the ends of the segments in the path
    * @param join
    *          the decoration applied where path segments meet

--- a/java/libraries/dxf/src/processing/dxf/RawDXF.java
+++ b/java/libraries/dxf/src/processing/dxf/RawDXF.java
@@ -31,13 +31,13 @@ import processing.core.*;
  * A simple library to write DXF files with Processing.
  * Because this is used with beginRaw() and endRaw(), only individual
  * triangles and (discontinuous) line segments will be written to the file.
- * <P/>
+ * <p>
  * Use something like a keyPressed() in PApplet to trigger it,
  * to avoid writing a bazillion .dxf files.
- * <P/>
+ * <p>
  * Usually, the file will be saved to the sketch's folder.
  * Use Sketch &rarr; Show Sketch Folder to see it from the PDE.
- * <p/>
+ * <p>
  * A simple example of how to use:
  * <PRE>
  * import processing.dxf.*;
@@ -104,7 +104,7 @@ import processing.core.*;
  * </PRE>
  * Note that even though this class is a subclass of PGraphics, it only
  * implements the parts of the API that are necessary for beginRaw/endRaw.
- * <P/>
+ * <p>
  * Based on the original DXF writer from Simon Greenwold, February 2004.
  * Updated for Processing 0070 by Ben Fry in September 2004,
  * and again for Processing beta in April 2005.

--- a/java/libraries/io/src/processing/io/SPI.java
+++ b/java/libraries/io/src/processing/io/SPI.java
@@ -145,7 +145,7 @@ public class SPI {
    *  Configures the SPI interface
    *  @param maxSpeed maximum transmission rate in Hz, 500000 (500 kHz) is a resonable default
    *  @param dataOrder whether data is send with the first- or least-significant bit first (SPI.MSBFIRST or SPI.LSBFIRST, the former is more common)
-   *  @param mode <a href="https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase">SPI.MODE0 to SPI.MODE3</br>
+   *  @param mode <a href="https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase">SPI.MODE0 to SPI.MODE3</a>
    *  @webref
    */
   public void settings(int maxSpeed, int dataOrder, int mode) {

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -533,7 +533,7 @@ public class Serial implements SerialPortEventListener {
    * @generate serialEvent.xml
    * @webref serial:events
    * @usage web_application
-   * @param serialPorttEvent the port where new data is available
+   * @param event the port where new data is available
    */
   public void serialEvent(SerialPortEvent event) {
     if (event.getEventType() == SerialPortEvent.RXCHAR) {


### PR DESCRIPTION
I'm trying to significantly reduce the number of error messages from the `ant doc` command, so that the genuine errors can be seen and dealt with. Currently, for example, there's an unclosed bold tag over a lot of an online Javadoc page. (It seems to have been fixed in the original files now though.)

This isn't finished yet; I'd like some advice. This first commit was just running [GenerateDescriptions.py](https://github.com/processing/processing-docs/blob/master/java_generate/GenerateDescriptions.py) with some patching/manual editing of files where it was broken. This was so that if I needed to modify and rerun the script or XMLs later, the later commits' diffs wouldn't contain ordinary updates to XML files.

The second commit fixes most of the errors except those in the HTML and syntax categories of Javadoc's Doc-lint tool, and suppresses the production of those messages by the Javadoc tool. It also makes the `@usage` and `@brief` tags display in the proper Javadoc, since that was an option I had when stopping them from being errors; I can hide them if preferred.

This just leaves the syntax errors. As far as I can tell, there's no way to stop Javadoc moaning about `<br />` but keep getting the useful messages about unclosed tags and other real errors. And there are *loads* of messages about `<br />`, making Javadoc's output almost unreadable if you don't suppress them. So: can I
* modify all the XML files to make them say `<br>` as preferred?
* modify the script to convert `<br />` to `<br>`?
* or just leave it alone and keep all syntax errors suppressed?

I'm asking because I don't know what else uses those files and how strict their XML needs to be. I'd also need to wrap code samples in the XMLs in `{@code }` tags where they contain angle brackets (which escapes them) to avoid filling the doc comments in the .java files with `&lt;&lt;=`; can all other users of the XML files handle that sort of Javadoc syntax?