### PR TITLE
PDEX: Add 'Jump to Declaration' to right-click menu (#4668)

### DIFF
--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -312,6 +312,7 @@ editor.header.delete.warning.title = Yeah, no.
 editor.header.delete.warning.text = You cannot delete the main tab of the only open sketch.
 
 # PopUp menu
+editor.popup.jump_to_declaration = Jump to Declaration
 editor.popup.show_usage = Show Usage...
 editor.popup.rename = Rename...
 

--- a/build/shared/lib/languages/PDE_uk.properties
+++ b/build/shared/lib/languages/PDE_uk.properties
@@ -316,6 +316,7 @@ editor.header.delete.warning.title = Хех, ні.
 editor.header.delete.warning.text = Не можна видалити головну вкладку єдиного відкритого ескізу.
 
 # PopUp menu
+editor.popup.jump_to_declaration = Перейти до визначення
 editor.popup.show_usage = Показати використання...
 editor.popup.rename = Перейменувати...
 

--- a/java/src/processing/mode/java/pdex/PDEX.java
+++ b/java/src/processing/mode/java/pdex/PDEX.java
@@ -22,6 +22,7 @@ import java.awt.EventQueue;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.InputEvent;
@@ -205,6 +206,10 @@ public class PDEX {
 
       // Add listeners
 
+      JMenuItem showUsageItem = new JMenuItem(Language.text("editor.popup.jump_to_declaration"));
+      showUsageItem.addActionListener(e -> handleInspect());
+      editor.getTextArea().getRightClickPopup().add(showUsageItem);
+
       editor.getJavaTextArea().getPainter().addMouseListener(new MouseAdapter() {
         @Override
         public void mousePressed(MouseEvent e) {
@@ -273,6 +278,12 @@ public class PDEX {
 
     }
 
+    void handleInspect() {
+      int off = editor.getSelectionStart();
+      int tabIndex = editor.getSketch().getCurrentCodeIndex();
+
+      pps.whenDoneBlocking(ps -> handleInspect(ps, tabIndex, off));
+    }
 
     // Thread: EDT
     void handleInspect(MouseEvent evt) {


### PR DESCRIPTION
### Contains

A simple implementation for #4668 - adds a "Jump to Declaration" option to the PDEX context menu with the same functionality as ctrl-clicking on a variable (jumps to the declaration of the variable if it was declared within the sketch; otherwise shows its' usage instead).

![image](https://cloud.githubusercontent.com/assets/13783592/19515960/64c9c59a-9602-11e6-9597-be5979c4f207.png)
### How to test

In a Processing sketch, right-click on a variable, select "Jump to Declaration" and verify that the declaration is indeed being jumped to 😄 
### Outstanding before merging
- [ ] When a variable not defined within the sketch is ctrl+clicked, the "Show Usage" window is displayed instead. Should the menu option behave in the same way?
