### PR TITLE
Add automatic mipmap support to GLES2

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2110,11 +2110,13 @@ public abstract class PGL {
 
   protected boolean hasAutoMipmapGenSupport() {
     int major = getGLVersion()[0];
-    if (major < 3) {
+    if (isES() && major >= 2) {
+      return true;
+    } else if (!isES() && major >= 3) {
+      return true;
+    } else {
       String ext = getString(EXTENSIONS);
       return -1 < ext.indexOf("_generate_mipmap");
-    } else {
-      return true;
     }
   }
 


### PR DESCRIPTION
glGenerateMipmap is supported on GL ES 2.0 and above. Tested on Raspberry Pi w/ binary GLES2 driver.