### PR TITLE
FX: Prevent matrix stack overflow

### DIFF
--- a/core/src/processing/javafx/PGraphicsFX2D.java
+++ b/core/src/processing/javafx/PGraphicsFX2D.java
@@ -64,6 +64,7 @@ public class PGraphicsFX2D extends PGraphics {
   Path2D workPath = new Path2D();
   Path2D auxPath = new Path2D();
   boolean openContour;
+  boolean adjustedForThinLines;
   /// break the shape at the next vertex (next vertex() call is a moveto())
   boolean breakShape;
 
@@ -214,7 +215,7 @@ public class PGraphicsFX2D extends PGraphics {
     flushPixels();
 
     if (drawingThinLines()) {
-      pushMatrix();
+      adjustedForThinLines = true;
       translate(0.5f, 0.5f);
     }
   }
@@ -420,8 +421,9 @@ public class PGraphicsFX2D extends PGraphics {
       }
     }
     shape = 0;
-    if (drawingThinLines()) {
-      popMatrix();
+    if (adjustedForThinLines) {
+      adjustedForThinLines = false;
+      translate(-0.5f, -0.5f);
     }
     loaded = false;
   }


### PR DESCRIPTION
Matrix stack could overflow in a very special case when beginShape() was
called while strokeWeight=1 and then strokeWeight was changed before
endShape(). This PR makes sure matrix is popped correctly even when user
changes strokeWeight in the beginShape()/endShape() block.

Decided to bug user only when necessary and not show warining when user
changes strokeWeight in the beginShape()/endShape() block, same as in
JAVA2D. Otherwise we could add checks for all the other things which are
mentioned in the docs, but it would be hell to maintain and use.

Fixes #4206