### PR TITLE
Fix #4826. PShape in Java2D wasn't respecting kind.

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1604,9 +1604,9 @@ public class PShape implements PConstants {
     } else if (family == PRIMITIVE) {
       drawPrimitive(g);
     } else if (family == GEOMETRY) {
-      // same as path
-      drawPath(g);
-//      drawGeometry(g);
+      // Not same as path: `kind` matters.
+//      drawPath(g);
+      drawGeometry(g);
     } else if (family == PATH) {
       drawPath(g);
     }


### PR DESCRIPTION
Fix #4826. I think the bug reporter is confused, since I can't reproduce the bug in P2D but I can in normal Java 2D. It's fixed in Java 2D now anyway.