### PR TITLE
Insert string when it is committed

### DIFF
--- a/app/src/processing/app/syntax/im/InputMethodSupport.java
+++ b/app/src/processing/app/syntax/im/InputMethodSupport.java
@@ -184,15 +184,17 @@ public class InputMethodSupport implements InputMethodRequests, InputMethodListe
     }
 
     if (text != null) {
-      char[] insertion = new char[committedCount];
-      char c = text.first();
-      for (int i = 0; i < committedCount; i++) {
-        insertion[i] = c;
-        c = text.next();
+      if (committedCount > 0) {
+        char[] insertion = new char[committedCount];
+        char c = text.first();
+        for (int i = 0; i < committedCount; i++) {
+          insertion[i] = c;
+          c = text.next();
+        }
+        // Insert this as a compound edit
+        textArea.setSelectedText(new String(insertion), true);
+        inputHandler.handleInputMethodCommit();
       }
-      // Insert this as a compound edit
-      textArea.setSelectedText(new String(insertion), true);
-      inputHandler.handleInputMethodCommit();
 
       CompositionTextPainter compositionPainter = textArea.getPainter().getCompositionTextpainter();
       if (Base.DEBUG) {


### PR DESCRIPTION
`inputMethodTextChanged` is called each time
when a user pressed key and keeps modifying a text on input method support.
In the time, code hasn't been modified yet,
but calling `handleInputMethodCommit` makes sketch as modified.

Code is modified when the user pressed enter key to decide the input,
and then `committedCount` becomes non zero.