### PR TITLE
Fixes non-arm linux deb build process

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -948,13 +948,13 @@
 
    <!-- Set properties for DEBIAN/control file -->
    <condition property="linux.deb" value="linux/processing-${version}-linux-armv6hf.deb">
-     <equals arg1="linux-arm32" arg2="linux-arm32" />
+     <equals arg1="${linux-arm32}" arg2="linux-arm32" />
    </condition>
    <property name="linux.deb" value="linux/processing-${version}-linux${sun.arch.data.model}.deb" />
 
    <!-- Raspbian seems to borrow armhf for armv6hf, so this works -->
    <condition property="deb.arch" value="armhf">
-     <equals arg1="linux-arm32" arg2="linux-arm32" />
+     <equals arg1="${linux-arm32}" arg2="linux-arm32" />
    </condition>
    <condition property="deb.arch" value="i386"> 
      <equals arg1="${sun.arch.data.model}" arg2="32" />


### PR DESCRIPTION
As discussed in Issue #4308 adding arm support for .deb broke the .deb build process for non-arm devices.  I've tested it and this commit allows .deb to be built on non-arm devices again.  I have not tested to verify if .debs can still be built on the raspberry pi.  Perhaps @gohai can verify this?