### PR TITLE
Be more verbose with drawExceptions with cause null

### DIFF
--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -445,6 +445,8 @@ public class PSurfaceJOGL implements PSurface {
               throw (RuntimeException)cause;
             } else if (cause instanceof UnsatisfiedLinkError) {
               throw new UnsatisfiedLinkError(cause.getMessage());
+            } else if (cause == null) {
+              throw new RuntimeException(drawException.getMessage());
             } else {
               throw new RuntimeException(cause);
             }


### PR DESCRIPTION
Before:
```
java.lang.RuntimeException
	at processing.opengl.PSurfaceJOGL$2.run(PSurfaceJOGL.java:449)
	at java.lang.Thread.run(Thread.java:745)
```
After:
```
java.lang.RuntimeException: Waited 5000ms for: <fb397, c84a66>[count 1, qsz 0, owner <main-Display-.bcm.vc.iv_nil-1-EDT-1>] - <main-FPSAWTAnimator#00-Timer0-FPSAWTAnimator#01-Timer1>
	at processing.opengl.PSurfaceJOGL$2.run(PSurfaceJOGL.java:452)
	at java.lang.Thread.run(Thread.java:745)
```