### PR TITLE
Ignore memory options when exporting for ARM

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1123,7 +1123,11 @@ public class JavaBuild {
     /// figure out run options for the VM
 
     List<String> runOptions = new ArrayList<String>();
-    if (Preferences.getBoolean("run.options.memory")) {
+
+    // set memory options, except for ARM where we're more memory-constrained compared
+    // to the machine the user might be building the sketch on
+    if (Preferences.getBoolean("run.options.memory") &&
+        !exportVariant.equals("armv6hf")) {
       runOptions.add("-Xms" + Preferences.get("run.options.memory.initial") + "m");
       runOptions.add("-Xmx" + Preferences.get("run.options.memory.maximum") + "m");
     }


### PR DESCRIPTION
I had students export a sketch on their laptops and try it out on a Raspberry Pi, but this failed for most, since their memory settings in Preferences were at insanely high values. Perhaps for the time being, we could ignore those for ARM?