### PR TITLE
Support input method as default

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -100,6 +100,7 @@ public class Preferences {
 
     // other things that have to be set explicitly for the defaults
     setColor("run.window.bgcolor", SystemColor.control); //$NON-NLS-1$
+    setBoolean("editor.input_method_support", true);
 
     // next load user preferences file
     preferencesFile = Base.getSettingsFile(PREFS_FILE);


### PR DESCRIPTION
It is kind to support input method as default for such environment.
And if a user is in an environment what doesn't use input method,
enabling input method is no harm, I think.