### PR TITLE
Scrub comments: skip the second chracter in the escape sequence

### DIFF
--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -730,9 +730,15 @@ public class PdePreprocessor {
           throw new RuntimeException("Missing the */ from the end of a " +
                                      "/* comment */");
         }
-      } else if (p[index] == '"' && index > 0 && p[index-1] != '\\') {
+
+        // switch in/out of quoted region
+      } else if (p[index] == '"') {
         insideQuote = !insideQuote;
         index++;
+
+        // skip the escaped char
+      } else if (insideQuote && p[index] == '\\') {
+        index += 2;
 
       } else {  // any old character, move along
         index++;


### PR DESCRIPTION
Fixes #5016