### PR TITLE
 'Background Color when Presenting' not visible on Preferences window

### DIFF
--- a/app/src/processing/app/ui/PreferencesFrame.java
+++ b/app/src/processing/app/ui/PreferencesFrame.java
@@ -165,7 +165,8 @@ public class PreferencesFrame {
 
     presentColor = new JTextField("      ");
     presentColor.setOpaque(true);
-    presentColor.setEnabled(false);
+    presentColor.setEnabled(true);
+    presentColor.setEditable(false);
     Border cb = new CompoundBorder(BorderFactory.createMatteBorder(1, 1, 0, 0, new Color(195, 195, 195)),
                                    BorderFactory.createMatteBorder(0, 0, 1, 1, new Color(54, 54, 54)));
     presentColor.setBorder(cb);


### PR DESCRIPTION
This patch fixes the issue -> https://github.com/processing/processing/issues/4272

***Color selector icon*** in the ***Preferences*** window will now be able to update it's color depending upon user's color selection in Color Selector panel.