### PR TITLE
Fix set extensions MAC OSX CFBundleDocument

### DIFF
--- a/build/macosx/appbundler/src/com/oracle/appbundler/BundleDocument.java
+++ b/build/macosx/appbundler/src/com/oracle/appbundler/BundleDocument.java
@@ -51,7 +51,7 @@ public class BundleDocument {
         
         extensions = extensionsList.split(",");
         for (String extension : extensions) {
-            extension.trim().toLowerCase();
+            extension = extension.trim().toLowerCase();
         }
     }
     


### PR DESCRIPTION
Updated extensions with the returned value from trim() and toLowerCase() methods.
Fix [#4615](https://github.com/processing/processing/issues/4615)