### PR TITLE
Fix a few undo-related bugs

### DIFF
--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -1429,7 +1429,6 @@ public class JEditTextArea extends JComponent
     }
   }
 
-
   /**
    * Replaces the selection with the specified text.
    * @param selectedText The replacement text for the selection

--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -1597,11 +1597,9 @@ public class JEditTextArea extends JComponent
     int caretLineEnd = getLineStopOffset(getCaretLine());
     if(caretLineEnd - caret <= str.length())
     {
-      setSelectedText(str);
+      setSelectedText(str, false);
       return;
     }
-
-    document.beginCompoundEdit();
 
     try
     {
@@ -1611,10 +1609,6 @@ public class JEditTextArea extends JComponent
     catch(BadLocationException bl)
     {
       bl.printStackTrace();
-    }
-    finally
-    {
-      document.endCompoundEdit();
     }
   }
 

--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -1429,15 +1429,30 @@ public class JEditTextArea extends JComponent
     }
   }
 
+
   /**
    * Replaces the selection with the specified text.
    * @param selectedText The replacement text for the selection
    */
   public void setSelectedText(String selectedText) {
+    setSelectedText(selectedText, false);
+  }
+
+
+  /**
+   * Replaces the selection with the specified text.
+   * @param selectedText The replacement text for the selection
+   * @param recordCompoundEdit Whether the replacement should be 
+   * recorded as a compound edit
+   */
+  public void setSelectedText(String selectedText, boolean recordCompoundEdit) {
     if (!editable) {
       throw new InternalError("Text component read only");
     }
-    document.beginCompoundEdit();
+    
+    if (recordCompoundEdit) {
+      document.beginCompoundEdit();
+    }
 
     try {
       if (rectSelect) {
@@ -1494,7 +1509,10 @@ public class JEditTextArea extends JComponent
 
     } finally {
       // No matter what happens... stops us from leaving document in a bad state
-      document.endCompoundEdit();
+      // (provided this has to be recorded as a compound edit, of course...)
+      if (recordCompoundEdit) {
+        document.endCompoundEdit();
+      }
     }
     setCaretPosition(selectionEnd);
   }
@@ -1566,7 +1584,10 @@ public class JEditTextArea extends JComponent
     // Don't overstrike if there is a selection
     if(!overwrite || selectionStart != selectionEnd)
     {
-      setSelectedText(str);
+      // record the whole operation as a compound edit if 
+      // selected text is being replaced
+      boolean isSelectAndReplaceOp = (selectionStart != selectionEnd);
+      setSelectedText(str, isSelectAndReplaceOp);
       return;
     }
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1711,7 +1711,20 @@ public abstract class Editor extends JFrame implements RunnerListener {
     SyntaxDocument document = (SyntaxDocument) code.getDocument();
 
     if (document == null) {  // this document not yet inited
-      document = new SyntaxDocument();
+      document = new SyntaxDocument() {
+        @Override
+        public void beginCompoundEdit() {
+          if (compoundEdit == null)
+            startCompoundEdit();
+          super.beginCompoundEdit();
+        }
+        
+        @Override
+        public void endCompoundEdit() {
+          stopCompoundEdit();
+          super.endCompoundEdit();
+        }
+      };
       code.setDocument(document);
 
       // turn on syntax highlighting

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -297,7 +297,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       String lastText = textarea.getText();
       public void caretUpdate(CaretEvent e) {
         String newText = textarea.getText();
-        if (lastText.equals(newText) && isDirectEdit()) {
+        if (lastText.equals(newText) && isDirectEdit() && !textarea.isOverwriteEnabled()) {
           endTextEditHistory();
         }
         lastText = newText;
@@ -1743,17 +1743,20 @@ public abstract class Editor extends JFrame implements RunnerListener {
       document.addDocumentListener(new DocumentListener() {
 
         public void removeUpdate(DocumentEvent e) {
-          if (isInserting && isDirectEdit()) {
+          if (isInserting && isDirectEdit() && !textarea.isOverwriteEnabled()) {
             endTextEditHistory();
           }
           isInserting = false;
         }
 
         public void insertUpdate(DocumentEvent e) {
-          if (!isInserting && isDirectEdit()) {
+          if (!isInserting && !textarea.isOverwriteEnabled() && isDirectEdit()) {
             endTextEditHistory();
           }
-          isInserting = true;
+          
+          if (!textarea.isOverwriteEnabled()) {
+            isInserting = true;
+          }
         }
 
         public void changedUpdate(DocumentEvent e) {

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1572,6 +1572,11 @@ public abstract class Editor extends JFrame implements RunnerListener {
   }
 
 
+  public void setSelectedText(String what, boolean ever) {
+    textarea.setSelectedText(what, ever);
+  }
+
+
   public void setSelection(int start, int stop) {
     // make sure that a tool isn't asking for a bad location
     start = PApplet.constrain(start, 0, textarea.getDocumentLength());

--- a/app/src/processing/app/ui/FindReplace.java
+++ b/app/src/processing/app/ui/FindReplace.java
@@ -417,15 +417,27 @@ public class FindReplace extends JFrame {
     replaceAndFindButton.setEnabled(found);
   }
 
+/**
+ * Replace the current selection with whatever's in the
+   * replacement text field.
+ * @param isCompoundEdit True if the action is to be marked as a copmound edit
+ */
+  public void replace(boolean isCompoundEdit) {
+    editor.setSelectedText(replaceField.getText(), isCompoundEdit);
+    
+    editor.getSketch().setModified(true);  // This necessary- calling replace()
+    // doesn't seem to mark a sketch as modified
+    
+    setFound(false);
+  }
+
 
   /**
    * Replace the current selection with whatever's in the
-   * replacement text field.
+   * replacement text field, marking the action as a compound edit.
    */
   public void replace() {
-    editor.setSelectedText(replaceField.getText());
-    editor.getSketch().setModified(true);  // TODO is this necessary?
-    setFound(false);
+    replace(true);
   }
 
 
@@ -451,6 +463,8 @@ public class FindReplace extends JFrame {
     int startTab = -1;
     int startIndex = -1;
     int counter = 10000;  // prevent infinite loop
+
+    editor.startCompoundEdit();
     while (--counter > 0) {
       if (find(false, false)) {
         int caret = editor.getSelectionStart();
@@ -467,11 +481,12 @@ public class FindReplace extends JFrame {
           startTab = editor.getSketch().getCurrentCodeIndex();
           startIndex = editor.getSelectionStart();
         }
-        replace();
+        replace(false);
      } else {
         break;
       }
     }
+    editor.stopCompoundEdit();
     if (!foundAtLeastOne) {
       Toolkit.beep();
     }


### PR DESCRIPTION
This PR attempts to resolve #4280, fix #4302 and close #4303.

#4303 was mostly an issue with not considering `Replace All` as a compound edit. I have left `Replace`s to be individually undo-able, since technically each `Replace` i a distinct operation (unlike `Replace All`s, which all happen at once).

I had to modify the `JEditTextArea` a little for #4280, because the replacement happens from within there, and there's no `Editor` object accessible (and hence, the `Editor`'s compound edit methods can't be called). The `SyntaxDocument` has compound edit methods, but they were left blank, and never overridden, so I now have.

#4302 was a little tougher to crack, but primarily boiled down to each insert and deletion being considered a separate compound edit, with replacements (i.e., entries in `Insert` mode) being modeled as a delete+insert, which kept triggering `endCompoundEdit()` and starting a new one. Another issue was that a compound edit ends whenever the text in the Editor is the same before and after a key press, which could happen when the user replace a line like `int k = 4;` with `int x = 5;' (several character overlap here, and the set of characters between each overlapping "block" would be undone at a go, and a block could be as small as a single character).

@benfry There are changes in here to a few of the methods, and how they are called, but I have tried to keep things as neat as possible. Could you please let me know if these changes are ok, if any modification to how changes have been incorporated need to be made, or if further changes are required? Thanks!