### PR TITLE
CM: Fix null versions in the contribution manager (#4696)

### DIFF
--- a/app/src/processing/app/contrib/DetailPanel.java
+++ b/app/src/processing/app/contrib/DetailPanel.java
@@ -461,7 +461,7 @@ class DetailPanel extends JPanel {
     desc.append("</font> ");
 
     String version = contrib.getPrettyVersion();
-    if (version != null) {
+    if (version != null && !version.equals("null")) {
       desc.append(version);
     }
     desc.append(" <br/>");

--- a/app/src/processing/app/contrib/StatusPanel.java
+++ b/app/src/processing/app/contrib/StatusPanel.java
@@ -259,12 +259,24 @@ class StatusPanel extends JPanel {
 
     if (panel.getContrib().isCompatible(Base.getRevision())) {
       if (installButton.isEnabled()) {
-        updateLabel.setText(latestVersion + " available");
+        if (latestVersion != null) {
+          updateLabel.setText(latestVersion + " available");
+        } else {
+          updateLabel.setText("Available");
+        }
       } else {
-        updateLabel.setText(currentVersion + " installed");
+        if (currentVersion != null && !currentVersion.equals("null")) {
+          updateLabel.setText(currentVersion + " installed");
+        } else {
+          updateLabel.setText("Installed");
+        }
       }
     } else {
-      updateLabel.setText(currentVersion + " not compatible");
+      if (currentVersion != null && !currentVersion.equals("null")) {
+        updateLabel.setText(currentVersion + " not compatible");
+      } else {
+        updateLabel.setText("Not compatible");
+      }
     }
 
     if (latestVersion != null) {


### PR DESCRIPTION
### Contains

A fix for #4696 that adds some checks to avoid displaying `null` in the contribution manager. Note that `prettyVersion` becomes a `"null"` **string** when the base version is invalid - this is reflected in the checks.

### How to test

Check that PeasyCam, a library that currently has an invalid contribution file, has no `null` versions displayed in the contribution manager:

![image](https://cloud.githubusercontent.com/assets/13783592/19627243/f2b65472-994a-11e6-8df6-a6ec43de64cb.png)
