### PR TITLE
fix:load fallback font for CJK(The Chinese, Japanese and Korean).

### DIFF
--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import javax.swing.Action;
@@ -892,6 +893,16 @@ public class Toolkit {
             monoBoldFont = createFont("AnonymousPro-Bold.ttf", size);
           }
         }
+        // issue2886
+        // follback for Chinese, Korean, Japanese.
+        String lang = Language.getLanguage();
+        if (Locale.CHINESE.getLanguage().equals(lang) ||
+          Locale.JAPANESE.getLanguage().equals(lang) ||
+          Locale.KOREAN.getLanguage().equals(lang)) {
+          sansFont = new Font("Monospaced", Font.PLAIN, size);
+          sansBoldFont = new Font("Monospaced", Font.BOLD, size);
+          Messages.log("load Monospaced font for CJK.");
+        }
       } catch (Exception e) {
         Messages.loge("Could not load mono font", e);
         monoFont = new Font("Monospaced", Font.PLAIN, size);
@@ -927,6 +938,17 @@ public class Toolkit {
             sansFont = createFont("Carlito-Regular.ttf", size);
             sansBoldFont = createFont("Carlito-Bold.ttf", size);
           }
+        }
+        
+        // issue2886
+        // follback for Chinese, Korean, Japanese.
+        String lang = Language.getLanguage();
+        if (Locale.CHINESE.getLanguage().equals(lang) ||
+          Locale.JAPANESE.getLanguage().equals(lang) ||
+          Locale.KOREAN.getLanguage().equals(lang)) {
+          sansFont = new Font("SansSerif", Font.PLAIN, size);
+          sansBoldFont = new Font("SansSerif", Font.BOLD, size);
+          Messages.log("load sans font for CJK.");
         }
       } catch (Exception e) {
         Messages.loge("Could not load sans font", e);

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -283,15 +283,15 @@ debugger.type = 型
 # [Run/Present] [Stop] [New] [Open] [Save]
 # FIXME: スケッチのメニュー部分は日本語が表示できないため、英語のままにする
 #        https://github.com/processing/processing/issues/2886
-#toolbar.run = 実行
-#toolbar.present = プレゼンテーション
-#toolbar.stop = 停止
-#toolbar.debug = デバッグ
+toolbar.run = 実行
+toolbar.present = プレゼンテーション
+toolbar.stop = 停止
+toolbar.debug = デバッグ
 # ---
-#toolbar.new = 新規
-#toolbar.open = 開く
-#toolbar.save = 保存
-# toolbar.export_application = Export Application
+toolbar.new = 新規
+toolbar.open = 開く
+toolbar.save = 保存
+ toolbar.export_application = Export Application
 toolbar.add_mode = モードの追加...
 
 # [Debug] [Continue] [Step] [Stop] [Toggle Breakpoints] [Variable Inspector]
@@ -333,8 +333,8 @@ editor.sketch.rename.description = スケッチの新しい名前
 #editor.status.drag_and_drop.files_added.0 = No files were added to the sketch.
 #editor.status.drag_and_drop.files_added.1 = One file added to the sketch.
 #editor.status.drag_and_drop.files_added.n = %d files added to the sketch.
-#editor.status.saving = 保存しています...
-#editor.status.saving.done = 保存が完了しました。
+editor.status.saving = 保存しています...
+editor.status.saving.done = 保存が完了しました。
 #editor.status.saving.canceled = 保存がキャンセルされました。
 #editor.status.printing = 印刷しています...
 #editor.status.printing.done = 印刷が完了しました。
@@ -349,9 +349,9 @@ editor.sketch.rename.description = スケッチの新しい名前
 # Errors
 # FIXME: この部分は文字化けするため、英語のままにする
 #        https://github.com/processing/processing/issues/2886
-#editor.status.warning = 警告
-#editor.status.error = エラー
-#editor.status.error_on = "%s" でエラー
+editor.status.warning = 警告
+editor.status.error = エラー
+editor.status.error_on = "%s" でエラー
 #editor.status.missing.default = "%c" がありません
 #editor.status.missing.semicolon = セミコロン ";" がありません
 #editor.status.missing.left_sq_bracket = Missing left square bracket "["
@@ -378,11 +378,11 @@ editor.sketch.rename.description = スケッチの新しい名前
 # Footer buttons
 # FIXME: この部分は文字化けするため、英語のままにする
 #        https://github.com/processing/processing/issues/2886
-#editor.footer.errors = エラー
-#editor.footer.errors.problem = 問題
-#editor.footer.errors.tab = タブ
-#editor.footer.errors.line = 行
-#editor.footer.console = コンソール
+editor.footer.errors = エラー
+editor.footer.errors.problem = 問題
+editor.footer.errors.tab = タブ
+editor.footer.errors.line = 行
+editor.footer.console = コンソール
 
 # New handler
 new.messages.is_read_only = スケッチが読込み専用です


### PR DESCRIPTION
This is a pull request for #2886.
If a language is the CJK(The Chinese, Japanese and Korean), this patch load a system font.
the header and footer could draw correct font.

![screenshot from 2016-03-05 13-26-46](https://cloud.githubusercontent.com/assets/16870334/13545644/ffb17570-e2d5-11e5-8322-d8555c194b9b.png)
