### PR TITLE
Fix running PDE from network locations

### DIFF
--- a/app/src/processing/app/Language.java
+++ b/app/src/processing/app/Language.java
@@ -316,6 +316,9 @@ public class Language {
 
     void read(File additions) {
       String[] lines = PApplet.loadStrings(additions);
+      if (lines == null) {
+        throw new NullPointerException("File not found:\n" + additions.getAbsolutePath());
+      }
       //for (String line : lines) {
       for (int i = 0; i < lines.length; i++) {
         String line = lines[i];

--- a/app/src/processing/app/Platform.java
+++ b/app/src/processing/app/Platform.java
@@ -288,7 +288,7 @@ public class Platform {
       // Decode URL
       String decodedPath;
       try {
-        decodedPath = pathURL.toURI().getPath();
+        decodedPath = pathURL.toURI().getSchemeSpecificPart();
       } catch (URISyntaxException e) {
         e.printStackTrace();
         return null;

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -7413,7 +7413,7 @@ public class PApplet implements PConstants {
       URL jarURL =
           PApplet.class.getProtectionDomain().getCodeSource().getLocation();
       // Decode URL
-      String jarPath = jarURL.toURI().getPath();
+      String jarPath = jarURL.toURI().getSchemeSpecificPart();
 
       // Workaround for bug in Java for OS X from Oracle (7u51)
       // https://github.com/processing/processing/issues/2181


### PR DESCRIPTION
Fixes #4417

Java has problems dealing with UNC paths. See http://wiki.eclipse.org/Eclipse/UNC_Paths#Programming_with_UNC_paths to get an idea how bad it is. Scheme specific part should contain the whole decoded URI except the protocol name and following colon, which should shield us from Java parsing URL parts incorrectly.