### PR TITLE
Move updateErrorPoints background work to UI thread

### DIFF
--- a/java/src/processing/mode/java/MarkerColumn.java
+++ b/java/src/processing/mode/java/MarkerColumn.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JPanel;
-import javax.swing.SwingWorker;
 import javax.swing.text.BadLocationException;
 
 import processing.app.Mode;
@@ -115,40 +114,21 @@ public class MarkerColumn extends JPanel {
 	}
 
 
-	synchronized public void updateErrorPoints(final List<Problem> problems) {
-		// NOTE: ErrorMarkers are calculated for the present tab only Error Marker
-	  // index in the arraylist is LOCALIZED for current tab. Also, update is in
-	  // the UI thread via SwingWorker to prevent concurrency issues. [Manindra]
-	  try {
-	    new SwingWorker() {
-	      protected Object doInBackground() throws Exception {
-	        Sketch sketch = editor.getSketch();
-	        int currentTab = sketch.getCurrentCodeIndex();
-	        errorPoints = new ArrayList<>();
-
-	        // Each problem.getSourceLine() will have an extra line added because
-	        // of class declaration in the beginning as well as default imports
-	        synchronized (problems) {
-	          for (Problem problem : problems) {
-	            if (problem.getTabIndex() == currentTab) {
-	              errorPoints.add(new LineMarker(problem, problem.isError()));
-	            }
-	          }
-	        }
-
-	        recalculateMarkerPositions();
-	        return null;
-	      }
-
-	      protected void done() {
-	        repaint();
-					editor.getErrorChecker().updateEditorStatus();
-	      }
-	    }.execute();
-
-		} catch (Exception ex) {
-		  ex.printStackTrace();
-		}
+	public void updateErrorPoints(final List<Problem> problems) {
+	  // NOTE: ErrorMarkers are calculated for the present tab only Error Marker
+	  // index in the arraylist is LOCALIZED for current tab.
+	  Sketch sketch = editor.getSketch();
+	  int currentTab = sketch.getCurrentCodeIndex();
+	  errorPoints = Collections.synchronizedList(new ArrayList<LineMarker>());
+	  // Each problem.getSourceLine() will have an extra line added because
+	  // of class declaration in the beginning as well as default imports
+	  for (Problem problem : problems) {
+	    if (problem.getTabIndex() == currentTab) {
+	      errorPoints.add(new LineMarker(problem, problem.isError()));
+	    }
+	  }
+	  repaint();
+	  editor.getErrorChecker().updateEditorStatus();
 	}
 
 

--- a/java/src/processing/mode/java/MarkerColumn.java
+++ b/java/src/processing/mode/java/MarkerColumn.java
@@ -62,8 +62,7 @@ public class MarkerColumn extends JPanel {
 	private Color warningColor;
 
 	// Stores error markers displayed PER TAB along the error bar.
-	private List<LineMarker> errorPoints =
-	  Collections.synchronizedList(new ArrayList<LineMarker>());
+	private List<LineMarker> errorPoints = new ArrayList<LineMarker>();
 
 
 	public MarkerColumn(JavaEditor editor, int height) {
@@ -119,7 +118,7 @@ public class MarkerColumn extends JPanel {
 	  // index in the arraylist is LOCALIZED for current tab.
 	  Sketch sketch = editor.getSketch();
 	  int currentTab = sketch.getCurrentCodeIndex();
-	  errorPoints = Collections.synchronizedList(new ArrayList<LineMarker>());
+	  errorPoints.clear();
 	  // Each problem.getSourceLine() will have an extra line added because
 	  // of class declaration in the beginning as well as default imports
 	  for (Problem problem : problems) {


### PR DESCRIPTION
This pull request addresses #4322 and provides alternative solution of this problem than #4324, as suggested by @JakubValtar.

Instead of using Java synchronization mechanisms, which would sometimes cause UI thread to block until background thread in `updateErrorPoints` finishes execution, the work from background thread is now entirely done on the UI thread, which entirely eliminates synchronization issues (that's why all `synchronized` blocks were removed from `updateErrorPoints`).

Also, `errorPoints` redeclaration is fixed in order to be consistent with the initial declaration (which allows future `errorPoints` references from different threads to be safe - although maybe using `synchronizedList` now is unnecessary, given that all `errorPoints` references are from UI thread now?)