### PR TITLE
Set text color for InputMethod

### DIFF
--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -80,6 +80,7 @@ public class JEditTextArea extends JComponent
   private InputMethodSupport inputMethodSupport = null;
 
   private Brackets bracketHelper = new Brackets();
+  private TextAreaDefaults defaults;
 
 
   /**
@@ -87,6 +88,8 @@ public class JEditTextArea extends JComponent
    * @param defaults The default settings
    */
   public JEditTextArea(TextAreaDefaults defaults, InputHandler inputHandler) {
+    this.defaults = defaults;
+
     // Enable the necessary events
     enableEvents(AWTEvent.KEY_EVENT_MASK);
 
@@ -192,7 +195,7 @@ public class JEditTextArea extends JComponent
   public InputMethodRequests getInputMethodRequests() {
     if (Preferences.getBoolean("editor.input_method_support")) {
       if (inputMethodSupport == null) {
-        inputMethodSupport = new InputMethodSupport(this, inputHandler);
+        inputMethodSupport = new InputMethodSupport(this, defaults, inputHandler);
         /*
         inputMethodSupport.setCallback(new InputMethodSupport.Callback() {
           @Override

--- a/app/src/processing/app/syntax/im/InputMethodSupport.java
+++ b/app/src/processing/app/syntax/im/InputMethodSupport.java
@@ -23,6 +23,7 @@ import processing.app.Messages;
 import processing.app.Preferences;
 import processing.app.syntax.InputHandler;
 import processing.app.syntax.JEditTextArea;
+import processing.app.syntax.TextAreaDefaults;
 import processing.app.syntax.TextAreaPainter;
 
 
@@ -52,13 +53,16 @@ public class InputMethodSupport implements InputMethodRequests, InputMethodListe
   };
 
   private JEditTextArea textArea;
+  private TextAreaDefaults defaults;
   private InputHandler inputHandler;
 
   private int committedCount = 0;
   private AttributedString composedTextString;
 
-  public InputMethodSupport(JEditTextArea textArea, InputHandler inputHandler) {
+  public InputMethodSupport(JEditTextArea textArea, TextAreaDefaults defaults,
+                            InputHandler inputHandler) {
     this.textArea = textArea;
+    this.defaults = defaults;
     this.inputHandler = inputHandler;
 
     textArea.enableInputMethods(true);
@@ -220,8 +224,15 @@ public class InputMethodSupport implements InputMethodRequests, InputMethodListe
     if (text.getEndIndex() - (text.getBeginIndex() + committedCount) > 0) {
       composedTextString = new AttributedString(text, committedCount, text.getEndIndex(), CUSTOM_IM_ATTRIBUTES);
       Font font = painter.getFontMetrics().getFont();
+      Color bgColor;
+      if (defaults.lineHighlight) {
+        bgColor = defaults.lineHighlightColor;
+      } else {
+        bgColor = defaults.bgcolor;
+      }
       composedTextString.addAttribute(TextAttribute.FONT, font);
-      composedTextString.addAttribute(TextAttribute.BACKGROUND, Color.WHITE);
+      composedTextString.addAttribute(TextAttribute.FOREGROUND, defaults.fgcolor);
+      composedTextString.addAttribute(TextAttribute.BACKGROUND, bgColor);
     } else {
       composedTextString = new AttributedString("");
       return null;


### PR DESCRIPTION
It is difficult to see the editing text,
because default text color might be similar to the background color:

![ss](https://cloud.githubusercontent.com/assets/7347125/17280312/05ed6004-57c8-11e6-98b9-c602273e593f.png)
