### PR TITLE
Fix concurrency issues with errorPoints

### DIFF
--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -2529,13 +2529,15 @@ public class JavaEditor extends Editor {
   public LineMarker findError(int line) {
     List<LineMarker> errorPoints = getErrorPoints();
     JavaTextArea textArea = getJavaTextArea();
-    for (LineMarker emarker : errorPoints) {
-      Problem p = emarker.getProblem();
-      int pStartLine = p.getLineNumber();
-      int pEndOffset = textArea.getLineStartOffset(pStartLine) + p.getPDELineStopOffset() + 1;
-      int pEndLine = textArea.getLineOfOffset(pEndOffset);
-      if (line >= pStartLine && line <= pEndLine) {
-        return emarker;
+    synchronized (errorPoints) {
+      for (LineMarker emarker : errorPoints) {
+        Problem p = emarker.getProblem();
+        int pStartLine = p.getLineNumber();
+        int pEndOffset = textArea.getLineStartOffset(pStartLine) + p.getPDELineStopOffset() + 1;
+        int pEndLine = textArea.getLineOfOffset(pEndOffset);
+        if (line >= pStartLine && line <= pEndLine) {
+          return emarker;
+        }
       }
     }
     return null;


### PR DESCRIPTION
This pull request addresses #4322

It is caused by using enhanced for-loop when iterating through `synchronizedList` (details here https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedList(java.util.List) and here http://stackoverflow.com/questions/6596673/java-concurrentmodificationexception-while-iterating-over-list) and one unfortunate line in code that makes `synchronizedList` normal `ArrayList` which breaks thread-safety.

The problem is resolved by wrapping each enhanced for-loop with `synchronized` block (and also fixing one `errorPoints` redeclaration). After doing that, I'm unable to reproduce the bug by code change described here https://github.com/qiubit/processing/commit/62138e78dc75506b690401a027271e7b60907bb8 (the scheduler always schedules list modification after iteration).