### PR TITLE
Fix bracket matching bugs.

### DIFF
--- a/app/src/processing/app/syntax/Brackets.java
+++ b/app/src/processing/app/syntax/Brackets.java
@@ -51,7 +51,7 @@ public class Brackets {
       return -1;
     }
 
-    if (offsets == null || offsets.get(offsets.size()-1) >= text.length())
+    if (offsets == null)
       parse(text);
     
     // find this bracket
@@ -126,9 +126,9 @@ public class Brackets {
     for (pos++; pos < len; pos++) {
       final char c = text.charAt(pos);
       if (c == '*' && (pos < len - 1)) {
-        pos++;
-        final char d = text.charAt(pos);
+        final char d = text.charAt(pos + 1);
         if (d == '/') {
+          pos++;
           return;
         }
       }

--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -818,6 +818,7 @@ public class JEditTextArea extends JComponent
 
     document.addDocumentListener(documentHandler);
 
+    bracketHelper.invalidate();
     select(0, 0);
     updateScrollBars();
     painter.repaint();
@@ -838,6 +839,7 @@ public class JEditTextArea extends JComponent
 
     document.addDocumentListener(documentHandler);
 
+    bracketHelper.invalidate();
     select(start, stop);
     updateScrollBars();
     setVerticalScrollPosition(scroll);


### PR DESCRIPTION
Fixes #4397 and  makes bracket matching work immediately after changing tabs. (Previously, you had to make an edit after changing tabs for the bracket matchers "offsets" variable to be invalidated.)
Also undoes one line from #4113:
````
if (offsets == null || offsets.get(offsets.size()-1) >= text.length())
````
If `offsets` contains an invalid offset, then there is a bug that needs fixing, because invalidate() hasn't been called when the document changed. So it doesn't make sense to just check for bad offsets and then call parse(), because it's likely that the bug will also manifest itself in other ways.