### PR TITLE
Not printing exception to the console

### DIFF
--- a/app/src/processing/app/contrib/ManagerFrame.java
+++ b/app/src/processing/app/contrib/ManagerFrame.java
@@ -383,7 +383,7 @@ public class ManagerFrame {
         activeTab.updateCategoryChooser();
 
         if (error) {
-          exception.printStackTrace();
+          // Show the tab with error panel
           makeAndShowTab(true, false);
         } else {
           makeAndShowTab(false, false);


### PR DESCRIPTION
Fix for #4732 
Completely removes the network error stack from Processing console.