### PR TITLE
Attempt to ease `processing.java` argument passing

### DIFF
--- a/app/src/processing/app/tools/InstallCommander.java
+++ b/app/src/processing/app/tools/InstallCommander.java
@@ -94,7 +94,9 @@ public class InstallCommander implements Tool {
                    "    if [ \"$ARG\" = \"--build\" ]; then\n" +
                    "        OPTION_FOR_HEADLESS_RUN=\"-Djava.awt.headless=true\"\n" +
                    "    fi\n" +
-                   "done\n\n");
+                   "done\n" +
+                   "args=($(pwd) $@)\n" +
+                   "set -- ${args[*]}\n\n");
 
       String javaRoot = Platform.getContentFile(".").getCanonicalPath();
 

--- a/build/linux/processing
+++ b/build/linux/processing
@@ -13,6 +13,11 @@
 # Thanks to Ferdinand Kasper for this build script. [fry]
 
 
+# Make pwd as the first arg
+args=($(pwd) $@)
+set -- ${args[*]}
+
+
 # JARs required from JDK (anywhere in/below the JDK home directory)
 JDKLIBS="rt.jar"
 

--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -210,6 +210,11 @@ public class Commander implements RunnerListener {
       } else if (arg.startsWith(outputArg)) {
         outputSet = true;
         outputPath = arg.substring(outputArg.length());
+        outputPath = outputPath.replaceAll("~", System.getProperty("user.home"));
+        // Relative paths
+        if (!outputPath.matches("^(\\$|\\/).*")) {
+          outputPath = pwd + "/" + outputPath;
+        }
 
       } else if (arg.equals(forceArg)) {
         force = true;

--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -101,6 +101,14 @@ public class Commander implements RunnerListener {
     int task = HELP;
     boolean embedJava = true;
 
+    // Contains the current path
+    String pwd = "";
+    // Only for MacOS and Linux
+    if (!Platform.isWindows() && args.length > 0) {
+      pwd = args[0];
+      args[0] = "";
+    }
+
     try {
       if (Platform.isWindows()) {
         // On Windows, it needs to use the default system encoding.
@@ -173,9 +181,22 @@ public class Commander implements RunnerListener {
 
       } else if (arg.startsWith(sketchArg)) {
         sketchPath = arg.substring(sketchArg.length());
+        sketchPath = sketchPath.replaceAll("~", System.getProperty("user.home"));
         sketchFolder = new File(sketchPath);
+        // If the full path does not exist
         if (!sketchFolder.exists()) {
-          complainAndQuit(sketchFolder + " does not exist.", false);
+          if (Platform.isWindows()) {
+            complainAndQuit(sketchFolder + " does not exist.", false);
+          } else {
+            // Try the relative path
+            if (!new File(pwd + "/" + sketchPath).exists()) {
+              complainAndQuit(sketchFolder + " does not exist.", false);
+            } else {
+              // And then update sketchFolder and sketchPath
+              sketchPath = pwd + "/" + sketchPath;
+              sketchFolder = new File(sketchPath);
+            }
+          }
         }
         File pdeFile = new File(sketchFolder, sketchFolder.getName() + ".pde");
         if (!pdeFile.exists()) {


### PR DESCRIPTION
It should be noted that I speak for Processing on macOS.

In command-line Processing, `processing-java`, the argument for the sketch folder `--sketch=` has to be the full path to that directory, and this can get quite cumbersome. Digging in, I found that the reason was this [line] where the program changes directory and the origin of the directory passed in as an argument is lost.

I'll show you what I mean. Say you're in a directory `~` and you run `processing-java --sketch=test_sketch --run`, you get an error message saying that `test_sketch` cannot be found. Even when you prepend `~/` to the sketch name, you still get a similar error message. But only when you type everything out `/Users/user_name/test_sketch` will you be able to run the program. My Pull Request aims to solve this issue.

First of all, I replace all `~`s with `$HOME`s. Then I check if the sketch directory is valid. If it is, no problem. Otherwise, we prepend the directory from which the command was called.

You can see that this also modifies the `output`. The reason is similar. If you don't specify the full directory for the output folder, it will end up being wherever your [`javaRoot`](https://github.com/processing/processing/blob/a395991e7d9036f979dd77267a641f467cdfd93b/app/src/processing/app/tools/InstallCommander.java#L99) is. So I apply a similar, but simpler, logic for `--output`.

> Note: I have tested this by editing the `processing-java` directly in Bash and it has worked successfully (or at least as far as I can tell). But I haven't tested this Java code in `InstallCommander.java` (because I don't know how).