### PR TITLE
Added readBytes(max) to net library

### DIFF
--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -408,6 +408,36 @@ public class Client implements Runnable {
 
   /**
    * <h3>Advanced</h3>
+   * Return a byte array of anything that's in the serial buffer
+   * up to the specified maximum number of bytes.
+   * Not particularly memory/speed efficient, because it creates
+   * a byte array on each read, but it's easier to use than
+   * readBytes(byte b[]) (see below).
+   *
+   * @param max the maximum number of bytes to read
+   */
+  public byte[] readBytes(int max) {
+    if (bufferIndex == bufferLast) return null;
+
+    synchronized (buffer) {
+      int length = bufferLast - bufferIndex;
+      if (length > max) length = max;
+      byte outgoing[] = new byte[length];
+      System.arraycopy(buffer, bufferIndex, outgoing, 0, length);
+
+      bufferIndex += length;
+      if (bufferIndex == bufferLast) {
+        bufferIndex = 0;  // rewind
+        bufferLast = 0;
+      }
+
+      return outgoing;
+    }
+  }
+
+
+  /**
+   * <h3>Advanced</h3>
    * Grab whatever is in the serial buffer, and stuff it into a
    * byte buffer passed in by the user. This is more memory/time
    * efficient than readBytes() returning a byte[] array.


### PR DESCRIPTION
This adds the requested feature (issue #4167) to allow reading a specific number of bytes from a network Client.  I have tested out the new function and it appears to be working well.