### PR TITLE
Revert updatePixels() to set modified flag to true

### DIFF
--- a/core/src/processing/awt/PGraphicsJava2D.java
+++ b/core/src/processing/awt/PGraphicsJava2D.java
@@ -2797,7 +2797,7 @@ public class PGraphicsJava2D extends PGraphics {
     if (pixels != null) {
       getRaster().setDataElements(0, 0, pixelWidth, pixelHeight, pixels);
     }
-    modified = false;
+    modified = true;
   }
 
 


### PR DESCRIPTION
This fixes the bug for now, but uncovers a deeper issue.

PImage.modify flag is now used for two purposes and should be split into two variables:
- internally by renderers to signal that pixels[] changed and need to be drawn
- externally to signal other renderers that this image changed in some way and they should update their cache

When a PGraphics is drawn onto other PGraphics, both of these uses collide and may cause problems. This needs to be looked at and resolved later, probably by adding another variable (a flush counter which could be compared with couter of the cached image to tell if cache needs to be updated).

Reverts 51dff7689968c5da7344b61d53e90359eaf8329f

Fixes #5040