### PR TITLE
Report missing brace in correct tab, suppress other errors until fixed

### DIFF
--- a/java/src/processing/mode/java/pdex/ErrorMessageSimplifier.java
+++ b/java/src/processing/mode/java/pdex/ErrorMessageSimplifier.java
@@ -75,7 +75,7 @@ public class ErrorMessageSimplifier {
 
 
   public static String getIDName(int id) {
-    if (constantsMap == null){
+    if (constantsMap == null) {
       prepareConstantsList();
     }
     return constantsMap.get(id);
@@ -103,175 +103,174 @@ public class ErrorMessageSimplifier {
 
     switch (iprob.getID()) {
 
-    case IProblem.ParsingError:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.error_on", args[0]);
-      }
-      break;
+      case IProblem.ParsingError:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.error_on", args[0]);
+        }
+        break;
 
-    case IProblem.ParsingErrorDeleteToken:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.error_on", args[0]);
-      }
-      break;
+      case IProblem.ParsingErrorDeleteToken:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.error_on", args[0]);
+        }
+        break;
 
-    case IProblem.ParsingErrorInsertToComplete:
-      if (args.length > 0) {
-        if (args[0].length() == 1) {
-          result = getErrorMessageForBracket(args[0].charAt(0));
-
-        } else {
-          if (args[0].equals("AssignmentOperator Expression")) {
-            result = Language.interpolate("editor.status.missing.add", "=");
-
-          } else if (args[0].equalsIgnoreCase(") Statement")) {
+      case IProblem.ParsingErrorInsertToComplete:
+        if (args.length > 0) {
+          if (args[0].length() == 1) {
             result = getErrorMessageForBracket(args[0].charAt(0));
 
           } else {
-            result = Language.interpolate("editor.status.error_on", args[0]);
+            if (args[0].equals("AssignmentOperator Expression")) {
+              result = Language.interpolate("editor.status.missing.add", "=");
+
+            } else if (args[0].equalsIgnoreCase(") Statement")) {
+              result = getErrorMessageForBracket(args[0].charAt(0));
+
+            } else {
+              result = Language.interpolate("editor.status.error_on", args[0]);
+            }
           }
         }
-      }
-      break;
+        break;
 
-    case IProblem.ParsingErrorInvalidToken:
-      if (args.length > 0) {
-        if (args[1].equals("VariableDeclaratorId")) {
-          if (args[0].equals("int")) {
-            result = Language.text ("editor.status.reserved_words");
+      case IProblem.ParsingErrorInvalidToken:
+        if (args.length > 0) {
+          if (args[1].equals("VariableDeclaratorId")) {
+            if (args[0].equals("int")) {
+              result = Language.text("editor.status.reserved_words");
+            } else {
+              result = Language.interpolate("editor.status.error_on", args[0]);
+            }
           } else {
             result = Language.interpolate("editor.status.error_on", args[0]);
           }
-        } else {
-          result = Language.interpolate("editor.status.error_on", args[0]);
         }
-      }
-      break;
+        break;
 
-    case IProblem.ParsingErrorInsertTokenAfter:
-      if (args.length > 0) {
-        if (args[1].length() == 1) {
-          result = getErrorMessageForBracket(args[1].charAt(0));
-        }
-        else {
-          // https://github.com/processing/processing/issues/3104
-          if (args[1].equalsIgnoreCase("Statement")) {
-            result = Language.interpolate("editor.status.error_on", args[0]);
+      case IProblem.ParsingErrorInsertTokenAfter:
+        if (args.length > 0) {
+          if (args[1].length() == 1) {
+            result = getErrorMessageForBracket(args[1].charAt(0));
           } else {
-            result =
-              Language.interpolate("editor.status.error_on", args[0]) + " " +
-              Language.interpolate("editor.status.missing.add", args[1]);
+            // https://github.com/processing/processing/issues/3104
+            if (args[1].equalsIgnoreCase("Statement")) {
+              result = Language.interpolate("editor.status.error_on", args[0]);
+            } else {
+              result =
+                  Language.interpolate("editor.status.error_on", args[0]) + " " +
+                      Language.interpolate("editor.status.missing.add", args[1]);
+            }
           }
         }
-      }
-      break;
+        break;
 
-    case IProblem.UndefinedConstructor:
-      if (args.length == 2) {
-        String constructorName = args[0];
-        // For messages such as "contructor sketch_name.ClassXYZ() is undefined", change
-        // constructor name to "ClassXYZ()". See #3434
-        if (constructorName.contains(".")) {
-          // arg[0] contains sketch name twice: sketch_150705a.sketch_150705a.Thing
-          constructorName = constructorName.substring(constructorName.indexOf('.') + 1);
-          constructorName = constructorName.substring(constructorName.indexOf('.') + 1);
+      case IProblem.UndefinedConstructor:
+        if (args.length == 2) {
+          String constructorName = args[0];
+          // For messages such as "contructor sketch_name.ClassXYZ() is undefined", change
+          // constructor name to "ClassXYZ()". See #3434
+          if (constructorName.contains(".")) {
+            // arg[0] contains sketch name twice: sketch_150705a.sketch_150705a.Thing
+            constructorName = constructorName.substring(constructorName.indexOf('.') + 1);
+            constructorName = constructorName.substring(constructorName.indexOf('.') + 1);
+          }
+          String constructorArgs = removePackagePrefixes(args[args.length - 1]);
+          result = Language.interpolate("editor.status.undefined_constructor", constructorName, constructorArgs);
         }
-        String constructorArgs = removePackagePrefixes(args[args.length - 1]);
-        result = Language.interpolate("editor.status.undefined_constructor", constructorName, constructorArgs);
-      }
-      break;
+        break;
 
-    case IProblem.UndefinedMethod:
-      if (args.length > 2) {
-        String methodName = args[args.length - 2];
-        String methodArgs = removePackagePrefixes(args[args.length - 1]);
-        result = Language.interpolate("editor.status.undefined_method", methodName, methodArgs);
-      }
-      break;
+      case IProblem.UndefinedMethod:
+        if (args.length > 2) {
+          String methodName = args[args.length - 2];
+          String methodArgs = removePackagePrefixes(args[args.length - 1]);
+          result = Language.interpolate("editor.status.undefined_method", methodName, methodArgs);
+        }
+        break;
 
-    case IProblem.ParameterMismatch:
-      if (args.length > 3) {
-        // 2nd arg is method name, 3rd arg is correct param list
-        if (args[2].trim().length() == 0) {
-          // the case where no params are needed.
-          result = Language.interpolate("editor.status.empty_param", args[1]);
+      case IProblem.ParameterMismatch:
+        if (args.length > 3) {
+          // 2nd arg is method name, 3rd arg is correct param list
+          if (args[2].trim().length() == 0) {
+            // the case where no params are needed.
+            result = Language.interpolate("editor.status.empty_param", args[1]);
 
-        } else {
-          result = Language.interpolate("editor.status.wrong_param",
-                                 args[1], args[1], removePackagePrefixes(args[2]));
+          } else {
+            result = Language.interpolate("editor.status.wrong_param",
+                                          args[1], args[1], removePackagePrefixes(args[2]));
 //          String method = q(args[1]);
 //          String methodDef = " \"" + args[1] + "(" + getSimpleName(args[2]) + ")\"";
 //          result = result.replace("method", method);
 //          result += methodDef;
+          }
         }
-      }
-      break;
+        break;
 
-    case IProblem.UndefinedField:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.undef_global_var", args[0]);
-      }
-      break;
+      case IProblem.UndefinedField:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.undef_global_var", args[0]);
+        }
+        break;
 
-    case IProblem.UndefinedType:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.undef_class", args[0]);
-      }
-      break;
+      case IProblem.UndefinedType:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.undef_class", args[0]);
+        }
+        break;
 
-    case IProblem.UnresolvedVariable:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.undef_var", args[0]);
-      }
-      break;
+      case IProblem.UnresolvedVariable:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.undef_var", args[0]);
+        }
+        break;
 
-    case IProblem.UndefinedName:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.undef_name", args[0]);
-      }
-      break;
+      case IProblem.UndefinedName:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.undef_name", args[0]);
+        }
+        break;
 
-    case IProblem.TypeMismatch:
-      if (args.length > 1) {
-        result = Language.interpolate("editor.status.type_mismatch", args[0], args[1]);
+      case IProblem.TypeMismatch:
+        if (args.length > 1) {
+          result = Language.interpolate("editor.status.type_mismatch", args[0], args[1]);
 //        result = result.replace("typeA", q(args[0]));
 //        result = result.replace("typeB", q(args[1]));
-      }
-      break;
+        }
+        break;
 
-    case IProblem.LocalVariableIsNeverUsed:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.unused_variable", args[0]);
-      }
-      break;
+      case IProblem.LocalVariableIsNeverUsed:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.unused_variable", args[0]);
+        }
+        break;
 
