### PR TITLE
Added getVertexData() and getMatrix() to PShape

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2158,6 +2158,15 @@ public class PShape implements PConstants {
     return getVertex(index, null);
   }
 
+  public float[] getVertexData(int index)
+  {
+    return vertices[index];
+  }
+
+  public PMatrix getMatrix()
+  {
+    return matrix;
+  }
 
   /**
    * @param vec PVector to assign the data to
@@ -2387,14 +2396,14 @@ public class PShape implements PConstants {
  /**
    * ( begin auto-generated from PShape_setFill.xml )
    *
-   * The <b>setFill()</b> method defines the fill color of a <b>PShape</b>. 
-   * This method is used after shapes are created or when a shape is defined explicitly 
-   * (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in the above example. 
-   * When a shape is created with <b>beginShape()</b> and <b>endShape()</b>, its 
-   * attributes may be changed with <b>fill()</b> and <b>stroke()</b> within 
-   * <b>beginShape()</b> and <b>endShape()</b>. However, after the shape is 
-   * created, only the <b>setFill()</b> method can define a new fill value for 
-   * the <b>PShape</b>. 
+   * The <b>setFill()</b> method defines the fill color of a <b>PShape</b>.
+   * This method is used after shapes are created or when a shape is defined explicitly
+   * (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in the above example.
+   * When a shape is created with <b>beginShape()</b> and <b>endShape()</b>, its
+   * attributes may be changed with <b>fill()</b> and <b>stroke()</b> within
+   * <b>beginShape()</b> and <b>endShape()</b>. However, after the shape is
+   * created, only the <b>setFill()</b> method can define a new fill value for
+   * the <b>PShape</b>.
    *
    * ( end auto-generated )
    *
@@ -2543,14 +2552,14 @@ public class PShape implements PConstants {
   /**
    * ( begin auto-generated from PShape_setStroke.xml )
    *
-   * The <b>setStroke()</b> method defines the outline color of a <b>PShape</b>. 
-   * This method is used after shapes are created or when a shape is defined 
-   * explicitly (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in 
-   * the above example. When a shape is created with <b>beginShape()</b> and 
-   * <b>endShape()</b>, its attributes may be changed with <b>fill()</b> and 
-   * <b>stroke()</b> within <b>beginShape()</b> and <b>endShape()</b>. 
-   * However, after the shape is created, only the <b>setStroke()</b> method 
-   * can define a new stroke value for the <b>PShape</b>. 
+   * The <b>setStroke()</b> method defines the outline color of a <b>PShape</b>.
+   * This method is used after shapes are created or when a shape is defined
+   * explicitly (e.g. <b>createShape(RECT, 20, 20, 80, 80)</b>) as shown in
+   * the above example. When a shape is created with <b>beginShape()</b> and
+   * <b>endShape()</b>, its attributes may be changed with <b>fill()</b> and
+   * <b>stroke()</b> within <b>beginShape()</b> and <b>endShape()</b>.
+   * However, after the shape is created, only the <b>setStroke()</b> method
+   * can define a new stroke value for the <b>PShape</b>.
    *
    * ( end auto-generated )
    *


### PR DESCRIPTION
Hello,

In PShape class there is methods for change matrix of the shape; like translate, rotate etc. But there is no function to retrieve this matrix. Which is important for being able to copy shapes manually and create a shape from previous shape by applying some transformations. (There is static copyMatrix function but it also not public and marked as unapproved and only used by createShape that uses another shape which only does automatic copying)

Also another missing functionality was accessing raw float[] per vertex data. It seems possible to add new vertices by giving raw float array (shown in reference but I couldn't find in code, is it removed?) but is not possible retrieve it. Currently it is required to access this data by calling these functions getVertex, getTextureU getTextureV, getNormal etc. Still there is some other data (like per vertex material data) that is not accessible might be lost. It would be great if it is possible access it directly for the purpose of copying with applying different transforms.

If this changes are approved, copyGeometry function could use this getVertexData and copy the geometry by directly copying the float array.

Thanks!
