### PR TITLE
fix the composed text is shown doubly

### DIFF
--- a/app/src/processing/app/syntax/im/CompositionTextPainter.java
+++ b/app/src/processing/app/syntax/im/CompositionTextPainter.java
@@ -1,7 +1,6 @@
 package processing.app.syntax.im;
 
 import java.awt.Color;
-import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -83,9 +82,7 @@ public class CompositionTextPainter {
    * 
    * This draw method is proceeded with the following steps.
    * 1. Original TextAreaPainter draws characters. 
-   * 2. This refillComposedArea method erase previous paint characters by textarea's background color.
-   *    The refill area is only square that width and height defined by characters with input method.
-   * 3. CompositionTextPainter.draw method paints composed text. It was actually drawn by TextLayout.
+   * 2. CompositionTextPainter.draw method paints composed text. It was actually drawn by TextLayout.
    * 
    * @param gfx set TextAreaPainter's Graphics object.
    * @param fillBackGroundColor set textarea's background.
@@ -93,35 +90,34 @@ public class CompositionTextPainter {
   public void draw(Graphics gfx, Color fillBackGroundColor) {
     assert(composedTextLayout != null);
     Point composedLoc = getCaretLocation();
-    refillComposedArea(fillBackGroundColor, composedLoc.x, composedLoc.y);
+    //refillComposedArea(fillBackGroundColor, composedLoc.x, composedLoc.y);
     composedTextLayout.draw((Graphics2D) gfx, composedLoc.x, composedLoc.y);
   }
   
 
-  /**
-   * Fill color to erase characters drawn by original TextAreaPainter. 
-   *  
-   * @param fillColor fill color to erase characters drawn by original TextAreaPainter method.
-   * @param x x-coordinate where to fill.
-   * @param y y-coordinate where to fill.
-   */
-  private void refillComposedArea(Color fillColor, int x, int y) {
-    Graphics gfx = textArea.getPainter().getGraphics();
-    gfx.setColor(fillColor);
-    FontMetrics fm = textArea.getPainter().getFontMetrics();
-    int newY = y - (fm.getHeight() - CompositionTextManager.COMPOSING_UNDERBAR_HEIGHT);
-    int paintHeight = fm.getHeight();
-    int paintWidth = (int) composedTextLayout.getBounds().getWidth();
-    gfx.fillRect(x, newY, paintWidth, paintHeight);
-  }
+//  /**
+//   * Fill color to erase characters drawn by original TextAreaPainter. 
+//   *  
+//   * @param fillColor fill color to erase characters drawn by original TextAreaPainter method.
+//   * @param x x-coordinate where to fill.
+//   * @param y y-coordinate where to fill.
+//   */
+//  private void refillComposedArea(Color fillColor, int x, int y) {
+//    Graphics gfx = textArea.getPainter().getGraphics();
+//    gfx.setColor(fillColor);
+//    FontMetrics fm = textArea.getPainter().getFontMetrics();
+//    int newY = y - (fm.getHeight() - CompositionTextManager.COMPOSING_UNDERBAR_HEIGHT);
+//    int paintHeight = fm.getHeight();
+//    int paintWidth = (int) composedTextLayout.getBounds().getWidth();
+//    gfx.fillRect(x, newY, paintWidth, paintHeight);
+//  }
   
 
   private Point getCaretLocation() {
-    FontMetrics fm = textArea.getPainter().getFontMetrics();
-    int offsetY = fm.getHeight() - CompositionTextManager.COMPOSING_UNDERBAR_HEIGHT;
-    int lineIndex = textArea.getCaretLine();
-    int offsetX = composedBeginCaretPosition - textArea.getLineStartOffset(lineIndex);
-    return new Point(textArea.offsetToX(lineIndex, offsetX), 
-                     (lineIndex - textArea.getFirstLine()) * fm.getHeight() + offsetY);
+    int line = textArea.getCaretLine();
+    int offsetX = composedBeginCaretPosition - textArea.getLineStartOffset(line);
+    // '+1' mean textArea.lineToY(line) + textArea.getPainter().getFontMetrics().getHeight().
+    // TextLayout#draw method need at least one height of font.
+    return new Point(textArea.offsetToX(line, offsetX), textArea.lineToY(line + 1));
   }
 }


### PR DESCRIPTION
Hi all,

long time, the composed text of the Input method  is shown doubly. I changed the processing.app.syntax.im package. I don't test Mac OSX and Linux.

- remove draw rectangle logic. because the processing3 don't draw correctly by double buffering.
- input method support antialias.
- calculate by font metrics, so maybe fix #3860.

**before:**
![01](https://cloud.githubusercontent.com/assets/16870334/12540929/f1eead42-c352-11e5-9bcf-325078444753.png)

**after:**
![02](https://cloud.githubusercontent.com/assets/16870334/12540931/f442382a-c352-11e5-8f18-4c994e68c712.png)

**my environment**
- Windows 8.1 Pro 64bit