### PR TITLE
Use HTML to print

### DIFF
--- a/app/src/processing/app/syntax/TextAreaPainter.java
+++ b/app/src/processing/app/syntax/TextAreaPainter.java
@@ -12,7 +12,6 @@ package processing.app.syntax;
 
 import java.awt.event.MouseEvent;
 import java.awt.*;
-import java.awt.print.*;
 
 import javax.swing.ToolTipManager;
 import javax.swing.text.*;
@@ -28,9 +27,6 @@ import processing.app.syntax.im.CompositionTextPainter;
  * @author Slava Pestov
  */
 public class TextAreaPainter extends JComponent implements TabExpander {
-  /** True if inside printing, will handle disabling the highlight */
-  boolean printing;
-
   /** A specific painter composed by the InputMethod.*/
   protected CompositionTextPainter compositionTextPainter;
 
@@ -502,38 +498,6 @@ public class TextAreaPainter extends JComponent implements TabExpander {
   }
 
 
-  public Printable getPrintable() {
-    return new Printable() {
-
-      @Override
-      public int print(Graphics graphics, PageFormat pageFormat,
-                       int pageIndex) throws PrinterException {
-        int lineHeight = fm.getHeight();
-        int linesPerPage = (int) (pageFormat.getImageableHeight() / lineHeight);
-        int lineCount = textArea.getLineCount();
-        int lastPage = lineCount / linesPerPage;
-
-        if (pageIndex > lastPage) {
-          return NO_SUCH_PAGE;
-
-        } else {
-          Graphics2D g2 = (Graphics2D) graphics;
-          TokenMarker tokenMarker = textArea.getDocument().getTokenMarker();
-          int firstLine = pageIndex*linesPerPage;
-          g2.translate(Math.max(54, pageFormat.getImageableX()),
-                        pageFormat.getImageableY() - firstLine*lineHeight);
-          printing = true;
-          for (int line = firstLine; line < firstLine + linesPerPage; line++) {
-            paintLine(g2, line, 0, tokenMarker);
-          }
-          printing = false;
-          return PAGE_EXISTS;
-        }
-      }
-    };
-  }
-
-
   /**
    * Marks a line as needing a repaint.
    * @param line The line to invalidate
@@ -661,9 +625,7 @@ public class TextAreaPainter extends JComponent implements TabExpander {
 //  protected void paintPlainLine(Graphics gfx, int line, Font defaultFont,
 //                                Color defaultColor, int x, int y) {
   protected void paintPlainLine(Graphics gfx, int line, int x, int y) {
-    if (!printing) {
-      paintHighlight(gfx,line,y);
-    }
+    paintHighlight(gfx,line,y);
     textArea.getLineText(line, currentLine);
 
 //    gfx.setFont(plainFont);
@@ -786,8 +748,7 @@ public class TextAreaPainter extends JComponent implements TabExpander {
   }
 
 
-  protected void paintHighlight(Graphics gfx, int line, int y) {//, boolean printing) {
-//    if (!printing) {
+  protected void paintHighlight(Graphics gfx, int line, int y) {
     if (line >= textArea.getSelectionStartLine() &&
         line <= textArea.getSelectionStopLine()) {
       paintLineHighlight(gfx, line, y);

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -64,6 +64,7 @@ import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.plaf.basic.*;
 import javax.swing.text.*;
+import javax.swing.text.html.*;
 import javax.swing.undo.*;
 
 
@@ -2610,15 +2611,51 @@ public abstract class Editor extends JFrame implements RunnerListener {
    */
   public void handlePrint() {
     statusNotice(Language.text("editor.status.printing"));
+
+    StringBuilder html = new StringBuilder("<html><body>");
+    for (SketchCode tab : sketch.getCode()) {
+      html.append("<b>" + tab.getPrettyName() + "</b><br>");
+      html.append(textarea.getTextAsHtml((SyntaxDocument)tab.getDocument()));
+      html.append("<br>");
+    }
+    html.setLength(html.length() - 4); // Don't want last <br>.
+    html.append("</body></html>");
+    JTextPane jtp = new JTextPane();
+    // Needed for good line wrapping; otherwise one very long word breaks
+    // wrapping for the whole document.
+    jtp.setEditorKit(new HTMLEditorKit() {
+      public ViewFactory getViewFactory() {
+        return new HTMLFactory() {
+          public View create(Element e) {
+            View v = super.create(e);
+            if (!(v instanceof javax.swing.text.html.ParagraphView))
+              return v;
+            else
+              return new javax.swing.text.html.ParagraphView(e) {
+                protected SizeRequirements calculateMinorAxisRequirements(
+                    int axis, SizeRequirements r) {
+                  r = super.calculateMinorAxisRequirements(axis, r);
+                  r.minimum = 1;
+                  return r;
+                }
+              };
+          }
+        };
+      }
+    });
+    jtp.setFont(new Font(Preferences.get("editor.font.family"), Font.PLAIN, 10));
+    jtp.setText(html.toString().replace("\n", "<br>") // Not in a <pre>.
+        .replaceAll("(?<!&nbsp;)&nbsp;", " "));       // Allow line wrap.
+
     //printerJob = null;
     if (printerJob == null) {
       printerJob = PrinterJob.getPrinterJob();
     }
     if (pageFormat != null) {
       //System.out.println("setting page format " + pageFormat);
-      printerJob.setPrintable(textarea.getPrintable(), pageFormat);
+      printerJob.setPrintable(jtp.getPrintable(null, null), pageFormat);
     } else {
-      printerJob.setPrintable(textarea.getPrintable());
+      printerJob.setPrintable(jtp.getPrintable(null, null));
     }
     // set the name of the job to the code name
     printerJob.setJobName(sketch.getCurrentCode().getPrettyName());


### PR DESCRIPTION
Allows multiple tabs at once and lifts responsibility for print rendering from TextAreaPainter. This was to avoid wrapping every other statement of TextAreaPainter in `if (!printing)` blocks, as there are so many features (eg. line numbers on a blue background) in it that would otherwise need suppressing when printing. It also makes line wrapping work.  I've only tested on Linux.

Fixes #50.
Closes #213 (as I think I've deleted all the code that could have been responsible).