### PR TITLE
Fix change detection when adding files to a sketch

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -758,6 +758,16 @@ public class Sketch {
 
 
   /**
+   * Ensure that all SketchCodes are up-to-date, so that sc.save() works.
+   */
+  public void updateSketchCodes() {
+//    if (current.isModified()) {
+    current.setProgram(editor.getText());
+//    }
+  }
+
+
+  /**
    * Save all code in the current sketch. This just forces the files to save
    * in place, so if it's an untitled (un-saved) sketch, saveAs() should be
    * called instead. (This is handled inside Editor.handleSave()).
@@ -767,9 +777,7 @@ public class Sketch {
     ensureExistence();
 
     // first get the contents of the editor text area
-//    if (current.isModified()) {
-    current.setProgram(editor.getText());
-//    }
+    updateSketchCodes();
 
     // don't do anything if not actually modified
     //if (!modified) return false;
@@ -911,9 +919,7 @@ public class Sketch {
 
     // grab the contents of the current tab before saving
     // first get the contents of the editor text area
-    if (current.isModified()) {
-      current.setProgram(editor.getText());
-    }
+    updateSketchCodes();
 
     File[] copyItems = folder.listFiles(new FileFilter() {
       public boolean accept(File file) {

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -450,7 +450,7 @@ change_detect.message.title = File Modified
 change_detect.message.merge.question = Your sketch has been modified externally.<br>Would you like to merge these changes into the editor?
 change_detect.message.merge.comment = Your unsaved changes will be saved first.
 change_detect.message.reload.question = Your sketch has been modified externally, and conflicts exist between<br>your unsaved changes and the external modifications for some tabs.<br>Would you like to reload the sketch?
-change_detect.message.reload.comment = If you reload the sketch, unsaved changes to the following tabs will be lost: <ul>%s</ul>
+change_detect.message.reload.comment = If you reload the sketch, unsaved changes to the following tabs will be lost: <ul>%s</ul><br>All other tabs will be saved.
 
 # ---------------------------------------
 # Contributions

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -445,6 +445,13 @@ ensure_exist.messages.unrecoverable.description = Could not properly re-save the
 # Check name
 check_name.messages.is_name_modified = The sketch name had to be modified. Sketch names can only consist\nof ASCII characters and numbers (but cannot start with a number).\nThey should also be less than 64 characters long.
 
+# Change detector
+change_detect.message.title = File Modified
+change_detect.message.merge.question = Your sketch has been modified externally.<br>Would you like to merge these changes into the editor?
+change_detect.message.merge.comment = Your unsaved changes will be saved first.
+change_detect.message.reload.question = Your sketch has been modified externally, and conflicts exist between<br>your unsaved changes and the external modifications for some tabs.<br>Would you like to reload the sketch?
+change_detect.message.reload.comment = If you reload the sketch, unsaved changes to the following tabs will be lost: <ul>%s</ul>
+
 # ---------------------------------------
 # Contributions
 


### PR DESCRIPTION
Change Detector now differentiates between a merge conflict (same file changed; will load the external changes if accepted by user; discards editor content) or a non-conflicting change (will load the external changes if accepted by user; nothing is lost). This is done per file so that if one tab does conflict and the next doesn't, the non-conflicting tab is not discarded for no reason.
Fixes #4713.