### PR TITLE
Grab bag of Contribution Manager fixes I accumulated while fixing other stuff

### DIFF
--- a/app/src/processing/app/contrib/ContributionManager.java
+++ b/app/src/processing/app/contrib/ContributionManager.java
@@ -39,7 +39,7 @@ import processing.data.StringDict;
 
 
 public class ContributionManager {
-  static final ContributionListing listing = ContributionListing.getInstance();
+  static ContributionListing listing;
 
 
   /**
@@ -543,6 +543,8 @@ public class ContributionManager {
       @Override
       protected Void doInBackground() throws Exception {
         try {
+          // TODO: pls explain the sleep and why this runs on a worker thread,
+          //   but a couple of lines above on EDT [jv]
           Thread.sleep(1000);
           installPreviouslyFailed(base, Base.getSketchbookToolsFolder());
         } catch (InterruptedException e) {
@@ -610,7 +612,9 @@ public class ContributionManager {
         if (file.getName().equals(contrib.getName())) {
           file.delete();
           installOnStartUp(base, contrib);
-          listing.replaceContribution(contrib, contrib);
+          EventQueue.invokeAndWait(() -> {
+            listing.replaceContribution(contrib, contrib);
+          });
         }
       }
     }
@@ -700,6 +704,7 @@ public class ContributionManager {
 
 
   static public void init(Base base) throws Exception {
+    listing = ContributionListing.getInstance(); // Moved here to make sure it runs on EDT [jv 170121]
     managerDialog = new ManagerFrame(base);
     cleanup(base);
   }

--- a/app/src/processing/app/contrib/ListPanel.java
+++ b/app/src/processing/app/contrib/ListPanel.java
@@ -378,7 +378,7 @@ implements Scrollable, ContributionListing.ChangeListener {
         }
         String authorList = contribution.getAuthorList();
         String name = getAuthorNameWithoutMarkup(authorList);
-        label.setText(name.toString());
+        label.setText(name);
         label.setHorizontalAlignment(SwingConstants.LEFT);
         if(!contribution.isCompatible(Base.getRevision())){
           label.setForeground(Color.LIGHT_GRAY);
@@ -454,12 +454,10 @@ implements Scrollable, ContributionListing.ChangeListener {
           new DetailPanel(ListPanel.this);
         panelByContribution.put(contribution, newPanel);
         visibleContributions.add(contribution);
-        if (newPanel != null) {
-          newPanel.setContribution(contribution);
-          add(newPanel);
-          updatePanelOrdering(visibleContributions);
-          updateColors();  // XXX this is the place
-        }
+        newPanel.setContribution(contribution);
+        add(newPanel);
+        updatePanelOrdering(visibleContributions);
+        updateColors();  // XXX this is the place
       }
     }
   }

--- a/app/src/processing/app/contrib/ListPanel.java
+++ b/app/src/processing/app/contrib/ListPanel.java
@@ -433,7 +433,6 @@ implements Scrollable, ContributionListing.ChangeListener {
 
   void updatePanelOrdering(Set<Contribution> contributionsSet) {
     model.getDataVector().removeAllElements();
-    model.fireTableDataChanged();
     int rowCount = 0;
     synchronized (contributionsSet) {
       for (Contribution entry : contributionsSet) {
@@ -445,6 +444,7 @@ implements Scrollable, ContributionListing.ChangeListener {
         rowCount++;
       }
     }
+    model.fireTableDataChanged();
   }
 
 

--- a/app/src/processing/app/contrib/ListPanel.java
+++ b/app/src/processing/app/contrib/ListPanel.java
@@ -476,50 +476,54 @@ implements Scrollable, ContributionListing.ChangeListener {
 
 
   public void contributionRemoved(final Contribution contribution) {
-    // TODO: this should already be on EDT, check it [jv]
-    EventQueue.invokeLater(new Runnable() {
-      public void run() {
-        synchronized (panelByContribution) {
-          DetailPanel panel = panelByContribution.get(contribution);
-          if (panel != null) {
-            remove(panel);
-            panelByContribution.remove(contribution);
+    if (filter.matches(contribution)) {
+      // TODO: this should already be on EDT, check it [jv]
+      EventQueue.invokeLater(new Runnable() {
+        public void run() {
+          synchronized (panelByContribution) {
+            DetailPanel panel = panelByContribution.get(contribution);
+            if (panel != null) {
+              remove(panel);
+              panelByContribution.remove(contribution);
+            }
           }
+          synchronized (visibleContributions) {
+            visibleContributions.remove(contribution);
+          }
+          updatePanelOrdering(visibleContributions);
+          updateColors();
+          updateUI();
         }
-        synchronized (visibleContributions) {
-          visibleContributions.remove(contribution);
-        }
-        updatePanelOrdering(visibleContributions);
-        updateColors();
-        updateUI();
-      }
-    });
+      });
+    }
   }
 
   public void contributionChanged(final Contribution oldContrib,
                                   final Contribution newContrib) {
-    // TODO: this should already be on EDT, check it [jv]
-    EventQueue.invokeLater(new Runnable() {
-      public void run() {
-        synchronized (panelByContribution) {
-          DetailPanel panel = panelByContribution.get(oldContrib);
-          if (panel == null) {
-            contributionAdded(newContrib);
-          } else {
-            panelByContribution.remove(oldContrib);
-            panel.setContribution(newContrib);
-            panelByContribution.put(newContrib, panel);
+    if (filter.matches(oldContrib) || filter.matches(newContrib)) {
+      // TODO: this should already be on EDT, check it [jv]
+      EventQueue.invokeLater(new Runnable() {
+        public void run() {
+          synchronized (panelByContribution) {
+            DetailPanel panel = panelByContribution.get(oldContrib);
+            if (panel == null) {
+              contributionAdded(newContrib);
+            } else {
+              panelByContribution.remove(oldContrib);
+              panel.setContribution(newContrib);
+              panelByContribution.put(newContrib, panel);
+            }
+          }
+          synchronized (visibleContributions) {
+            if (visibleContributions.contains(oldContrib)) {
+              visibleContributions.remove(oldContrib);
+              visibleContributions.add(newContrib);
+            }
+            updatePanelOrdering(visibleContributions);
           }
         }
-        synchronized (visibleContributions) {
-          if (visibleContributions.contains(oldContrib)) {
-            visibleContributions.remove(oldContrib);
-            visibleContributions.add(newContrib);
-          }
-          updatePanelOrdering(visibleContributions);
-        }
-      }
-    });
+      });
+    }
   }
 
   public void filterLibraries(List<Contribution> filteredContributions) {

--- a/app/src/processing/app/contrib/ListPanel.java
+++ b/app/src/processing/app/contrib/ListPanel.java
@@ -448,81 +448,70 @@ implements Scrollable, ContributionListing.ChangeListener {
   }
 
 
+  // Thread: EDT
   public void contributionAdded(final Contribution contribution) {
     if (filter.matches(contribution)) {
-      // TODO: this should already be on EDT, check it [jv]
-      EventQueue.invokeLater(new Runnable() {
-        public void run() {
-          if (!panelByContribution.containsKey(contribution)) {
-            DetailPanel newPanel =
-              new DetailPanel(ListPanel.this);
-            synchronized (panelByContribution) {
-              panelByContribution.put(contribution, newPanel);
-            }
-            synchronized (visibleContributions) {
-              visibleContributions.add(contribution);
-            }
-            if (newPanel != null) {
-              newPanel.setContribution(contribution);
-              add(newPanel);
-              updatePanelOrdering(visibleContributions);
-              updateColors();  // XXX this is the place
-            }
-          }
+      if (!panelByContribution.containsKey(contribution)) {
+        DetailPanel newPanel =
+          new DetailPanel(ListPanel.this);
+        synchronized (panelByContribution) {
+          panelByContribution.put(contribution, newPanel);
         }
-      });
+        synchronized (visibleContributions) {
+          visibleContributions.add(contribution);
+        }
+        if (newPanel != null) {
+          newPanel.setContribution(contribution);
+          add(newPanel);
+          updatePanelOrdering(visibleContributions);
+          updateColors();  // XXX this is the place
+        }
+      }
     }
   }
 
 
+  // Thread: EDT
   public void contributionRemoved(final Contribution contribution) {
     if (filter.matches(contribution)) {
-      // TODO: this should already be on EDT, check it [jv]
-      EventQueue.invokeLater(new Runnable() {
-        public void run() {
-          synchronized (panelByContribution) {
-            DetailPanel panel = panelByContribution.get(contribution);
-            if (panel != null) {
-              remove(panel);
-              panelByContribution.remove(contribution);
-            }
-          }
-          synchronized (visibleContributions) {
-            visibleContributions.remove(contribution);
-          }
-          updatePanelOrdering(visibleContributions);
-          updateColors();
-          updateUI();
+      synchronized (panelByContribution) {
+        DetailPanel panel = panelByContribution.get(contribution);
+        if (panel != null) {
+          remove(panel);
+          panelByContribution.remove(contribution);
         }
-      });
+      }
+      synchronized (visibleContributions) {
+        visibleContributions.remove(contribution);
+      }
+      updatePanelOrdering(visibleContributions);
+      updateColors();
+      updateUI();
     }
   }
 
+
+  // Thread: EDT
   public void contributionChanged(final Contribution oldContrib,
                                   final Contribution newContrib) {
     if (filter.matches(oldContrib) || filter.matches(newContrib)) {
-      // TODO: this should already be on EDT, check it [jv]
-      EventQueue.invokeLater(new Runnable() {
-        public void run() {
-          synchronized (panelByContribution) {
-            DetailPanel panel = panelByContribution.get(oldContrib);
-            if (panel == null) {
-              contributionAdded(newContrib);
-            } else {
-              panelByContribution.remove(oldContrib);
-              panel.setContribution(newContrib);
-              panelByContribution.put(newContrib, panel);
-            }
-          }
-          synchronized (visibleContributions) {
-            if (visibleContributions.contains(oldContrib)) {
-              visibleContributions.remove(oldContrib);
-              visibleContributions.add(newContrib);
-            }
-            updatePanelOrdering(visibleContributions);
-          }
+      synchronized (panelByContribution) {
+        DetailPanel panel = panelByContribution.get(oldContrib);
+        if (panel == null) {
+          contributionAdded(newContrib);
+        } else {
+          panelByContribution.remove(oldContrib);
+          panel.setContribution(newContrib);
+          panelByContribution.put(newContrib, panel);
         }
-      });
+      }
+      synchronized (visibleContributions) {
+        if (visibleContributions.contains(oldContrib)) {
+          visibleContributions.remove(oldContrib);
+          visibleContributions.add(newContrib);
+        }
+        updatePanelOrdering(visibleContributions);
+      }
     }
   }
 

--- a/app/src/processing/app/contrib/UpdateListPanel.java
+++ b/app/src/processing/app/contrib/UpdateListPanel.java
@@ -247,10 +247,8 @@ public class UpdateListPanel extends ListPanel {
     DetailPanel panel = panelByContribution.get(oldContrib);
     if (panel == null) {
       contributionAdded(newContrib);
-    } else {
+    } else if (newContrib.isInstalled()) {
       panelByContribution.remove(oldContrib);
-    }
-    if (visibleContributions.contains(oldContrib)) {
       visibleContributions.remove(oldContrib);
     }
     updatePanelOrdering(visibleContributions);

--- a/app/src/processing/app/contrib/UpdateListPanel.java
+++ b/app/src/processing/app/contrib/UpdateListPanel.java
@@ -218,58 +218,50 @@ public class UpdateListPanel extends ListPanel {
   }
 
 
+  // Thread: EDT
   @Override
   public void contributionAdded(final Contribution contribution) {
     if (filter.matches(contribution)) {
-      // TODO: this should already be on EDT, check it [jv]
-      EventQueue.invokeLater(new Runnable() {
-        public void run() {
-          // TODO make this longer and more contorted [fry]
-          DetailPanel newPanel =
-            contributionTab.contribDialog.getTab(contribution.getType()).contributionListPanel.panelByContribution.get(contribution);
-          if (newPanel == null) {
-            newPanel = new DetailPanel(UpdateListPanel.this);
-          }
-          synchronized (panelByContribution) {
-            if (!panelByContribution.containsKey(contribution)) {
-              panelByContribution.put(contribution, newPanel);
-            }
-            synchronized (visibleContributions) {
-              visibleContributions.add(contribution);
-            }
-            if (newPanel != null) {
-              newPanel.setContribution(contribution);
-              add(newPanel);
-              updatePanelOrdering(panelByContribution.keySet());
-              updateColors(); // XXX this is the place
-            }
-          }
+      // TODO make this longer and more contorted [fry]
+      DetailPanel newPanel =
+        contributionTab.contribDialog.getTab(contribution.getType()).contributionListPanel.panelByContribution.get(contribution);
+      if (newPanel == null) {
+        newPanel = new DetailPanel(UpdateListPanel.this);
+      }
+      synchronized (panelByContribution) {
+        if (!panelByContribution.containsKey(contribution)) {
+          panelByContribution.put(contribution, newPanel);
         }
-      });
+        synchronized (visibleContributions) {
+          visibleContributions.add(contribution);
+        }
+        if (newPanel != null) {
+          newPanel.setContribution(contribution);
+          add(newPanel);
+          updatePanelOrdering(panelByContribution.keySet());
+          updateColors(); // XXX this is the place
+        }
+      }
     }
   }
-  
+
+  // Thread: EDT
   @Override
   public void contributionChanged(final Contribution oldContrib,
                                   final Contribution newContrib) {
-    // TODO: this should already be on EDT, check it [jv]
-    EventQueue.invokeLater(new Runnable() {
-      public void run() {
-        synchronized (panelByContribution) {
-          DetailPanel panel = panelByContribution.get(oldContrib);
-          if (panel == null) {
-            contributionAdded(newContrib);
-          } else {
-            panelByContribution.remove(oldContrib);
-          }
-        }
-        synchronized (visibleContributions) {
-          if (visibleContributions.contains(oldContrib)) {
-            visibleContributions.remove(oldContrib);
-          }
-          updatePanelOrdering(visibleContributions);
-        }
+    synchronized (panelByContribution) {
+      DetailPanel panel = panelByContribution.get(oldContrib);
+      if (panel == null) {
+        contributionAdded(newContrib);
+      } else {
+        panelByContribution.remove(oldContrib);
       }
-    });
+    }
+    synchronized (visibleContributions) {
+      if (visibleContributions.contains(oldContrib)) {
+        visibleContributions.remove(oldContrib);
+      }
+      updatePanelOrdering(visibleContributions);
+    }
   }
 }

--- a/app/src/processing/app/contrib/UpdateListPanel.java
+++ b/app/src/processing/app/contrib/UpdateListPanel.java
@@ -233,12 +233,10 @@ public class UpdateListPanel extends ListPanel {
         panelByContribution.put(contribution, newPanel);
       }
       visibleContributions.add(contribution);
-      if (newPanel != null) {
-        newPanel.setContribution(contribution);
-        add(newPanel);
-        updatePanelOrdering(panelByContribution.keySet());
-        updateColors(); // XXX this is the place
-      }
+      newPanel.setContribution(contribution);
+      add(newPanel);
+      updatePanelOrdering(panelByContribution.keySet());
+      updateColors(); // XXX this is the place
     }
   }
 

--- a/app/src/processing/app/contrib/UpdateListPanel.java
+++ b/app/src/processing/app/contrib/UpdateListPanel.java
@@ -158,7 +158,6 @@ public class UpdateListPanel extends ListPanel {
 //    (UpdateContributionTab) contributionTab
 
     model.getDataVector().removeAllElements();
-    model.fireTableDataChanged();
     ContributionType currentType = null;
 
     // Avoid ugly synthesized bold
@@ -213,6 +212,7 @@ public class UpdateListPanel extends ListPanel {
         contributionTab.contribListing.getLatestPrettyVersion(entry)
       });
     }
+    model.fireTableDataChanged();
     UpdateContributionTab tab = (UpdateContributionTab) contributionTab;
     ((UpdateStatusPanel) tab.statusPanel).update();
   }

--- a/app/src/processing/app/contrib/UpdateListPanel.java
+++ b/app/src/processing/app/contrib/UpdateListPanel.java
@@ -151,6 +151,7 @@ public class UpdateListPanel extends ListPanel {
     });
   }
 
+  // Thread: EDT
   @Override
   void updatePanelOrdering(Set<Contribution> contributionsSet) {
 //    int updateCount = panelByContribution.size();
@@ -228,19 +229,15 @@ public class UpdateListPanel extends ListPanel {
       if (newPanel == null) {
         newPanel = new DetailPanel(UpdateListPanel.this);
       }
-      synchronized (panelByContribution) {
-        if (!panelByContribution.containsKey(contribution)) {
-          panelByContribution.put(contribution, newPanel);
-        }
-        synchronized (visibleContributions) {
-          visibleContributions.add(contribution);
-        }
-        if (newPanel != null) {
-          newPanel.setContribution(contribution);
-          add(newPanel);
-          updatePanelOrdering(panelByContribution.keySet());
-          updateColors(); // XXX this is the place
-        }
+      if (!panelByContribution.containsKey(contribution)) {
+        panelByContribution.put(contribution, newPanel);
+      }
+      visibleContributions.add(contribution);
+      if (newPanel != null) {
+        newPanel.setContribution(contribution);
+        add(newPanel);
+        updatePanelOrdering(panelByContribution.keySet());
+        updateColors(); // XXX this is the place
       }
     }
   }
@@ -249,19 +246,15 @@ public class UpdateListPanel extends ListPanel {
   @Override
   public void contributionChanged(final Contribution oldContrib,
                                   final Contribution newContrib) {
-    synchronized (panelByContribution) {
-      DetailPanel panel = panelByContribution.get(oldContrib);
-      if (panel == null) {
-        contributionAdded(newContrib);
-      } else {
-        panelByContribution.remove(oldContrib);
-      }
+    DetailPanel panel = panelByContribution.get(oldContrib);
+    if (panel == null) {
+      contributionAdded(newContrib);
+    } else {
+      panelByContribution.remove(oldContrib);
     }
-    synchronized (visibleContributions) {
-      if (visibleContributions.contains(oldContrib)) {
-        visibleContributions.remove(oldContrib);
-      }
-      updatePanelOrdering(visibleContributions);
+    if (visibleContributions.contains(oldContrib)) {
+      visibleContributions.remove(oldContrib);
     }
+    updatePanelOrdering(visibleContributions);
   }
 }


### PR DESCRIPTION
- Fire table change notifincations only after all changes happened
- In listeners, ignore contributions which are of different kind than current tab
- Remove redundant invokeLater() which spammed EDT with hundreds of Runnables
- Remove some manual sychronization since the code runs on EDT
- Remove two conditions which are always true
- Fix Update tab which broke in the process - contributions now stay on update screen with spinning wheel until installation completes