### PR TITLE
Make the change detector not reload the sketch

### DIFF
--- a/app/src/processing/app/Messages.java
+++ b/app/src/processing/app/Messages.java
@@ -266,6 +266,34 @@ public class Messages {
                                            JOptionPane.YES_NO_OPTION,
                                            JOptionPane.QUESTION_MESSAGE);
     } else {
+      int result = showCustomQuestion(editor, title, primary, secondary,
+          0, "Yes", "No");
+      if (result == 0) {
+        return JOptionPane.YES_OPTION;
+      } else if (result == 1) {
+        return JOptionPane.NO_OPTION;
+      } else {
+        return JOptionPane.CLOSED_OPTION;
+      }
+    }
+  }
+
+
+  /**
+   * @param highlight A valid array index for options[] that specifies the
+   *                  default (i.e. safe) choice.
+   * @return The (zero-based) index of the selected value, -1 otherwise.
+   */
+  static public int showCustomQuestion(Frame editor, String title,
+                                       String primary, String secondary,
+                                       int highlight, String... options) {
+    Object result;
+    if (!Platform.isMacOS()) {
+      return JOptionPane.showOptionDialog(editor,
+          "<html><body><b>" + primary + "</b><br>" + secondary, title,
+          JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+          options, options[highlight]);
+    } else {
       // Pane formatting adapted from the Quaqua guide
       // http://www.randelshofer.ch/quaqua/guide/joptionpane.html
       JOptionPane pane =
@@ -275,29 +303,23 @@ public class Messages {
                         "p { font: 11pt \"Lucida Grande\"; margin-top: 8px; width: 300px }"+
                         "</style> </head>" +
                         "<b>" + primary + "</b>" +
-                        "<p>" + secondary + "</p>",
+                        "<p>" + secondary, // + "</p>",
                         JOptionPane.QUESTION_MESSAGE);
 
-      String[] options = new String[] {
-        "Yes", "No"
-      };
       pane.setOptions(options);
 
       // highlight the safest option ala apple hig
-      pane.setInitialValue(options[0]);
+      pane.setInitialValue(options[highlight]);
 
       JDialog dialog = pane.createDialog(editor, null);
       dialog.setVisible(true);
 
-      Object result = pane.getValue();
-      if (result == options[0]) {
-        return JOptionPane.YES_OPTION;
-      } else if (result == options[1]) {
-        return JOptionPane.NO_OPTION;
-      } else {
-        return JOptionPane.CLOSED_OPTION;
-      }
+      result = pane.getValue();
     }
+    for (int i = 0; i < options.length; i++) {
+      if (result != null && result.equals(options[i])) return i;
+    }
+    return -1;
   }
 
 

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -227,6 +227,20 @@ public class Sketch {
   }
 
 
+  /**
+   * Load a tab that the user added to the sketch or modified with an external
+   * editor.
+   */
+  public void loadNewTab(String filename, String ext, boolean newAddition) {
+    if (newAddition) {
+      insertCode(new SketchCode(new File(folder, filename), ext));
+    } else {
+      replaceCode(new SketchCode(new File(folder, filename), ext));
+    }
+    sortCode();
+  }
+
+
   protected void replaceCode(SketchCode newCode) {
     for (int i = 0; i < codeCount; i++) {
       if (code[i].getFileName().equals(newCode.getFileName())) {
@@ -685,7 +699,11 @@ public class Sketch {
   }
 
 
-  protected void removeCode(SketchCode which) {
+  /**
+   * Remove a SketchCode from the list of files without deleting its file.
+   * @see #handleDeleteCode()
+   */
+  public void removeCode(SketchCode which) {
     // remove it from the internal list of files
     // resort internal list of files
     for (int i = 0; i < codeCount; i++) {
@@ -758,6 +776,16 @@ public class Sketch {
 
 
   /**
+   * Ensure that all SketchCodes are up-to-date, so that sc.save() works.
+   */
+  public void updateSketchCodes() {
+//    if (current.isModified()) {
+    current.setProgram(editor.getText());
+//    }
+  }
+
+
+  /**
    * Save all code in the current sketch. This just forces the files to save
    * in place, so if it's an untitled (un-saved) sketch, saveAs() should be
    * called instead. (This is handled inside Editor.handleSave()).
@@ -767,9 +795,7 @@ public class Sketch {
     ensureExistence();
 
     // first get the contents of the editor text area
-//    if (current.isModified()) {
-    current.setProgram(editor.getText());
-//    }
+    updateSketchCodes();
 
     // don't do anything if not actually modified
     //if (!modified) return false;
@@ -911,9 +937,7 @@ public class Sketch {
 
     // grab the contents of the current tab before saving
     // first get the contents of the editor text area
-    if (current.isModified()) {
-      current.setProgram(editor.getText());
-    }
+    updateSketchCodes();
 
     File[] copyItems = folder.listFiles(new FileFilter() {
       public boolean accept(File file) {

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -445,6 +445,18 @@ ensure_exist.messages.unrecoverable.description = Could not properly re-save the
 # Check name
 check_name.messages.is_name_modified = The sketch name had to be modified. Sketch names can only consist\nof ASCII characters and numbers (but cannot start with a number).\nThey should also be less than 64 characters long.
 
+# External changes detector
+change_detect.reload.title=Tab modified externally
+change_detect.reload.question="%s" was modified by another program.
+change_detect.reload.comment=Would you like to keep this version or load the new changes?\nEither way, the version you discard will be saved to your sketch folder.
+change_detect.button.keep=Keep
+change_detect.button.load_new=Load changes
+change_detect.delete.title=Tab deleted externally
+change_detect.delete.question="%s" has disappeared from the sketch folder.
+change_detect.delete.comment=Would you like to re-save it or remove it from your sketch?
+change_detect.button.discard=Remove permanently
+change_detect.button.resave=Re-save
+
 # ---------------------------------------
 # Contributions
 


### PR DESCRIPTION
Fixes #4713, fixes #4849. I've added a method to Messages that accepts custom buttons, and Messages.showYesNoQuestion is now based on it for Mac OS.