### PR TITLE
Fixed InputMethod Chiese/Japanese/Korean support.

### DIFF
--- a/app/src/processing/app/syntax/im/InputMethodSupport.java
+++ b/app/src/processing/app/syntax/im/InputMethodSupport.java
@@ -1,120 +1,239 @@
 package processing.app.syntax.im;
 
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.event.InputMethodEvent;
 import java.awt.event.InputMethodListener;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextAttribute;
 import java.awt.font.TextHitInfo;
+import java.awt.font.TextLayout;
 import java.awt.im.InputMethodRequests;
 import java.text.AttributedCharacterIterator;
+import java.text.AttributedCharacterIterator.Attribute;
 
+import javax.swing.text.BadLocationException;
+
+import java.text.AttributedString;
+
+import processing.app.Base;
+import processing.app.Messages;
+import processing.app.Preferences;
 import processing.app.syntax.JEditTextArea;
+import processing.app.syntax.TextAreaPainter;
 
 /**
- * Support in-line Japanese input for PDE. (Maybe Chinese, Korean and more)
- * This class is implemented by Java Input Method Framework and handles
- * If you would like to know more about Java Input Method Framework,
- * Please see http://java.sun.com/j2se/1.5.0/docs/guide/imf/
- * 
- * This class is implemented to fix Bug #854.
- * http://dev.processing.org/bugs/show_bug.cgi?id=854
+ * on-the-spot style input support for CJK.(Chinese, Japanese, Korean).
+ * This class is implemented to fix Bug #854 from 2010-02-16.
+ *
+ * @see <a href="https://processing.org/bugs/bugzilla/854.html">Bug 854 : implement input method support for Japanese (and other languages)</a>
+ * @see <a href="https://processing.org/bugs/bugzilla/1531.html">Bug 1531 : Can't input full-width space when Japanese IME is on.</a>
+ * @see http://docs.oracle.com/javase/8/docs/technotes/guides/imf/index.html
+ * @see http://docs.oracle.com/javase/tutorial/2d/text/index.html
  *  
  * @author Takashi Maekawa (takachin@generative.info)
+ * @author Satoshi Okita
  */
 public class InputMethodSupport implements InputMethodRequests,
     InputMethodListener {
 
+  private static final Attribute[] CUSTOM_IM_ATTRIBUTES = {
+    TextAttribute.INPUT_METHOD_HIGHLIGHT,
+  };
+  
   private int committed_count = 0;
-  private CompositionTextManager textManager;
+  private TextHitInfo caret;
+  private JEditTextArea textArea;
+  private AttributedCharacterIterator composedText;
+  private AttributedString composedTextString;
 
   public InputMethodSupport(JEditTextArea textArea) {
-    textManager = new CompositionTextManager(textArea);
-    textArea.enableInputMethods(true);
-    textArea.addInputMethodListener(this);
+    this.textArea = textArea;
+    this.textArea.enableInputMethods(true);
+    this.textArea.addInputMethodListener(this);
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+  // InputMethodRequest
+  /////////////////////////////////////////////////////////////////////////////
+  @Override
   public Rectangle getTextLocation(TextHitInfo offset) {
-    return textManager.getTextLocation();
+    if (Base.DEBUG) {
+      Messages.log("#Called getTextLocation:" + offset);
+    }
+    int line = textArea.getCaretLine();
+    int offsetX = textArea.getCaretPosition() - textArea.getLineStartOffset(line);
+    // '+1' mean textArea.lineToY(line) + textArea.getPainter().getFontMetrics().getHeight().
+    // TextLayout#draw method need at least one height of font.
+    Rectangle rectangle = new Rectangle(textArea.offsetToX(line, offsetX), textArea.lineToY(line + 1), 0, 0);
+    
+    Point location = textArea.getPainter().getLocationOnScreen();
+    rectangle.translate(location.x, location.y);
+    
+    return rectangle;
   }
 
+
+  @Override
   public TextHitInfo getLocationOffset(int x, int y) {
     return null;
   }
 
+  @Override
   public int getInsertPositionOffset() {
-    return textManager.getInsertPositionOffset();
+    return textArea.getCaretPosition() * -1;
   }
-
+  
+  @Override
   public AttributedCharacterIterator getCommittedText(int beginIndex,
       int endIndex, AttributedCharacterIterator.Attribute[] attributes) {
-    return textManager.getCommittedText(beginIndex, endIndex);
+    int length = endIndex - beginIndex;
+    String textAreaString = textArea.getText(beginIndex, length);
+    return new AttributedString(textAreaString).getIterator();
   }
 
+  @Override
   public int getCommittedTextLength() {
     return committed_count;
   }
 
+  @Override
   public AttributedCharacterIterator cancelLatestCommittedText(
       AttributedCharacterIterator.Attribute[] attributes) {
     return null;
   }
 
+  @Override
   public AttributedCharacterIterator getSelectedText(
       AttributedCharacterIterator.Attribute[] attributes) {
     return null;
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+  // InputMethodListener
+  /////////////////////////////////////////////////////////////////////////////
   /**
    * Handles events from InputMethod.
-   * This method judges whether beginning of input or 
-   * progress of input or end and call related method.
    * 
    * @param event event from Input Method.
    */
-  public void inputMethodTextChanged(InputMethodEvent event) {
-    AttributedCharacterIterator text = event.getText();
+  @Override
+  public void inputMethodTextChanged(InputMethodEvent event) {    
+    composedText = null;
+    if (Base.DEBUG) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("#Called inputMethodTextChanged");
+      sb.append("\t ID: " + event.getID());
+      sb.append("\t timestamp: " + new java.util.Date(event.getWhen()));
+      sb.append("\t parmString: " + event.paramString());
+      Messages.log(sb.toString());
+    }
+    
+    AttributedCharacterIterator text = event.getText(); // text = composedText + commitedText
     committed_count = event.getCommittedCharacterCount();
-    if(isFullWidthSpaceInput(text)){
-      textManager.insertFullWidthSpace();
-      caretPositionChanged(event);
-      return;
+    
+    
+    // The caret for Input Method.
+    // if you type a character by a input method, original caret become off.
+    // a JEditTextArea is not implemented by the AttributedStirng and TextLayout.
+    // so JEditTextArea Caret On-off logic.
+    // 
+    // japanese        : if the enter key pressed, event.getText is null.
+    // japanese        : if first space key pressed, event.getText is null.
+    // chinese(pinin)  : if a space key pressed, event.getText is null.
+    // taiwan(bopomofo): ?
+    // korean          : ?
+    textArea.setCaretVisible(false);
+    // Korean Input Method
+    if (text != null && text.getEndIndex() - (text.getBeginIndex() + committed_count) <= 0) {
+      textArea.setCaretVisible(true);
     }
-    if(isBeginInputProcess(text, textManager)){
-      textManager.beginCompositionText(text, committed_count);
-      caretPositionChanged(event);
-      return;
+    // Japanese Input Method
+    if (text == null) {
+      textArea.setCaretVisible(true);
     }
-    if (isInputProcess(text)){
-      textManager.processCompositionText(text, committed_count);
-      caretPositionChanged(event);
-      return;
-    }
-    textManager.endCompositionText(text, committed_count);
-    caretPositionChanged(event);
-  }
-  
-  private boolean isFullWidthSpaceInput(AttributedCharacterIterator text){
-    if(text == null)
-      return false;
-    if(textManager.getIsInputProcess())
-      return false;
-    return (String.valueOf(text.first()).equals("\u3000"));
-  }
-  
-  private boolean isBeginInputProcess(AttributedCharacterIterator text, CompositionTextManager textManager){
-    if(text == null)
-      return false;
-    if(textManager.getIsInputProcess())
-      return false;
-    return (isInputProcess(text));
-  }
 
-  private boolean isInputProcess(AttributedCharacterIterator text){
-    if(text == null)
-      return false;
-    return (text.getEndIndex() - (text.getBeginIndex() + committed_count) > 0);
-  }
-
-  public void caretPositionChanged(InputMethodEvent event) {
+    char c;
+    if (text != null) {
+      int toCopy = committed_count;
+      c = text.first();
+      while (toCopy-- > 0) {
+        if (Base.DEBUG) {
+          Messages.log("INSERT:'" + c + "'");
+        }
+        this.insertCharacter(c);
+        c = text.next();
+      }
+      
+      CompositionTextPainter compositionPainter = textArea.getPainter().getCompositionTextpainter();
+      if (Base.DEBUG) {
+        Messages.log(" textArea.getCaretPosition() + committed_count: " + (textArea.getCaretPosition() + committed_count));
+      }
+      compositionPainter.setComposedTextLayout(getTextLayout(text, committed_count), textArea.getCaretPosition() + committed_count);
+      compositionPainter.setCaret(event.getCaret());
+    } else {
+      // hide input method.
+      CompositionTextPainter compositionPainter = textArea.getPainter().getCompositionTextpainter();
+      compositionPainter.setComposedTextLayout(null, 0);
+      compositionPainter.setCaret(null);
+    }
+    caret = event.getCaret();
     event.consume();
+    textArea.repaint(); 
+  }
+  
+  private TextLayout getTextLayout(AttributedCharacterIterator text, int committedCount) {
+    boolean antialias = Preferences.getBoolean("editor.smooth");
+    TextAreaPainter painter = textArea.getPainter();
+    
+    // create attributed string with font info.
+    //if (text.getEndIndex() - (text.getBeginIndex() + committedCharacterCount) > 0) {
+    if (text.getEndIndex() - (text.getBeginIndex() + committedCount) > 0) {
+      composedTextString = new AttributedString(text, committedCount, text.getEndIndex(), CUSTOM_IM_ATTRIBUTES);
+      Font font = painter.getFontMetrics().getFont();
+      composedTextString.addAttribute(TextAttribute.FONT, font);
+      composedTextString.addAttribute(TextAttribute.BACKGROUND, Color.WHITE);
+      composedText = composedTextString.getIterator();
+    } else {
+      composedTextString = new AttributedString("");
+      return null;
+    }
+    
+    // set hint of antialiasing to render target.
+    Graphics2D g2d = (Graphics2D)painter.getGraphics();
+    g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                        antialias ?
+                        RenderingHints.VALUE_TEXT_ANTIALIAS_ON :
+                        RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+    FontRenderContext frc = g2d.getFontRenderContext();
+    if (Base.DEBUG) {
+      Messages.log("debug: FontRenderContext is Antialiased = " + frc.getAntiAliasingHint());
+    }
+
+    return new TextLayout(composedTextString.getIterator(), frc);
+  }
+
+  @Override
+  public void caretPositionChanged(InputMethodEvent event) {
+    caret = event.getCaret();
+    event.consume();
+  }
+  
+  private void insertCharacter(char c) {
+    if (Base.DEBUG) {
+      Messages.log("debug: insertCharacter(char c) textArea.getCaretPosition()=" + textArea.getCaretPosition());
+    }
+    try {
+      textArea.getDocument().insertString(textArea.getCaretPosition(), Character.toString(c), null);
+      if (Base.DEBUG) {
+        Messages.log("debug: \t after:insertCharacter(char c) textArea.getCaretPosition()=" + textArea.getCaretPosition());
+      }
+    } catch (BadLocationException e) {
+      e.printStackTrace();
+    }
   }
 }


### PR DESCRIPTION
current InputMethod of syntax.im package was only support Japanese. the Japanese Input Method and Chinese Input Method(this called pinyin) are similar system. but Korean Input Method is not.
I rewrited code for CJK support. and I tested only Windows8.1 64bit(Japanese). 
I dont test Mac OSX. (need test)

## fixed issue list
#2968
#3860
#3475


### Input Method key
Language | Commited text Trigger Key | toggle key to english
--- | --- | --- | ---
Japanese | Enter key or space key | hankaku Key
Chiese(Pinyin) | space key | left shift key
Chiese(Bopomofo) | space key  | left shift key
Korean(Hangl) | NO | right alt key

### screenshot
korean 
![01](https://cloud.githubusercontent.com/assets/16870334/13025241/f387d9e2-d245-11e5-902c-9796e53c9d25.png)

japanese
![02](https://cloud.githubusercontent.com/assets/16870334/13025244/f60c3654-d245-11e5-955f-1f2d6fcb29d6.png)

chinese
![03](https://cloud.githubusercontent.com/assets/16870334/13025245/f8cfbc76-d245-11e5-8d99-e2675c30cbb5.png)

#3475 fixed
![issue3475](https://cloud.githubusercontent.com/assets/16870334/13027446/2ae00592-d294-11e5-86a4-817d78d577a4.png)
