### PR TITLE
Replace keyChar with keyCode to prevent new line error when debugging

### DIFF
--- a/java/src/processing/mode/java/JavaInputHandler.java
+++ b/java/src/processing/mode/java/JavaInputHandler.java
@@ -164,7 +164,7 @@ public class JavaInputHandler extends PdeInputHandler {
         event.consume();
       }
 
-    } else if (c == 10 || c == 13) {  // auto-indent
+    } else if (code == 10 || code == 13) {  // auto-indent
       if (Preferences.getBoolean("editor.indent")) {
         char contents[] = textarea.getText().toCharArray();
         int tabSize = Preferences.getInteger("editor.tabs.size");


### PR DESCRIPTION
This PR replaces the keyChar check used to trigger auto-indent with a keyCode check, and fixes #4804. `Ctrl+J` happens to be an escape sequence representing new line (and their keyChar values are therefore both 10/`\n`), so `Ctrl+J` and `Ctrl+Shift+J` created a new line to appear when stepping. The keyCode for the Enter Key, however, is different, and hitting the Enter Key would be when the auto-format is triggered.