### PR TITLE
Fix file path decoding

### DIFF
--- a/app/src/processing/app/Platform.java
+++ b/app/src/processing/app/Platform.java
@@ -26,6 +26,8 @@ package processing.app;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -281,9 +283,16 @@ public class Platform {
   static public File getContentFile(String name) {
     if (processingRoot == null) {
       // Get the path to the .jar file that contains Base.class
-      String path = Base.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-      // Path may have URL encoding, so remove it
-      String decodedPath = PApplet.urlDecode(path);
+      URL pathURL =
+          Base.class.getProtectionDomain().getCodeSource().getLocation();
+      // Decode URL
+      String decodedPath;
+      try {
+        decodedPath = pathURL.toURI().getPath();
+      } catch (URISyntaxException e) {
+        e.printStackTrace();
+        return null;
+      }
 
       if (decodedPath.contains("/app/bin")) {  // This means we're in Eclipse
         final File build = new File(decodedPath, "../../build").getAbsoluteFile();
@@ -311,8 +320,7 @@ public class Platform {
           System.err.println("Could not find lib folder via " +
             jarFolder.getAbsolutePath() +
             ", switching to user.dir");
-          final String userDir = System.getProperty("user.dir");
-          processingRoot = new File(PApplet.urlDecode(userDir));
+          processingRoot = new File(""); // resolves to "user.dir"
         }
       }
     }

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -7389,10 +7389,10 @@ public class PApplet implements PConstants {
     try {
       folder = System.getProperty("user.dir");
 
-      String jarPath =
-        PApplet.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-      // The jarPath from above will be URL encoded (%20 for spaces)
-      jarPath = urlDecode(jarPath);
+      URL jarURL =
+          PApplet.class.getProtectionDomain().getCodeSource().getLocation();
+      // Decode URL
+      String jarPath = jarURL.toURI().getPath();
 
       // Workaround for bug in Java for OS X from Oracle (7u51)
       // https://github.com/processing/processing/issues/2181
@@ -7543,12 +7543,17 @@ public class PApplet implements PConstants {
     File why = new File(where);
     if (why.isAbsolute()) return why;
 
-    String jarPath =
-      getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+    URL jarURL = getClass().getProtectionDomain().getCodeSource().getLocation();
+    // Decode URL
+    String jarPath;
+    try {
+      jarPath = jarURL.toURI().getPath();
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+      return null;
+    }
     if (jarPath.contains("Contents/Java/")) {
-      // The path will be URL encoded (%20 for spaces) coming from above
-      // http://code.google.com/p/processing/issues/detail?id=1073
-      File containingFolder = new File(urlDecode(jarPath)).getParentFile();
+      File containingFolder = new File(jarPath).getParentFile();
       File dataFolder = new File(containingFolder, "data");
       return new File(dataFolder, where);
     }
@@ -7633,6 +7638,11 @@ public class PApplet implements PConstants {
   }
 
 
+  // DO NOT use for file paths, URLDecoder can't handle RFC2396
+  // "The recommended way to manage the encoding and decoding of
+  // URLs is to use URI, and to convert between these two classes
+  // using toURI() and URI.toURL()."
+  // https://docs.oracle.com/javase/8/docs/api/java/net/URL.html
   static public String urlDecode(String str) {
     try {
       return URLDecoder.decode(str, "UTF-8");


### PR DESCRIPTION
URLDecoder was being used for path decoding, even though it can't handle
RFC2396 encoding. This resulted in plus characters being removed and
possibly other weirdness.

See https://docs.oracle.com/javase/8/docs/api/java/net/URL.html

> The recommended way to manage the encoding and decoding of URLs is to use URI, and to convert between these two classes using toURI() and URI.toURL(). The URLEncoder and URLDecoder classes can also be used, but only for HTML form encoding, which is not the same as the encoding scheme defined in RFC2396.

Fixes #4417