### PR TITLE
Add maximize() method. Fixes #4181.

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -865,10 +865,11 @@ public class PSurfaceAWT extends PSurfaceNone {
 
     if (sketch.sketchFullScreen()) {
       setFullFrame();
-    }
-
-    // Ignore placement of previous window and editor when full screen
-    if (!sketch.sketchFullScreen()) {
+    } else if (sketch.sketchMaximize()) {
+      frame.setExtendedState(Frame.MAXIMIZED_BOTH);
+    } else {
+      // Ignore placement of previous window and editor when full screen/
+      // maximized.
       if (location != null) {
         // a specific location was received from the Runner
         // (applet has been run more than once, user placed window)
@@ -1105,6 +1106,11 @@ public class PSurfaceAWT extends PSurfaceNone {
         // This seems to be firing when dragging the window on OS X
         // https://github.com/processing/processing/issues/3092
         if (Frame.MAXIMIZED_BOTH == e.getNewState()) {
+          if (sketch.sketchMaximize()) {
+            // If maximizing, mustn't start the animation thread until the window
+            // really has maximized.
+            sketch.doneMaximizing();
+          }
           // Supposedly, sending the frame to back and then front is a
           // workaround for this bug:
           // http://stackoverflow.com/a/23897602
@@ -1127,7 +1133,7 @@ public class PSurfaceAWT extends PSurfaceNone {
         // http://dev.processing.org/bugs/show_bug.cgi?id=341
         // This should also fix the blank screen on Linux bug
         // http://dev.processing.org/bugs/show_bug.cgi?id=282
-        if (frame.isResizable()) {
+        if (frame.isResizable() || sketch.sketchMaximize()) {
           // might be multiple resize calls before visible (i.e. first
           // when pack() is called, then when it's resized for use).
           // ignore them because it's not the user resizing things.

--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -125,6 +125,15 @@ public class PSurfaceFX implements PSurface {
           sketch.setSize(newWidth.intValue(), sketch.height);
 //          draw();
           fx.setSize(sketch.width, sketch.height);
+          // On Linux, there are three resize events to get the right size.
+          // 100 → 1, 1 → 100, 100 → correct value; not tried other platforms.
+          // There isn't an event to say the window's maximized.
+          // So I'm just waiting until the sketch is at least 90% screen width.
+          if (sketch.sketchMaximize()
+              && stage != null && stage.isMaximized()
+              && newWidth.floatValue() > sketch.displayWidth * 0.9f) {
+            sketch.doneMaximizing();
+          }
         }
       });
       heightProperty().addListener(new ChangeListener<Number>() {
@@ -304,6 +313,8 @@ public class PSurfaceFX implements PSurface {
         stage.setY(screenRect.getMinY());
         stage.setWidth(screenRect.getWidth());
         stage.setHeight(screenRect.getHeight());
+      } else if (sketch.sketchMaximize()) {
+        stage.setMaximized(true);
       }
 
       Canvas canvas = surface.canvas;

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -381,9 +381,13 @@ public class PSurfaceJOGL implements PSurface {
                                            ScalableSurface.IDENTITY_PIXELSCALE };
     }
     window.setSurfaceScale(reqSurfacePixelScale);
-    window.setSize(sketchWidth, sketchHeight);
+    if (sketch.sketchMaximize()) {
+      window.setMaximized(true, true);
+    } else {
+      window.setSize(sketchWidth, sketchHeight);
+      setSize(sketchWidth, sketchHeight);
+    }
     window.setResizable(false);
-    setSize(sketchWidth, sketchHeight);
     sketchX = displayDevice.getViewportInWindowUnits().getX();
     sketchY = displayDevice.getViewportInWindowUnits().getY();
     if (fullScreen) {
@@ -908,6 +912,9 @@ public class PSurfaceJOGL implements PSurface {
 //                         nativeSurfacePixelScale[0]+"x"+nativeSurfacePixelScale[1]+" (native)");
 
 
+      if (window.isMaximizedHorz() && window.isMaximizedVert()) {
+        sketch.doneMaximizing();
+      }
 
 
 //      System.out.println("reshape: " + w + ", " + h);

--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -347,10 +347,12 @@ public class PdePreprocessor {
 
     String[] sizeContents = matchMethod("size", searchArea);
     String[] fullContents = matchMethod("fullScreen", searchArea);
-    // First check and make sure they aren't both being used, otherwise it'll
-    // throw a confusing state exception error that one "can't be used here".
-    if (sizeContents != null && fullContents != null) {
-      throw new SketchException("size() and fullScreen() cannot be used in the same sketch", false);
+    String[] maxiContents = matchMethod("maximize", searchArea);
+    // First check and make sure there isn't more than one being used, otherwise
+    // it'll throw a confusing state exception error that one "can't be used here".
+    if ((sizeContents != null) == (fullContents != null)
+       ? (sizeContents != null) : (maxiContents != null)) {
+      throw new SketchException("Use only one of size(), maximize() and fullScreen() in the same sketch.", false);
     }
 
     // Get everything inside the parens for the size() method
@@ -420,6 +422,20 @@ public class PdePreprocessor {
 //      if (extraStatements.size() != 0) {
 //        info.statement += extraStatements.join(" ");
 //      }
+      info.addStatements(extraStatements);
+      info.checkEmpty();
+      return info;
+    }
+
+    if (maxiContents != null) {
+      SurfaceInfo info = new SurfaceInfo();
+      info.addStatement(maxiContents[0]);
+      StringList args = breakCommas(maxiContents[1]);
+      if (args.size() == 1) {
+        info.renderer = args.get(0).trim();
+      } else if (args.size() > 1) {
+        throw new SketchException("That's too many parameters for maximize().");
+      }
       info.addStatements(extraStatements);
       info.checkEmpty();
       return info;


### PR DESCRIPTION
As there doesn't seem to be an easy way to predict the maximized window's content size across platforms and renderers (you can get it with the window decoration included, but not easily without), the animation thread is blocked from starting until the window has actually maximized, and the correct content size has been established. This means that width and height have their correct values in setup(). 
If the user picks a renderer that doesn't support this, the sketch will start normally after a 2500ms delay, and they'll see an error message, naming their renderer as the culprit. The code for the JavaFX renderer is hacky; there just doesn't seem to be a better way.
Fixes #4181.
