### PR TITLE
Revert "ARM: Allow Raspberry Pi's Mesa GL driver to use up to 8 lights"

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -6885,7 +6885,8 @@ public class PGraphicsOpenGL extends PGraphics {
 
     // overwrite the default shaders with vendor specific versions
     // if needed
-    if (OPENGL_RENDERER.equals("VideoCore IV HW")) {   // Mesa driver for same hardware
+    if (OPENGL_RENDERER.equals("VideoCore IV HW") ||    // Broadcom's binary driver for Raspberry Pi
+      OPENGL_RENDERER.equals("Gallium 0.4 on VC4")) {   // Mesa driver for same hardware
         defLightShaderVertURL =
           PGraphicsOpenGL.class.getResource("/processing/opengl/shaders/LightVert-vc4.glsl");
         defTexlightShaderVertURL =


### PR DESCRIPTION
I must have a mistake setting up my testing environment - turn out we still need the custom shader hack for VC4, at least with Mesa 11.1.