### PR TITLE
ARM Updates

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -59,15 +59,6 @@
 
   <!-- Switching to 8 because updates for 7 ended April 2015 -->
   <property name="jdk.version" value="8" />
-
-  <!-- temporarily work around performance regression on ARM -->
-  <condition property="jdk.update" value="77">
-    <equals arg1="${linux-arm32}" arg2="linux-arm32" />
-  </condition>
-  <condition property="jdk.build" value="3">
-    <equals arg1="${linux-arm32}" arg2="linux-arm32" />
-  </condition>
-
   <property name="jdk.update" value="92" />
   <property name="jdk.build" value="14" />
 

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -133,6 +133,16 @@ public class PSurfaceJOGL implements PSurface {
   public void initFrame(PApplet sketch) {
     this.sketch = sketch;
     initIcons();
+
+    // https://jogamp.org/bugzilla/show_bug.cgi?id=1290
+    File mesaLib = new File("/usr/lib/arm-linux-gnueabihf/libGLESv2.so.2");
+    if (mesaLib.exists()) {
+      System.out.println("\nIf you are receiving an error regarding the undefined symbol bcm_host_init, " +
+                         "make sure you have the package libgles2-mesa deinstalled. This can be done " +
+                         "by executing \"sudo aptitude remove libgles2-mesa\" in the terminal, and is " +
+                         "a known issue with the Raspbian distribution.\n");
+    }
+
     initDisplay();
     initGL();
     initWindow();


### PR DESCRIPTION
The performance regression with 8u91 and above was figured out and worked around in version 1.0.2 of the GL Video library. See: https://github.com/gohai/processing-glvideo/commit/055a90cacd7c82c4b9e36fa9198a18c1947db8d6