### PR TITLE
Make preferences button wider for Japanese

### DIFF
--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -157,7 +157,7 @@ close.unsaved_changes = %s への変更を保存しますか?
 
 # Preferences (Frame)
 preferences = 設定
-preferences.button.width = 80
+preferences.button.width = 120
 preferences.requires_restart = Processing の再起動が必要です
 preferences.sketchbook_location = スケッチブックの場所
 preferences.sketchbook_location.popup = スケッチブックの場所


### PR DESCRIPTION
In preferences window,
[cancel] button is too narrow for Japanese word "キャンセル"
so make it wider.

Before:
![before](https://cloud.githubusercontent.com/assets/7347125/16542875/72345d0a-40f6-11e6-9358-779a213ee149.png)

After:
![after](https://cloud.githubusercontent.com/assets/7347125/16542876/7a61ce22-40f6-11e6-8f7e-859aeb6df240.png)
