### PR TITLE
ARM: Allow Raspberry Pi's Mesa GL driver to use up to 8 lights

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -6885,8 +6885,7 @@ public class PGraphicsOpenGL extends PGraphics {
 
     // overwrite the default shaders with vendor specific versions
     // if needed
-    if (OPENGL_RENDERER.equals("VideoCore IV HW") ||    // Broadcom's binary driver for Raspberry Pi
-      OPENGL_RENDERER.equals("Gallium 0.4 on VC4")) {   // Mesa driver for same hardware
+    if (OPENGL_RENDERER.equals("VideoCore IV HW")) {   // Mesa driver for same hardware
         defLightShaderVertURL =
           PGraphicsOpenGL.class.getResource("/processing/opengl/shaders/LightVert-vc4.glsl");
         defTexlightShaderVertURL =


### PR DESCRIPTION
This caused register allocation issues before, but now this seem to be only still necessary for the binary GLES2 driver, where even enabling one more light (from 2 to 3) will make the shader compiler unhappy. Tested with 11.1.0-1+rpi1 on all P2D & P3D examples.