### PR TITLE
Unify mouse pressed/released events across renderers

### DIFF
--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -806,11 +806,6 @@ public class PSurfaceFX implements PSurface {
     int count = fxEvent.getClickCount();
 
     int action = mouseMap.get(fxEvent.getEventType());
-    //EventType<? extends MouseEvent> et = nativeEvent.getEventType();
-//    if (et == MouseEvent.MOUSE_PRESSED) {
-//      peAction = processing.event.MouseEvent.PRESS;
-//    } else if (et == MouseEvent.MOUSE_RELEASED) {
-//      peAction = processing.event.MouseEvent.RELEASE;
 
     int modifiers = 0;
     if (fxEvent.isShiftDown()) {
@@ -827,12 +822,16 @@ public class PSurfaceFX implements PSurface {
     }
 
     int button = 0;
-    if (fxEvent.isPrimaryButtonDown()) {
-      button = PConstants.LEFT;
-    } else if (fxEvent.isSecondaryButtonDown()) {
-      button = PConstants.RIGHT;
-    } else if (fxEvent.isMiddleButtonDown()) {
-      button = PConstants.CENTER;
+    switch (fxEvent.getButton()) {
+      case PRIMARY:
+        button = PConstants.LEFT;
+        break;
+      case SECONDARY:
+        button = PConstants.RIGHT;
+        break;
+      case MIDDLE:
+        button = PConstants.CENTER;
+        break;
     }
 
     // If running on Mac OS, allow ctrl-click as right mouse.

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1060,12 +1060,16 @@ public class PSurfaceJOGL implements PSurface {
                        InputEvent.ALT_MASK);
 
     int peButton = 0;
-    if ((modifiers & InputEvent.BUTTON1_MASK) != 0) {
-      peButton = PConstants.LEFT;
-    } else if ((modifiers & InputEvent.BUTTON2_MASK) != 0) {
-      peButton = PConstants.CENTER;
-    } else if ((modifiers & InputEvent.BUTTON3_MASK) != 0) {
-      peButton = PConstants.RIGHT;
+    switch (nativeEvent.getButton()) {
+      case com.jogamp.newt.event.MouseEvent.BUTTON1:
+        peButton = PConstants.LEFT;
+        break;
+      case com.jogamp.newt.event.MouseEvent.BUTTON2:
+        peButton = PConstants.CENTER;
+        break;
+      case com.jogamp.newt.event.MouseEvent.BUTTON3:
+        peButton = PConstants.RIGHT;
+        break;
     }
 
     if (PApplet.platform == PConstants.MACOSX) {


### PR DESCRIPTION
OPENGL and FX renderers will now correctly report button which triggered
this pressed/released event (same as JAVA2D).

Previously:
- OPENGL would report currently pressed buttons in order LEFT, CENTER,
RIGHT regardless of which button triggered the event. E.g. when holding
LEFT and presing RIGHT, LEFT would be reported. When holding CENTER and
pressing LEFT, LEFT would be reported
- FX would report only first button which is down, so in RELEASE event
button would be missing

Now:
- event contains only button which triggred this event (button just
pressed or just released)

Fixes #4361