### PR TITLE
IO: Use GPIO numbers in examples

### DIFF
--- a/java/libraries/io/examples/Interrupt/Interrupt.pde
+++ b/java/libraries/io/examples/Interrupt/Interrupt.pde
@@ -1,20 +1,19 @@
 import processing.io.*;
 color bgcolor = 0;
 
-// RPI.PIN7 refers to the physical pin 7 on the Raspberry Pi's
-// pin header, which is located on the fourth row, above one of
-// the Ground pins
+// GPIO numbers refer to different phyiscal pins on various boards
+// On the Raspberry Pi GPIO 4 is physical pin 7 on the header
 
 void setup() {
-  GPIO.pinMode(RPI.PIN7, GPIO.INPUT);
-  GPIO.attachInterrupt(RPI.PIN7, this, "pinEvent", GPIO.RISING);
+  GPIO.pinMode(4, GPIO.INPUT);
+  GPIO.attachInterrupt(4, this, "pinEvent", GPIO.RISING);
 }
 
 void draw() {
   background(bgcolor);
 }
 
-// this function will be called whenever pin 7 is brought from LOW to HIGH
+// this function will be called whenever GPIO 4 is brought from LOW to HIGH
 void pinEvent(int pin) {
   println("Received interrupt");
   if (bgcolor == 0) {

--- a/java/libraries/io/examples/SimpleInput/SimpleInput.pde
+++ b/java/libraries/io/examples/SimpleInput/SimpleInput.pde
@@ -1,18 +1,15 @@
 import processing.io.*;
 
-// RPI.PIN7 refers to the physical pin 7 on the Raspberry Pi's
-// pin header, which is located on the fourth row, above one of
-// the Ground pins
+// GPIO numbers refer to different phyiscal pins on various boards
+// On the Raspberry Pi GPIO 4 is physical pin 7 on the header
 
 void setup() {
-  GPIO.pinMode(RPI.PIN7, GPIO.INPUT);
-  // this is equivalent to addressing the pin with its GPIO number:
-  // GPIO.pinMode(4, GPIO.INPUT);
+  GPIO.pinMode(4, GPIO.INPUT);
 }
 
 void draw() {
   // sense the input pin
-  if (GPIO.digitalRead(RPI.PIN7) == GPIO.HIGH) {
+  if (GPIO.digitalRead(4) == GPIO.HIGH) {
     fill(255);
   } else {
     fill(204);

--- a/java/libraries/io/examples/SimpleOutput/SimpleOutput.pde
+++ b/java/libraries/io/examples/SimpleOutput/SimpleOutput.pde
@@ -1,14 +1,11 @@
 import processing.io.*;
 boolean ledOn = false;
 
-// RPI.PIN7 refers to the physical pin 7 on the Raspberry Pi's
-// pin header, which is located on the fourth row, above one of
-// the Ground pins
+// GPIO numbers refer to different phyiscal pins on various boards
+// On the Raspberry Pi GPIO 4 is physical pin 7 on the header
 
 void setup() {
-  GPIO.pinMode(RPI.PIN7, GPIO.OUTPUT);
-  // this is equivalent to addressing the pin with its GPIO number:
-  // GPIO.pinMode(4, GPIO.OUTPUT);
+  GPIO.pinMode(4, GPIO.OUTPUT);
   frameRate(0.5);
 }
 
@@ -16,10 +13,10 @@ void draw() {
   // make the LED blink
   ledOn = !ledOn;
   if (ledOn) {
-    GPIO.digitalWrite(RPI.PIN7, GPIO.LOW);
+    GPIO.digitalWrite(4, GPIO.LOW);
     fill(204);
   } else {
-    GPIO.digitalWrite(RPI.PIN7, GPIO.HIGH);
+    GPIO.digitalWrite(4, GPIO.HIGH);
     fill(255);
   }
   stroke(255);


### PR DESCRIPTION
Even the Raspberry Pi Foundation used GPIO numbers over (congruous) physical pin numbers:
https://www.raspberrypi.org/learning/introduction-to-processing/worksheet-2/

Switch our examples as well, so that it they're more clear and hardware-agnostic.