### PR TITLE
Fix resizing targets for async save

### DIFF
--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -8364,12 +8364,10 @@ public class PGraphics extends PImage implements PConstants {
           targetsCreated++;
         } else {
           target = targetPool.take();
-          if (target.width != requestedWidth ||
-              target.height != requestedHeight) {
-            target.width = requestedWidth;
-            target.height = requestedHeight;
+          if (target.pixelWidth != requestedWidth ||
+              target.pixelHeight != requestedHeight) {
             // TODO: this kills performance when saving different sizes
-            target.pixels = new int[requestedWidth * requestedHeight];
+            target = new PImage(requestedWidth, requestedHeight);
           }
         }
         target.format = format;


### PR DESCRIPTION
Got burned by not setting pixelWidth and pixelHeight properly.

Fixes #4578