### PR TITLE
Improve loadBytes performance

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -7174,14 +7174,15 @@ public class PApplet implements PConstants {
    */
   static public byte[] loadBytes(InputStream input) {
     try {
-      BufferedInputStream bis = new BufferedInputStream(input);
       ByteArrayOutputStream out = new ByteArrayOutputStream();
+      byte[] buf = new byte[4096];
 
-      int c = bis.read();
-      while (c != -1) {
-        out.write(c);
-        c = bis.read();
+      int bytesRead = input.read(buf);
+      while (bytesRead != -1) {
+        out.write(buf, 0, bytesRead);
+        bytesRead = input.read(buf);
       }
+      out.flush();
       return out.toByteArray();
 
     } catch (IOException e) {


### PR DESCRIPTION
I was surprised that loading a 54 MB file with `loadBytes` took as long as it did (2.7 seconds). Hit the code with a hammer a little bit, and now it's down to 0.4 seconds. And seems to works for URLs still...