### PR TITLE
looping & redraw to private, draw

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -709,10 +709,10 @@ public class PApplet implements PConstants {
    */
   public float frameRate = 10;
 
-  protected boolean looping = true;
+  private boolean looping = true;
 
   /** flag set to true when a redraw is asked for by the user */
-  protected boolean redraw = true;
+  private boolean redraw = true;
 
   /**
    * ( begin auto-generated from frameCount.xml )
@@ -1803,7 +1803,7 @@ public class PApplet implements PConstants {
   public void draw() {
     // if no draw method, then shut things down
     //System.out.println("no draw method, goodbye");
-    finished = true;
+    //finished = true;
   }
 
 


### PR DESCRIPTION
* define `looping` & `redraw` to private, because there are `loop()` and `noLoop()` function to set it. It will ensure the encapsulation of class. 
* And in `draw()` function, `finished` should be false. Because class extends base and override `draw()` function, it will execute `super.draw()`. If `finshed` is true, it will execute once.