### PR TITLE
The previous translation would actually stand for "Open sketches folder", as if this…

### DIFF
--- a/build/shared/lib/languages/PDE_es.properties
+++ b/build/shared/lib/languages/PDE_es.properties
@@ -60,7 +60,7 @@ menu.library.contributed = Contribuidas
 menu.library.no_core_libraries = el modo no tiene bibliotecas incluidas
 # ---
 menu.sketch = Sketch
-menu.sketch.show_sketch_folder = Mostrar carpeta de sketches
+menu.sketch.show_sketch_folder = Mostrar carpeta del sketch
 menu.sketch.add_file = Añadir archivo
 
 # | File | Edit | Sketch | Debug | Tools | Help |


### PR DESCRIPTION
… menu option opened the generic folder where all the sketches are stored by default. But what it actually does is opening the folder of the sketch we are working on. That's why I think this translation is incorrect, and the correct one would be "Mostrar carpeta del sketch".