### PR TITLE
Set sketch as modified when any character committed using input method

### DIFF
--- a/app/src/processing/app/syntax/InputHandler.java
+++ b/app/src/processing/app/syntax/InputHandler.java
@@ -1173,4 +1173,12 @@ public abstract class InputHandler extends KeyAdapter
     }
     return wordEnd;
   }
+
+
+  /**
+   * Called when input method support committed a character.
+   * @param c The input character
+   */
+  public void onCommittedFromInputMethodSupport(char c) {
+  }
 }

--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -193,6 +193,12 @@ public class JEditTextArea extends JComponent
     if (Preferences.getBoolean("editor.input_method_support")) {
       if (inputMethodSupport == null) {
         inputMethodSupport = new InputMethodSupport(this);
+        inputMethodSupport.setCallback(new InputMethodSupport.Callback() {
+          @Override
+          public void onCommitted(char c) {
+            inputHandler.onCommittedFromInputMethodSupport(c);
+          }
+        });
       }
       return inputMethodSupport;
     }

--- a/app/src/processing/app/syntax/im/InputMethodSupport.java
+++ b/app/src/processing/app/syntax/im/InputMethodSupport.java
@@ -40,6 +40,10 @@ import processing.app.syntax.TextAreaPainter;
  */
 public class InputMethodSupport implements InputMethodRequests, InputMethodListener {
 
+  public interface Callback {
+    public void onCommitted(char c);
+  }
+
   static private final Attribute[] CUSTOM_IM_ATTRIBUTES = {
     TextAttribute.INPUT_METHOD_HIGHLIGHT,
   };
@@ -47,11 +51,17 @@ public class InputMethodSupport implements InputMethodRequests, InputMethodListe
   private int committedCount = 0;
   private JEditTextArea textArea;
   private AttributedString composedTextString;
+  private Callback callback;
 
   public InputMethodSupport(JEditTextArea textArea) {
     this.textArea = textArea;
     this.textArea.enableInputMethods(true);
     this.textArea.addInputMethodListener(this);
+  }
+
+
+  public void setCallback(Callback callback) {
+    this.callback = callback;
   }
 
 
@@ -170,6 +180,8 @@ public class InputMethodSupport implements InputMethodRequests, InputMethodListe
       char c = text.first();
       while (remaining-- > 0) {
         insertCharacter(c);
+        if (callback != null)
+          callback.onCommitted(c);
         c = text.next();
       }
 

--- a/java/src/processing/mode/java/JavaInputHandler.java
+++ b/java/src/processing/mode/java/JavaInputHandler.java
@@ -334,6 +334,13 @@ public class JavaInputHandler extends PdeInputHandler {
   }
 
 
+  @Override
+  public void onCommittedFromInputMethodSupport(char c) {
+    Sketch sketch = editor.getSketch();
+    sketch.setModified(true);
+  }
+
+
   /**
    * Return the index for the first character on this line.
    */


### PR DESCRIPTION
Currently, when a user input any character using input method support, sketch is not marked as modified.

So no dialog popped up when the user tried to close the window or quit the application and lost the changes.
