### PR TITLE
Add support for symlinks to exported applications in linux

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1280,7 +1280,8 @@ public class JavaBuild {
       // isn't used when exporting for Unix.
       pw.print("#!/bin/sh\n\n");
       //ps.print("APPDIR=`dirname $0`\n");
-      pw.print("APPDIR=$(dirname \"$0\")\n");  // more posix compliant
+      pw.print("APPDIR=$(readlink -f \"$0\")\n"); //Allow Symlinks
+      pw.print("APPDIR=$(dirname \"$APPDIR\")\n");  // more posix compliant
       // another fix for bug #234, LD_LIBRARY_PATH ignored on some platforms
       //ps.print("LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$APPDIR\n");
       if (embedJava) {


### PR DESCRIPTION
This PR addresses issue #4318 and allows exported linux applications to be launched via a symlink.