### PR TITLE
Hide line number if line doesn't exist

### DIFF
--- a/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
+++ b/java/src/processing/mode/java/pdex/JavaTextAreaPainter.java
@@ -157,6 +157,9 @@ public class JavaTextAreaPainter extends TextAreaPainter
       gfx.setClip(null);  // reset
     }
 
+    if (line >= textArea.getLineCount())
+      return;
+
     String text = null;
     if (getJavaEditor().isDebuggerEnabled()) {
       text = getJavaTextArea().getGutterText(line);


### PR DESCRIPTION
Even if source code is short and fit all lines inside the textarea,
line numbers are displayed after its end.

This is my preference, but I want to show line number
only if line exists.

![ss](https://cloud.githubusercontent.com/assets/7347125/16572495/1febbfca-42a4-11e6-90c1-c747947eca2a.png)
