### PR TITLE
Rebuild sketchbook window when needed

### DIFF
--- a/app/src/processing/app/Mode.java
+++ b/app/src/processing/app/Mode.java
@@ -691,11 +691,18 @@ public abstract class Mode {
 
   /** Sketchbook has changed, update it on next viewing. */
   public void rebuildSketchbookFrame() {
-    boolean wasVisible =
-      (sketchbookFrame == null) ? false : sketchbookFrame.isVisible();
-    sketchbookFrame = null;  // Force a rebuild
-    if (wasVisible) {
-      showSketchbookFrame();
+    if (sketchbookFrame != null) {
+      boolean visible = sketchbookFrame.isVisible();
+      Rectangle bounds = null;
+      if (visible) {
+        bounds = sketchbookFrame.getBounds();
+        sketchbookFrame.setVisible(false);
+      }
+      sketchbookFrame = null;
+      if (visible) {
+        showSketchbookFrame();
+        sketchbookFrame.setBounds(bounds);
+      }
     }
   }
 

--- a/app/src/processing/app/Mode.java
+++ b/app/src/processing/app/Mode.java
@@ -656,6 +656,7 @@ public abstract class Mode {
       if (visible) {
         bounds = examplesFrame.getBounds();
         examplesFrame.setVisible(false);
+        examplesFrame.dispose();
       }
       examplesFrame = null;
       if (visible) {
@@ -697,6 +698,7 @@ public abstract class Mode {
       if (visible) {
         bounds = sketchbookFrame.getBounds();
         sketchbookFrame.setVisible(false);
+        sketchbookFrame.dispose();
       }
       sketchbookFrame = null;
       if (visible) {

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -657,9 +657,10 @@ public class Sketch {
         // get the changes into the sketchbook menu
         //sketchbook.rebuildMenus();
 
-        // make a new sketch, and i think this will rebuild the sketch menu
+        // make a new sketch and rebuild the sketch menu
         //editor.handleNewUnchecked();
         //editor.handleClose2();
+        editor.getBase().rebuildSketchbookMenus();
         editor.getBase().handleClose(editor, false);
 
       } else {


### PR DESCRIPTION
It mostly worked, except
- old window did not get closed so you ended up with two sketchbook windows
- sketchbook was not being rebuilt when sketch was deleted

Also made sure old sketchbook window and old examples window are disposed before being rebuilt.

Fixes #2944