### PR TITLE
Fix nested type constructors raising error

### DIFF
--- a/java/src/processing/mode/java/pdex/SourceUtils.java
+++ b/java/src/processing/mode/java/pdex/SourceUtils.java
@@ -55,8 +55,12 @@ public class SourceUtils {
 
 
 
+  // Positive lookahead and lookbehind are needed to match all type constructors
+  // in code like `int(byte(245))` where first bracket matches as last
+  // group in "^int(" but also as a first group in "(byte(". Lookahead and
+  // lookbehind won't consume the shared character.
   public static final Pattern TYPE_CONSTRUCTOR_REGEX =
-      Pattern.compile("(?:^|\\W)(int|char|float|boolean|byte)(?:\\s*\\()",
+      Pattern.compile("(?<=^|\\W)(int|char|float|boolean|byte)(?=\\s*\\()",
                       Pattern.MULTILINE);
 
   public static List<Edit> replaceTypeConstructors(CharSequence source) {


### PR DESCRIPTION
Replace non-capturing groups by positive lookahead and lookbehind, because they don't consume the source String and allow for first and last group to overlap when two constructors are directly nested.

Fixes #4652