### PR TITLE
Fix Null Pointer Exception

### DIFF
--- a/app/src/processing/app/SketchCode.java
+++ b/app/src/processing/app/SketchCode.java
@@ -225,6 +225,8 @@ public class SketchCode {
 
 
   public String getDocumentText() throws BadLocationException {
+    if (document == null)
+      return null;
     return document.getText(0, document.getLength());
   }
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2713,7 +2713,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
     //current.setProgram(editor.getText());
     for (SketchCode sc : sketch.getCode()) {
       try {
-        sc.setProgram(sc.getDocumentText());
+        String text = sc.getDocumentText();
+        if (text != null)
+          sc.setProgram(text);
       } catch (BadLocationException e) { }
     }
 


### PR DESCRIPTION
`SketchCode` might have no `document`.
In the case, calling `getDocumentText()` raises NPE.
This might happen when `Editor#prepareRun()` is called.

Java mode works fine,
but I've encountered this exception
when I try to implement custom mode.
