### PR TITLE
Consider the $HOME on Linux for locating the sketchbook folder

### DIFF
--- a/app/src/processing/app/platform/LinuxPlatform.java
+++ b/app/src/processing/app/platform/LinuxPlatform.java
@@ -67,6 +67,26 @@ public class LinuxPlatform extends DefaultPlatform {
   }
 
 
+  // Unlike many other UNIX programs, the JVM does not evaluate
+  // the HOME environment variable to construct user.home and
+  // friends, but solely relies on the UID of the current user
+  // for this purpose.
+  // For this reason user.home will always be "/root", even when
+  // a different user attempts to launch Processing with "sudo".
+  // (see also https://askubuntu.com/a/659882)
+  // Attempt to work around this in the least invasive manner,
+  // so that "sudo -E processing" or "sudo -E processing-java"
+  // will pick up the invoking user's sketchbook folder instead.
+  public File getDefaultSketchbookFolder() throws Exception {
+    String sysEnvHome = System.getenv("HOME");
+    if (sysEnvHome != null && 0 < sysEnvHome.length()) {
+      return new File(sysEnvHome, "sketchbook");
+    } else {
+      return super.getDefaultSketchbookFolder();
+    }
+  }
+
+
   public void openURL(String url) throws Exception {
     if (openFolderAvailable()) {
       String launcher = Preferences.get("launcher");


### PR DESCRIPTION
The aim of this change is to make `sudo -E processing{,-java}` work with custom libraries installed in the invoking user's home directory.

@benfry 
It turns out that I might need `sudo -E` after all for use with the Carnivore library, which reasonably needs superpowers to run. Unfortunately, it turns out that Java completely ignores `$HOME` even if set, so `user.home` and friends is always `/root`, which will make Processing not find the libraries the user installed via the Contribution Manager :(

I thought of a couple of ways of addressing this:

* add an accessor function for all locations in P5 that use `user.home` (+ `user.dir`?) and simply return the value from `$HOME` instead if set and differing ... unfortunately my feeling is that the home directory might also be used in various indirect ways (`~` etc), and having the two converge could lead to some hard-to-debug issues
* overwrite the value of the `user.home` (+ `user.dir`?) somewhere right after startup ... Oracle's documentation says this is [potentially dangerous](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html)
* or, the attached patch, which just modifies the default sketchbook location on Linux ... this is good enough to get the Carnivore examples running for the default `pi` user with `sudo -E`.

In a similar way to modifying the default sketchbook location we _additionally_ overwrite `getSettingsFolder` in `LinuxPlatform.java` - not sure if this is preferable or not (it's not needed to get the example going). I am thinking that it might be beneficial to _refrain_ from writing any config files in the user's directory, since they would then be owned by `root` and could potentially no longer be edited by the user itself. 

(Technically the caveat with `sudo` on Java probably also extends to macOS, but not sure if there are many games with sudo played over there...)