### PR TITLE
Issue 4407: catches exception from WritableRaster.getDataElements.

### DIFF
--- a/core/src/processing/awt/PGraphicsJava2D.java
+++ b/core/src/processing/awt/PGraphicsJava2D.java
@@ -2749,7 +2749,13 @@ public class PGraphicsJava2D extends PGraphics {
     }
 
     WritableRaster raster = getRaster();
-    raster.getDataElements(0, 0, pixelWidth, pixelHeight, pixels);
+
+    try {
+      raster.getDataElements(0, 0, pixelWidth, pixelHeight, pixels);
+    } catch (Exception e) {
+      System.err.println(e.getMessage());
+    }
+
     if (raster.getNumBands() == 3) {
       // Java won't set the high bits when RGB, returns 0 for alpha
       // https://github.com/processing/processing/issues/2030


### PR DESCRIPTION
#4407 

Catches exception thrown by `.getDataElements` call when window is rapidly resized.

![issue_4407](https://cloud.githubusercontent.com/assets/2738046/17687379/78d3a724-6342-11e6-996d-a2eeedba3d40.gif)
