### PR TITLE
message when reference is find out on nothing selected

### DIFF
--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -328,6 +328,9 @@ public class JavaEditor extends Editor {
         if (textarea.isSelectionActive()) {
           handleFindReference();
         }
+        else {
+          statusNotice(Language.text("editor.status.find_reference.select_word_first"));
+        }
       }
     });
     menu.add(item);


### PR DESCRIPTION
When nothing is selected in editor, and then if someone clicks on Help->Find in Reference or Ctrl+Shift+F, then message gets displayed on message area as **'First Select a word to find in the Reference.'**