### PR TITLE
Call glGetProgramiv to retrieve program log length

### DIFF
--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1701,7 +1701,7 @@ public class PJOGL extends PGL {
   @Override
   public String getProgramInfoLog(int program) {
     int[] val = { 0 };
-    gl2.glGetShaderiv(program, GL2ES2.GL_INFO_LOG_LENGTH, val, 0);
+    gl2.glGetProgramiv(program, GL2ES2.GL_INFO_LOG_LENGTH, val, 0);
     int length = val[0];
 
     if (0 < length) {


### PR DESCRIPTION
Calling glGetShaderiv to retrieve the program log length produces a
GL_INVALID_OPERATION error and length < 0, preventing the return of the
actual info log. This fix replaces the call to glGetShaderiv with
glGetProgramiv.

Closes #4659