### PR TITLE
Fix run failure when tabs are unviewed

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2713,7 +2713,13 @@ public abstract class Editor extends JFrame implements RunnerListener {
     //current.setProgram(editor.getText());
     for (SketchCode sc : sketch.getCode()) {
       try {
-        sc.setProgram(sc.getDocumentText());
+        try {
+          sc.setProgram(sc.getDocumentText());
+        } catch (NullPointerException e) {
+          // sc has no document because the tab has not been viewed;
+          // carry on because String 'program' has been set and no
+		  // document should mean no changes have been made
+        }
       } catch (BadLocationException e) { }
     }
 


### PR DESCRIPTION
This affects Python mode, but the source of the bug is here. When some
tabs have not been viewed after the sketch has been opened, the
'document' of the respective SketchCode is null. This is fine, just
don't throw an error. This fix shouldn't have any negative effects.