-    case IProblem.UninitializedLocalVariable:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.uninitialized_variable", args[0]);
-      }
-      break;
+      case IProblem.UninitializedLocalVariable:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.uninitialized_variable", args[0]);
+        }
+        break;
 
-    case IProblem.AssignmentHasNoEffect:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.no_effect_assignment", args[0]);
-      }
-      break;
+      case IProblem.AssignmentHasNoEffect:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.no_effect_assignment", args[0]);
+        }
+        break;
 
-    case IProblem.HidingEnclosingType:
-      if (args.length > 0) {
-        result = Language.interpolate("editor.status.hiding_enclosing_type", args[0]);
-      }
-      break;
+      case IProblem.HidingEnclosingType:
+        if (args.length > 0) {
+          result = Language.interpolate("editor.status.hiding_enclosing_type", args[0]);
+        }
+        break;
 
-    default:
-      String message = iprob.getMessage();
-      if (message != null) {
-        // Remove all instances of token
-        // "Syntax error on token 'blah', delete this token"
-        Matcher matcher = tokenRegExp.matcher(message);
-        message = matcher.replaceAll("");
-        result = message;
-      }
+      default:
+        String message = iprob.getMessage();
+        if (message != null) {
+          // Remove all instances of token
+          // "Syntax error on token 'blah', delete this token"
+          Matcher matcher = tokenRegExp.matcher(message);
+          message = matcher.replaceAll("");
+          result = message;
+        }
     }
 
     if (DEBUG) {

--- a/java/src/processing/mode/java/pdex/JavaProblem.java
+++ b/java/src/processing/mode/java/pdex/JavaProblem.java
@@ -60,21 +60,28 @@ public class JavaProblem implements Problem {
 
   public static final int ERROR = 1, WARNING = 2;
 
+  public JavaProblem(String message, int type, int tabIndex, int lineNumber) {
+    this.message = message;
+    this.type = type;
+    this.tabIndex = tabIndex;
+    this.lineNumber = lineNumber;
+  }
+
   /**
    *
    * @param iProblem - The IProblem which is being wrapped
    * @param tabIndex - The tab number to which the error belongs to
    * @param lineNumber - Line number(pde code) of the error
    */
-  public JavaProblem(IProblem iProblem, int tabIndex, int lineNumber) {
+  public static JavaProblem fromIProblem(IProblem iProblem, int tabIndex, int lineNumber) {
+    int type = 0;
     if(iProblem.isError()) {
       type = ERROR;
     } else if (iProblem.isWarning()) {
       type = WARNING;
     }
-    this.tabIndex = tabIndex;
-    this.lineNumber = lineNumber;
-    this.message = ErrorMessageSimplifier.getSimplifiedErrorMessage(iProblem);
+    String message = ErrorMessageSimplifier.getSimplifiedErrorMessage(iProblem);
+    return new JavaProblem(message, type, tabIndex, lineNumber);
   }
 
   public void setPDEOffsets(int startOffset, int stopOffset){

--- a/java/src/processing/mode/java/pdex/JavaProblem.java
+++ b/java/src/processing/mode/java/pdex/JavaProblem.java
@@ -20,9 +20,6 @@ along with this program; if not, write to the Free Software Foundation, Inc.
 
 package processing.mode.java.pdex;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.eclipse.jdt.core.compiler.IProblem;
 
 import processing.app.Problem;
@@ -83,9 +80,7 @@ public class JavaProblem implements Problem {
     }
     this.tabIndex = tabIndex;
     this.lineNumber = lineNumber;
-    this.message = process(iProblem);
-    this.message = ErrorMessageSimplifier.getSimplifiedErrorMessage(this);
-    //ErrorMessageSimplifier.getSimplifiedErrorMessage(this);
+    this.message = ErrorMessageSimplifier.getSimplifiedErrorMessage(iProblem);
   }
 
   public void setPDEOffsets(int startOffset, int stopOffset){
@@ -155,30 +150,6 @@ public class JavaProblem implements Problem {
 
   public void setImportSuggestions(String[] a) {
     importSuggestions = a;
-  }
-
-  private static final Pattern tokenRegExp = Pattern.compile("\\b token\\b");
-
-  public static String process(IProblem problem) {
-    return process(problem.getMessage());
-  }
-
-  /**
-   * Processes error messages and attempts to make them a bit more english like.
-   * Currently performs:
-   * <li>Remove all instances of token. "Syntax error on token 'blah', delete this token"
-   * becomes "Syntax error on 'blah', delete this"
-   * @param message - The message to be processed
-   * @return String - The processed message
-   */
-  public static String process(String message) {
-    // Remove all instances of token
-    // "Syntax error on token 'blah', delete this token"
-	if(message == null) return null;
-    Matcher matcher = tokenRegExp.matcher(message);
-    message = matcher.replaceAll("");
-
-    return message;
   }
 
   // Split camel case words into separate words.

--- a/java/src/processing/mode/java/pdex/JavaProblem.java
+++ b/java/src/processing/mode/java/pdex/JavaProblem.java
@@ -31,10 +31,6 @@ import processing.app.Problem;
  */
 public class JavaProblem implements Problem {
   /**
-   * The IProblem which is being wrapped
-   */
-  private IProblem iProblem;
-  /**
    * The tab number to which the error belongs to
    */
   private int tabIndex;
@@ -71,11 +67,9 @@ public class JavaProblem implements Problem {
    * @param lineNumber - Line number(pde code) of the error
    */
   public JavaProblem(IProblem iProblem, int tabIndex, int lineNumber) {
-    this.iProblem = iProblem;
     if(iProblem.isError()) {
       type = ERROR;
-    }
-    else if(iProblem.isWarning()) {
+    } else if (iProblem.isWarning()) {
       type = WARNING;
     }
     this.tabIndex = tabIndex;
@@ -88,60 +82,39 @@ public class JavaProblem implements Problem {
     this.stopOffset = stopOffset;
   }
 
+  @Override
   public int getStartOffset() {
     return startOffset;
   }
 
+  @Override
   public int getStopOffset() {
     return stopOffset;
   }
 
-  public String toString() {
-    return new String("TAB " + tabIndex + ",LN " + lineNumber + "LN START OFF: "
-        + startOffset + ",LN STOP OFF: " + stopOffset + ",PROB: "
-        + message);
-  }
-
+  @Override
   public boolean isError() {
     return type == ERROR;
   }
 
+  @Override
   public boolean isWarning() {
     return type == WARNING;
   }
 
+  @Override
   public String getMessage() {
     return message;
   }
 
-  public IProblem getIProblem() {
-    return iProblem;
-  }
-
+  @Override
   public int getTabIndex() {
     return tabIndex;
   }
 
+  @Override
   public int getLineNumber() {
     return lineNumber;
-  }
-
-  /**
-   * Remember to subtract a -1 to line number because in compile check code an
-   * extra package statement is added, so all line numbers are increased by 1
-   *
-   * @return
-   */
-  public int getSourceLineNumber() {
-    return iProblem.getSourceLineNumber();
-  }
-
-  public void setType(int ProblemType){
-    if(ProblemType == ERROR)
-      type = ERROR;
-    else if(ProblemType == WARNING)
-      type = WARNING;
-    else throw new IllegalArgumentException("Illegal Problem type passed to Problem.setType(int)");
   }
 
   public String[] getImportSuggestions() {
@@ -152,23 +125,11 @@ public class JavaProblem implements Problem {
     importSuggestions = a;
   }
 
-  // Split camel case words into separate words.
-  // "VaraibleDeclaration" becomes "Variable Declaration"
-  // But sadly "PApplet" become "P Applet" and so on.
-  public static String splitCamelCaseWord(String word) {
-    String newWord = "";
-    for (int i = 1; i < word.length(); i++) {
-      if (Character.isUpperCase(word.charAt(i))) {
-        // System.out.println(word.substring(0, i) + " "
-        // + word.substring(i));
-        newWord += word.substring(0, i) + " ";
-        word = word.substring(i);
-        i = 1;
-      }
-    }
-    newWord += word;
-    // System.out.println(newWord);
-    return newWord.trim();
+  @Override
+  public String toString() {
+    return "TAB " + tabIndex + ",LN " + lineNumber + "LN START OFF: "
+        + startOffset + ",LN STOP OFF: " + stopOffset + ",PROB: "
+        + message;
   }
 
 }

--- a/java/src/processing/mode/java/pdex/PreprocessedSketch.java
+++ b/java/src/processing/mode/java/pdex/PreprocessedSketch.java
@@ -26,7 +26,7 @@ public class PreprocessedSketch {
   public final ClassPath classPath;
   public final URLClassLoader classLoader;
 
-  public final ClassPath searchClassPath;
+  public final String[] searchClassPathArray;
 
   public final int[] tabStartOffsets;
 
@@ -206,7 +206,7 @@ public class PreprocessedSketch {
     public ClassPath classPath;
     public URLClassLoader classLoader;
 
-    public ClassPath searchClassPath;
+    public String[] searchClassPathArray;
 
     public int[] tabStartOffsets = new int[0];
 
@@ -242,7 +242,7 @@ public class PreprocessedSketch {
     classPath = b.classPath;
     classLoader = b.classLoader;
 
-    searchClassPath = b.searchClassPath;
+    searchClassPathArray = b.searchClassPathArray;
 
     tabStartOffsets = b.tabStartOffsets;
 

--- a/java/src/processing/mode/java/pdex/PreprocessedSketch.java
+++ b/java/src/processing/mode/java/pdex/PreprocessedSketch.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import processing.app.Problem;
 import processing.app.Sketch;
 import processing.core.PApplet;
 import processing.mode.java.pdex.TextTransform.OffsetMapper;
@@ -33,6 +34,8 @@ public class PreprocessedSketch {
   public final String javaCode;
 
   public final OffsetMapper offsetMapper;
+
+  public final List<Problem> missingBraceProblems;
 
   public final boolean hasSyntaxErrors;
   public final boolean hasCompilationErrors;
@@ -212,6 +215,8 @@ public class PreprocessedSketch {
 
     public OffsetMapper offsetMapper;
 
+    public final List<Problem> missingBraceProblems = new ArrayList<>(0);
+
     public boolean hasSyntaxErrors;
     public boolean hasCompilationErrors;
 
@@ -245,6 +250,8 @@ public class PreprocessedSketch {
     javaCode = b.javaCode;
 
     offsetMapper = b.offsetMapper != null ? b.offsetMapper : OffsetMapper.EMPTY_MAPPER;
+
+    missingBraceProblems = Collections.unmodifiableList(b.missingBraceProblems);
 
     hasSyntaxErrors = b.hasSyntaxErrors;
     hasCompilationErrors = b.hasCompilationErrors;

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -341,7 +341,7 @@ public class PreprocessingService {
 
       boolean rebuildClassPath = reloadCodeFolder || rebuildLibraryClassPath ||
           prevResult.classLoader == null || prevResult.classPath == null ||
-          prevResult.classPathArray == null || prevResult.searchClassPath == null;
+          prevResult.classPathArray == null || prevResult.searchClassPathArray == null;
 
       if (reloadCodeFolder) {
         codeFolderClassPath = buildCodeFolderClassPath(sketch);
@@ -381,13 +381,12 @@ public class PreprocessingService {
           searchClassPath.addAll(coreLibraryClassPath);
           searchClassPath.addAll(codeFolderClassPath);
 
-          String[] searchClassPathArray = searchClassPath.stream().toArray(String[]::new);
-          result.searchClassPath = classPathFactory.createFromPaths(searchClassPathArray);
+          result.searchClassPathArray = searchClassPath.stream().toArray(String[]::new);
         }
       } else {
         result.classLoader = prevResult.classLoader;
         result.classPath = prevResult.classPath;
-        result.searchClassPath = prevResult.searchClassPath;
+        result.searchClassPathArray = prevResult.searchClassPathArray;
         result.classPathArray = prevResult.classPathArray;
       }
     }

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -392,6 +392,15 @@ public class PreprocessingService {
       }
     }
 
+    { // Check for missing braces
+      List<JavaProblem> missingBraceProblems =
+          SourceUtils.checkForMissingBraces(workBuffer, result.tabStartOffsets);
+      if (!missingBraceProblems.isEmpty()) {
+        result.missingBraceProblems.addAll(missingBraceProblems);
+        result.hasSyntaxErrors = true;
+      }
+    }
+
     // Transform code to parsable state
     String parsableStage = toParsable.apply();
     OffsetMapper parsableMapper = toParsable.getMapper();
@@ -414,7 +423,7 @@ public class PreprocessingService {
         makeAST(parser, compilableStageChars, COMPILER_OPTIONS);
 
     // Get syntax problems from compilable AST
-    result.hasSyntaxErrors = Arrays.stream(compilableCU.getProblems())
+    result.hasSyntaxErrors |= Arrays.stream(compilableCU.getProblems())
         .anyMatch(IProblem::isError);
 
     // Generate bindings after getting problems - avoids

--- a/java/src/processing/mode/java/pdex/SourceUtils.java
+++ b/java/src/processing/mode/java/pdex/SourceUtils.java
@@ -323,4 +323,45 @@ public class SourceUtils {
 
   }
 
+  static public List<JavaProblem> checkForMissingBraces(StringBuilder p, int[] tabStartOffsets) {
+    List<JavaProblem> problems = new ArrayList<>(0);
+    tabLoop: for (int tabIndex = 0; tabIndex < tabStartOffsets.length; tabIndex++) {
+      int tabStartOffset = tabStartOffsets[tabIndex];
+      int tabEndOffset = (tabIndex < tabStartOffsets.length - 1) ?
+          tabStartOffsets[tabIndex + 1] : p.length();
+      int depth = 0;
+      int lineNumber = 0;
+      for (int i = tabStartOffset; i < tabEndOffset; i++) {
+        char ch = p.charAt(i);
+        switch (ch) {
+          case '{':
+            depth++;
+            break;
+          case '}':
+            depth--;
+            break;
+          case '\n':
+            lineNumber++;
+            break;
+        }
+        if (depth < 0) {
+          JavaProblem problem =
+              new JavaProblem("Found one too many } characters without { to match it.",
+                              JavaProblem.ERROR, tabIndex, lineNumber);
+          problem.setPDEOffsets(i - tabStartOffset, i - tabStartOffset + 1);
+          problems.add(problem);
+          continue tabLoop;
+        }
+      }
+      if (depth > 0) {
+        JavaProblem problem =
+            new JavaProblem("Found one too many { characters without } to match it.",
+                            JavaProblem.ERROR, tabIndex, lineNumber - 1);
+        problem.setPDEOffsets(tabEndOffset - tabStartOffset - 2, tabEndOffset - tabStartOffset - 1);
+        problems.add(problem);
+      }
+    }
+    return problems;
+  }
+
 }


### PR DESCRIPTION
Fixes #4702

We should consider automatically completing blocks when user types { and hits enter, otherwise "Missing right curly bracket }" is the only error shown until the block is closed.

Edit: I also appended fix for #4748 *Can't update libraries - JARs are locked* because it would otherwise conflict with this PR.

Libraries imported in opened sketches will be still locked by latest
preprocessed CompilationUnit. Otherwise we would have to copy library
jars somewhere else so they can be available to CompilationUnit while
Contribution Manager updates original unlocked jars.