### PR TITLE
Allow JAVA2D to terminate when animation thread dies

### DIFF
--- a/core/src/processing/core/PSurfaceNone.java
+++ b/core/src/processing/core/PSurfaceNone.java
@@ -207,7 +207,7 @@ public class PSurfaceNone implements PSurface {
 
 
   public boolean isStopped() {
-    return thread == null;
+    return thread == null || !thread.isAlive();
   }
 
 


### PR DESCRIPTION
When Java2D sketch crashes, closing the window does not stop Event
Dispatch Thread. This fix makes PApplet.exit() do the right thing and
not wait for surface to finish when the thread is already dead.

Fixes #4831