### PR TITLE
fixed a processing-java command encoding problem for Windows Prompt

### DIFF
--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -106,7 +106,10 @@ public class Commander implements RunnerListener {
     try {
       systemOut = new PrintStream(System.out, true, "UTF-8");
       systemErr = new PrintStream(System.err, true, "UTF-8");
-
+      if (Platform.isWindows()) {
+        systemOut = new PrintStream(System.out, true);
+        systemErr = new PrintStream(System.err, true);
+      }
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
       System.exit(1);


### PR DESCRIPTION
this fix for #1633.
a Windows Command Prompt and Powershell Prompot are not UTF-8 encoding. so I add condition for windows . (Platform.isWindows())