### PR TITLE
Keep Windows timer resolution high for OpenGL sketches

### DIFF
--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -431,6 +431,20 @@ public class PSurfaceJOGL implements PSurface {
 
 
   protected void initAnimator() {
+    if (PApplet.platform == PConstants.WINDOWS) {
+      // Force Windows to keep timer resolution high by
+      // sleeping for time which is not a multiple of 10 ms.
+      // See section "Clocks and Timers on Windows":
+      //   https://blogs.oracle.com/dholmes/entry/inside_the_hotspot_vm_clocks
+      Thread highResTimerThread = new Thread(() -> {
+        try {
+          Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException ignore) { }
+      }, "HighResTimerThread");
+      highResTimerThread.setDaemon(true);
+      highResTimerThread.start();
+    }
+
     animator = new FPSAnimator(window, 60);
     drawException = null;
     animator.setUncaughtExceptionHandler(new GLAnimatorControl.UncaughtExceptionHandler() {


### PR DESCRIPTION
Otherwise java.util.Timer used by FPSAnimator uses 10 or 15 ms resolution, which results in 60 fps sketches running at around 30 fps and 30 fps sketches running at around 21 fps.

Fixes #4846