### PR TITLE
Show warning message if mode cannot be changed

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -885,8 +885,9 @@ public class Base {
   /**
    * The call has already checked to make sure this sketch is not modified,
    * now change the mode.
+   * @return true if mode is changed.
    */
-  public void changeMode(Mode mode) {
+  public boolean changeMode(Mode mode) {
     Mode oldMode = activeEditor.getMode();
     if (oldMode != mode) {
       Sketch sketch = activeEditor.getSketch();
@@ -908,7 +909,9 @@ public class Base {
             break;
           }
         }
-        if (newModeCanHandleCurrentSource) {
+        if (!newModeCanHandleCurrentSource) {
+          return false;
+        } else {
           final File props = new File(sketch.getCodeFolder(), "sketch.properties");
           saveModeSettings(props, nextMode);
           handleClose(activeEditor, true);
@@ -918,10 +921,12 @@ public class Base {
             // re-open the sketch using the mode we were in before
             saveModeSettings(props, oldMode);
             handleOpen(sketch.getMainFilePath());
+            return false;
           }
         }
       }
     }
+    return true;
   }
 
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -505,22 +505,15 @@ public abstract class Editor extends JFrame implements RunnerListener {
       item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           if (!sketch.isModified()) {
-            base.changeMode(m);
+            if (!base.changeMode(m)) {
+              reselectMode();
+              Messages.showWarning(Language.text("warn.cannot_change_mode.title"),
+                                   Language.interpolate("warn.cannot_change_mode.body", m));
+            }
           } else {
+            reselectMode();
             Messages.showWarning("Save",
                                  "Please save the sketch before changing the mode.");
-
-            // Re-select the old checkbox, because it was automatically
-            // updated by Java, even though the Mode could not be changed.
-            // https://github.com/processing/processing/issues/2615
-            for (Component c : getModePopup().getComponents()) {
-              if (c instanceof JRadioButtonMenuItem) {
-                if (((JRadioButtonMenuItem)c).getText() == mode.getTitle()) {
-                  ((JRadioButtonMenuItem)c).setSelected(true);
-                  break;
-                }
-              }
-            }
           }
         }
       });
@@ -543,6 +536,19 @@ public abstract class Editor extends JFrame implements RunnerListener {
     Toolkit.setMenuMnemsInside(modePopup);
   }
 
+  // Re-select the old checkbox, because it was automatically
+  // updated by Java, even though the Mode could not be changed.
+  // https://github.com/processing/processing/issues/2615
+  private void reselectMode() {
+    for (Component c : getModePopup().getComponents()) {
+      if (c instanceof JRadioButtonMenuItem) {
+        if (((JRadioButtonMenuItem)c).getText() == mode.getTitle()) {
+          ((JRadioButtonMenuItem)c).setSelected(true);
+          break;
+        }
+      }
+    }
+  }
 
   public JPopupMenu getModePopup() {
     return modePopup.getPopupMenu();

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -529,6 +529,8 @@ contrib.import.errors.link = Error: The library %s has a strange looking downloa
 warn.delete = Delete
 warn.delete.sketch = Are you sure you want to delete this sketch?
 warn.delete.file = Are you sure you want to delete "%s"?
+warn.cannot_change_mode.title = Cannot change mode
+warn.cannot_change_mode.body = Cannot change mode,\nbecause "%s" mode is not compatible with current mode.
 
 
 # ---------------------------------------

--- a/build/shared/lib/languages/PDE_ja.properties
+++ b/build/shared/lib/languages/PDE_ja.properties
@@ -528,6 +528,8 @@ contrib.import.errors.link = Error: The library %s has a strange looking downloa
 warn.delete = Delete
 warn.delete.sketch = Are you sure you want to delete this sketch?
 warn.delete.file = Are you sure you want to delete "%s"?
+warn.cannot_change_mode.title = モード変更失敗
+warn.cannot_change_mode.body = 互換性がないため、"%s"モードに切り替えられません。
 
 
 # ---------------------------------------


### PR DESCRIPTION
If you try to change the mode which is not compatible with the current mode,
the mode change is canceled silently and different mode is checked in mode menu popup.

Reproducing this issue:

  1. Install Python mode.
  2. Select Python mode.
  3. Load any sample sketch.
  4. Click mode menu popup, and select Java.
  5. No message is shown and Java is checked in popup (but keeps Python mode.) 

This change fixes the issue,
if selected mode cannot handle current source,
show warning dialog and reselect old (current) mode.

This change added text strings for English and Japanese only.

Related #2615
