### PR TITLE
Added resize() method for PApplet

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1230,6 +1230,21 @@ public class PApplet implements PConstants {
   }
 
 
+  /*
+   * Allows for more streamlined window resizing without needing to
+   * call setResizeable().
+   */
+  public void resize(int width, int height) {
+    if (this.width == width && this.height == height) {
+      return;
+    } else {
+      surface.setResizable(true);
+      surface.setSize(width, height);
+      surface.setResizable(false);
+    }
+  }
+
+  
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 


### PR DESCRIPTION
Issue [#4540](https://github.com/processing/processing/issues/4540) suggests the addition of a resize() method to change the sketch window size with a single line of code. The current way to do this seems to be

`surface.setResizable(true);`
`surface.setSize(w, h); `
`surface.setResizable(false);`

The proposed change allows changing the window size with:

`resize(w, h);`