### PR TITLE
Simplify font situation to make it possible to use vanilla JRE trees

### DIFF
--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -975,16 +975,24 @@ public class Toolkit {
    * the Preferences window, and can be used by HTMLEditorKit for WebFrame).
    */
   static private Font createFont(String filename, int size) throws IOException, FontFormatException {
+    boolean registerFont = false;
+
     // Can't use Base.getJavaHome(), because if we're not using our local JRE,
     // we likely have bigger problems with how things are running.
     File fontFile = new File(System.getProperty("java.home"), "lib/fonts/" + filename);
     if (!fontFile.exists()) {
+      // any of the fallbacks below is a custom location, so try to register the font as well
+      registerFont = true;
       // if we're debugging from Eclipse, grab it from the work folder (user.dir is /app)
       fontFile = new File(System.getProperty("user.dir"), "../build/shared/lib/fonts/" + filename);
     }
     if (!fontFile.exists()) {
       // if we're debugging the new Java Mode from Eclipse, paths are different
       fontFile = new File(System.getProperty("user.dir"), "../../shared/lib/fonts/" + filename);
+    }
+    if (!fontFile.exists()) {
+      // this if for Linux, where we're shipping a second copy of the fonts outside of java
+      fontFile = Platform.getContentFile("lib/fonts/" + filename);
     }
     if (!fontFile.exists()) {
       String msg = "Could not find required fonts. ";
@@ -1003,6 +1011,13 @@ public class Toolkit {
     BufferedInputStream input = new BufferedInputStream(new FileInputStream(fontFile));
     Font font = Font.createFont(Font.TRUETYPE_FONT, input);
     input.close();
+
+    // this makes Font() work for font files in custom locations
+    if (registerFont) {
+      GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+      ge.registerFont(font);
+    }
+
     return font.deriveFont((float) size);
   }
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -756,7 +756,10 @@
     <copy todir="linux/work">
       <fileset dir=".." includes="core/library/**" />
       <fileset dir="shared" includes="launch4j/**" />
-      <fileset dir="shared" includes="lib/**" excludes="lib/fonts/**" />
+      <!-- this used to excludes="lib/fonts/**", but instead, ship a second -->
+      <!-- copy of the font files on Linux, so that users can experiment with -->
+      <!-- drop-in or globally installed JVM versions -->
+      <fileset dir="shared" includes="lib/**"  />
       <fileset dir="shared" includes="modes/**" />
       <fileset file="shared/revisions.txt" />
     </copy>

--- a/build/build.xml
+++ b/build/build.xml
@@ -611,15 +611,8 @@
     <copy todir="macosx/work/Processing.app/Contents/Java">
       <fileset dir=".." includes="core/library/**" /> <!-- why this? -->
       <!--<fileset dir="shared" includes="launch4j/**" />-->
-      <fileset dir="shared" includes="lib/**" excludes="lib/fonts/**" />
+      <fileset dir="shared" includes="lib/**" />
       <fileset file="shared/revisions.txt" />
-    </copy>
-
-    <!--
-    Processing.app/Contents/PlugIns/jdk1.7.0_40.jdk/Contents/Home/jre/lib/fonts
-    -->
-    <copy todir="macosx/work/Processing.app/Contents/PlugIns/jdk${jdk.esoteric}.jdk/Contents/Home/jre/lib/fonts">
-      <fileset dir="shared/lib/fonts" includes="*" />
     </copy>
 
     <antcall target="assemble">
@@ -756,9 +749,6 @@
     <copy todir="linux/work">
       <fileset dir=".." includes="core/library/**" />
       <fileset dir="shared" includes="launch4j/**" />
-      <!-- this used to excludes="lib/fonts/**", but instead, ship a second -->
-      <!-- copy of the font files on Linux, so that users can experiment with -->
-      <!-- drop-in or globally installed JVM versions -->
       <fileset dir="shared" includes="lib/**"  />
       <fileset dir="shared" includes="modes/**" />
       <fileset file="shared/revisions.txt" />
@@ -860,11 +850,6 @@
       -->
       <fileset refid="jre-optional-linux" />
     </delete>
-
-    <copy todir="linux/work/java/lib/fonts">
-      <fileset dir="shared/lib/fonts" includes="*" />
-    </copy>
-
   </target>
   
   <target name="linux-run" depends="linux-build" 
@@ -1056,7 +1041,7 @@
     <copy todir="windows/work">
       <fileset dir=".." includes="core/library/**" />
       <fileset dir="shared" includes="launch4j/**" />
-      <fileset dir="shared" includes="lib/**" excludes="lib/fonts/**" />
+      <fileset dir="shared" includes="lib/**" />
       <fileset dir="shared" includes="modes/**" />
       <fileset file="shared/revisions.txt" />
     </copy>
@@ -1122,10 +1107,6 @@
       -->
       <fileset refid="jre-optional-windows" />
     </delete>
-
-    <copy todir="windows/work/java/lib/fonts">
-      <fileset dir="shared/lib/fonts" includes="*" />
-    </copy>
   </target>
   
   <target name="windows-run" depends="windows-build" 


### PR DESCRIPTION
This has only been lightly tested on OS X and ARM Linux. The createFont function could be also simplified in the future by mandating all custom files to be placed in shared/fonts.

Note: this still prints "Source Code Pro not available, resetting to monospaced" (and will change preferences.txt accordingly). This seems to be because the first `createFont("SourceCodePro-Regular.ttf")` only comes after the call to `updateAppearance()`. (The Source _Sans_ Pro fonts are instead created & registered _before_ the `updateAppearance()`).

Will be busy with real life the next week, but I can look some more into this next weekend!