### PR TITLE
Added readBytes(max) to serial library

### DIFF
--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -343,6 +343,37 @@ public class Serial implements SerialPortEventListener {
 
   /**
    * <h3>Advanced</h3>
+   * Return a byte array of anything that's in the serial buffer
+   * up to the specified maximum number of bytes.
+   * Not particularly memory/speed efficient, because it creates
+   * a byte array on each read, but it's easier to use than
+   * readBytes(byte b[]) (see below).
+   *
+   * @param max the maximum number of bytes to read
+   */
+  public byte[] readBytes(int max) {
+    if (inBuffer == readOffset) {
+      return null;
+    }
+
+    synchronized (buffer) {
+      int length = inBuffer - readOffset;
+      if (length > max) length = max;
+      byte[] ret = new byte[length];
+      System.arraycopy(buffer, readOffset, ret, 0, length);
+
+      readOffset += length;
+      if (inBuffer == readOffset) {
+        inBuffer = 0;
+        readOffset = 0;
+      }
+      return ret;
+    }
+  }
+
+
+  /**
+   * <h3>Advanced</h3>
    * Grab whatever is in the serial buffer, and stuff it into a
    * byte buffer passed in by the user. This is more memory/time
    * efficient than readBytes() returning a byte[] array.


### PR DESCRIPTION
This adds the requested feature (issue #4167) to allow reading a specific number of bytes from the serial library.  It follows the exact same logic as the readBytes(max) function which has been implemented for the network library (see PR #4320).  I have not been able to test it beyond ensuring that it compiles hence the separate pull request.