### PR TITLE
Simplify conditional branch

### DIFF
--- a/java/src/processing/mode/java/JavaInputHandler.java
+++ b/java/src/processing/mode/java/JavaInputHandler.java
@@ -160,7 +160,7 @@ public class JavaInputHandler extends PdeInputHandler {
         textarea.setSelectedText(spaces(tabSize));
         event.consume();
 
-      } else if (!Preferences.getBoolean("editor.tabs.expand")) {
+      } else {  // !Preferences.getBoolean("editor.tabs.expand")
         textarea.setSelectedText("\t");
         event.consume();
       }


### PR DESCRIPTION
Checking `editor.tabs.expand` is done just before the block,
so this condition is always met.