### PR TITLE
Message pops up instead of blank window when sketchbook is empty

### DIFF
--- a/app/src/processing/app/ui/SketchbookFrame.java
+++ b/app/src/processing/app/ui/SketchbookFrame.java
@@ -31,6 +31,7 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.IOException;
 
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
@@ -141,7 +142,17 @@ public class SketchbookFrame extends JFrame {
           // Open the window relative to the editor
           setLocation(p.x - roughWidth, p.y);
         }
-        setVisible(true);
+        //Check whether sketch book is empty or not
+        DefaultMutableTreeNode checksb =
+          new DefaultMutableTreeNode(Language.text("sketchbook.tree"));
+        try {
+              //Opens sketch book only if created sketches exist
+              if (base.addSketches(checksb, Base.getSketchbookFolder(), false)) {
+                  setVisible(true);
+              }
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
       }
     });
   }

--- a/app/src/processing/app/ui/SketchbookFrame.java
+++ b/app/src/processing/app/ui/SketchbookFrame.java
@@ -33,7 +33,9 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
 
+import javax.swing.ImageIcon;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.border.EmptyBorder;
@@ -149,6 +151,10 @@ public class SketchbookFrame extends JFrame {
               //Opens sketch book only if created sketches exist
               if (base.addSketches(checksb, Base.getSketchbookFolder(), false)) {
                   setVisible(true);
+              } else {
+                //Shows message in case sketch book is empty
+                JOptionPane.showMessageDialog(getParent(), "Your Sketchbook is empty!",
+                "Message", DO_NOTHING_ON_CLOSE, new ImageIcon(Toolkit.getLibImage("icons/pde-32.png")));
               }
         } catch (IOException e) {
           e.printStackTrace();


### PR DESCRIPTION
Presently when the File->sketchbook button is clicked , window that appears is(if the sketchbook is empty)-
![screenshot from 2016-01-24 19 37 14](https://cloud.githubusercontent.com/assets/8044561/12536684/246db6f4-c2d2-11e5-80d4-fc3b1e00b238.png)

Instead of showing this blank window , I thought that it would be better if it shows some message like shown below-
![screenshot from 2016-01-24 19 29 26](https://cloud.githubusercontent.com/assets/8044561/12536648/6f981de6-c2d1-11e5-8850-51f714868e5b.png)
I've sent a pull request for the changes required. Please tell me if something other than this is required.