### PR TITLE
Retry with multisampling disabled if creating a framebuffer fails because of INCOMPLETE_MULTISAMPLE

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -961,7 +961,16 @@ public abstract class PGL {
       createDepthAndStencilBuffer(true, depthBits, stencilBits, packed);
     }
 
-    validateFramebuffer();
+    int status = validateFramebuffer();
+
+    if (status == FRAMEBUFFER_INCOMPLETE_MULTISAMPLE && 1 < numSamples) {
+      System.err.println("Continuing with multisampling disabled");
+      reqNumSamples = 1;
+      destroyFBOLayer();
+      // try again
+      createFBOLayer();
+      return;
+    }
 
     // Clear all buffers.
     clearDepth(1);
@@ -2048,10 +2057,10 @@ public abstract class PGL {
   }
 
 
-  protected boolean validateFramebuffer() {
+  protected int validateFramebuffer() {
     int status = checkFramebufferStatus(FRAMEBUFFER);
     if (status == FRAMEBUFFER_COMPLETE) {
-      return true;
+      return 0;
     } else if (status == FRAMEBUFFER_UNDEFINED) {
       System.err.println(String.format(FRAMEBUFFER_ERROR,
                                        "framebuffer undefined"));
@@ -2086,7 +2095,7 @@ public abstract class PGL {
       System.err.println(String.format(FRAMEBUFFER_ERROR,
                                        "unknown error " + status));
     }
-    return false;
+    return status;
   }
 
   protected boolean isES() {


### PR DESCRIPTION
No idea if tearing down the FBO half-way and setting it back up again is recommended practice, but this does make the `Primitives3D` example work for me with the Mesa VC4 driver (see #4919).