### PR TITLE
Add a temporary workaround for the CHIP

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -1482,6 +1482,13 @@ public class PSurfaceAWT extends PSurfaceNone {
     // Don't set cursorType, instead use cursorType to save the last
     // regular cursor type used for when cursor() is called.
     //cursor_type = Cursor.CUSTOM_CURSOR;
+
+    // this is a temporary workaround for the CHIP, will be removed
+    Dimension cursorSize = Toolkit.getDefaultToolkit().getBestCursorSize(img.width, img.height);
+    if (cursorSize.width == 0 || cursorSize.height == 0) {
+      return;
+    }
+
     Cursor cursor =
       canvas.getToolkit().createCustomCursor((Image) img.getNative(),
                                              new Point(x, y),
@@ -1511,8 +1518,14 @@ public class PSurfaceAWT extends PSurfaceNone {
     if (invisibleCursor == null) {
       BufferedImage cursorImg =
         new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
-      invisibleCursor =
-        canvas.getToolkit().createCustomCursor(cursorImg, new Point(8, 8), "blank");
+      // this is a temporary workaround for the CHIP, will be removed
+      Dimension cursorSize = Toolkit.getDefaultToolkit().getBestCursorSize(16, 16);
+      if (cursorSize.width == 0 || cursorSize.height == 0) {
+        invisibleCursor = Cursor.getDefaultCursor();
+      } else {
+        invisibleCursor =
+          canvas.getToolkit().createCustomCursor(cursorImg, new Point(8, 8), "blank");
+      }
     }
     canvas.setCursor(invisibleCursor);
     cursorVisible = false;

--- a/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
+++ b/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
@@ -25,6 +25,7 @@ import processing.mode.java.tweak.*;
 
 import java.awt.Color;
 import java.awt.Cursor;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -401,8 +402,16 @@ public class JavaTextAreaPainter extends TextAreaPainter
 
 	int cursorType;
 	BufferedImage cursorImg = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
-	Cursor blankCursor = Toolkit.getDefaultToolkit().createCustomCursor(cursorImg, new Point(0, 0), "blank cursor");
-
+  Cursor blankCursor;
+  // this is a temporary workaround for the CHIP, will be removed
+  {
+    Dimension cursorSize = Toolkit.getDefaultToolkit().getBestCursorSize(16, 16);
+    if (cursorSize.width == 0 || cursorSize.height == 0) {
+      blankCursor = Cursor.getDefaultCursor();
+    } else {
+      blankCursor = Toolkit.getDefaultToolkit().createCustomCursor(cursorImg, new Point(0, 0), "blank cursor");
+    }
+  }
 
 	@Override
 	synchronized public void paint(Graphics gfx) {


### PR DESCRIPTION
Reported this to the CHIP team: Seeing some odd exception from deep within Java's awt classes ("Width (0) and height (0) must be non-zero"). This is triggered because the libX11 function XQueryBestCursor is returning a width and height of zero, which seems to be a bug. I am guessing that this will also pop up with other Java applications.

This makes things work on the CHIP w/ OS image 4.4 and latest packages. I also tested on OS X, but I am not familiar enough with the Tweak Mode to say for sure.