### PR TITLE
Prevent InvocationTargetException when running processing-java

### DIFF
--- a/app/src/processing/app/Mode.java
+++ b/app/src/processing/app/Mode.java
@@ -327,7 +327,9 @@ public abstract class Mode {
     // Make this Map thread-safe
     this.importToLibraryTable = Collections.unmodifiableMap(importToLibraryTable);
 
-    base.getEditors().forEach(Editor::librariesChanged);
+    if (base != null) {
+      base.getEditors().forEach(Editor::librariesChanged);
+    }
   }
 
 


### PR DESCRIPTION
In this case, base is null. Fixes #4452.