### PR TITLE
Scroll textarea to the left when caret is outside

### DIFF
--- a/app/src/processing/app/syntax/JEditTextArea.java
+++ b/app/src/processing/app/syntax/JEditTextArea.java
@@ -563,10 +563,12 @@ public class JEditTextArea extends JComponent
     }
 
     int x = _offsetToX(line,offset);
+    int leftLimit = _offsetToX(line, 0) - horizontalOffset;
     int width = painter.getFontMetrics().charWidth('w');
 
-    if(x < 0) {
-      newHorizontalOffset = Math.max(0,horizontalOffset - x + width + 5);
+    if (x - width < leftLimit) {
+      int d = leftLimit - (x - width);
+      newHorizontalOffset = Math.min(leftHandGutter, horizontalOffset + d);
     } else if(x + width >= painter.getWidth()) {
       newHorizontalOffset = horizontalOffset +
       (painter.getWidth() - x) - width - 5;


### PR DESCRIPTION
Left gutter is added in Java mode,
and `0` doesn't mean the left limit for `x` position.
So Scrolling to the left is not started
even if caret is hidden with left gutter.

This change calculates leftmost position of textarea,
and when caret moves out of it,
change horizontal scroll position.