### PR TITLE
Switch back to JRE 8u77 on ARM

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -59,6 +59,15 @@
 
   <!-- Switching to 8 because updates for 7 ended April 2015 -->
   <property name="jdk.version" value="8" />
+
+  <!-- temporarily work around performance regression on ARM -->
+  <condition property="jdk.update" value="77">
+    <equals arg1="${linux-arm32}" arg2="linux-arm32" />
+  </condition>
+  <condition property="jdk.build" value="3">
+    <equals arg1="${linux-arm32}" arg2="linux-arm32" />
+  </condition>
+
   <property name="jdk.update" value="92" />
   <property name="jdk.build" value="14" />
 


### PR DESCRIPTION
JRE 8u91 or higher cause performance problems with the GL Video library - specifically: SimpleCapture example doesn't show a texture from USB-attached webcam on Raspberry Pi 2, and TwoVideos example doesn't play two videos smoothly.

This was tested with Processing compiled on the Pi (JDK 8u65b17), and processing-glvideo 2d6de36a33fde3573b335e9a95cc3e380466f328.

@benfry Spent all morning tracking down this regression ... would you mind if I re-spun the ARM tar-ball for 3.1 with this change? (Holding off with the Raspbian image for now)