### PR TITLE
Consider $SUDO_USER on Linux for locating the sketchbook folder

### DIFF
--- a/app/src/processing/app/Console.java
+++ b/app/src/processing/app/Console.java
@@ -112,11 +112,14 @@ public class Console {
         }
       } else {
         consoleDir.mkdirs();
+        consoleDir.setWritable(true, false);
       }
 
       File outFile = new File(consoleDir, stamp + ".out");
+      outFile.setWritable(true, false);
       stdoutFile = new FileOutputStream(outFile);
       File errFile = new File(consoleDir, stamp + ".err");
+      errFile.setWritable(true, false);
       stderrFile = new FileOutputStream(errFile);
 
       consoleOut = new PrintStream(new ConsoleStream(false));

--- a/app/src/processing/app/Language.java
+++ b/app/src/processing/app/Language.java
@@ -147,6 +147,7 @@ public class Language {
   static public void saveLanguage(String language) {
     try {
       Util.saveFile(language, prefFile);
+      prefFile.setWritable(true, false);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -216,6 +216,7 @@ public class Preferences {
       try {
         File dir = preferencesFile.getParentFile();
         File preferencesTemp = File.createTempFile("preferences", ".txt", dir);
+        preferencesTemp.setWritable(true, false);
 
         // Fix for 0163 to properly use Unicode when writing preferences.txt
         PrintWriter writer = PApplet.createWriter(preferencesTemp);

--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -69,7 +69,7 @@ public class ContributionListing {
 
     //listingFile = Base.getSettingsFile("contributions.txt");
     listingFile = Base.getSettingsFile(LOCAL_FILENAME);
-    listingFile.setWritable(true);
+    listingFile.setWritable(true, false);
     if (listingFile.exists()) {
       setAdvertisedList(listingFile);
     }
@@ -422,7 +422,7 @@ public class ContributionListing {
 //          System.out.println(contribInfo.length() + " " + contribInfo);
 
           File tempContribFile = Base.getSettingsFile("contribs.tmp");
-          tempContribFile.setWritable(true);
+          tempContribFile.setWritable(true, false);
           ContributionManager.download(url, base.getInstalledContribsInfo(),
                                        tempContribFile, progress);
           if (!progress.isCanceled() && !progress.isError()) {

--- a/app/src/processing/app/platform/LinuxPlatform.java
+++ b/app/src/processing/app/platform/LinuxPlatform.java
@@ -77,6 +77,16 @@ public class LinuxPlatform extends DefaultPlatform {
   // Attempt to work around this in the least invasive manner,
   // so that "sudo -E processing" or "sudo -E processing-java"
   // will pick up the invoking user's sketchbook folder instead.
+  public File getSettingsFolder() throws Exception {
+    String sysEnvHome = System.getenv("HOME");
+    if (sysEnvHome != null && 0 < sysEnvHome.length()) {
+      return new File(sysEnvHome, ".processing");
+    } else {
+      return super.getSettingsFolder();
+    }
+  }
+
+
   public File getDefaultSketchbookFolder() throws Exception {
     String sysEnvHome = System.getenv("HOME");
     if (sysEnvHome != null && 0 < sysEnvHome.length()) {

--- a/app/src/processing/app/platform/LinuxPlatform.java
+++ b/app/src/processing/app/platform/LinuxPlatform.java
@@ -67,6 +67,26 @@ public class LinuxPlatform extends DefaultPlatform {
   }
 
 
+  // Unlike many other UNIX programs, the JVM does not evaluate
+  // the HOME environment variable to construct user.home and
+  // friends, but solely relies on the UID of the current user
+  // for this purpose.
+  // For this reason user.home will always be "/root", even when
+  // a different user attempts to launch Processing with "sudo".
+  // (see also https://askubuntu.com/a/659882)
+  // Attempt to work around this in the least invasive manner,
+  // so that "sudo -E processing" or "sudo -E processing-java"
+  // will pick up the invoking user's sketchbook folder instead.
+  public File getDefaultSketchbookFolder() throws Exception {
+    String sysEnvHome = System.getenv("HOME");
+    if (sysEnvHome != null && 0 < sysEnvHome.length()) {
+      return new File(sysEnvHome, "sketchbook");
+    } else {
+      return super.getDefaultSketchbookFolder();
+    }
+  }
+
+
   public void openURL(String url) throws Exception {
     if (openFolderAvailable()) {
       String launcher = Preferences.get("launcher");

--- a/app/src/processing/app/ui/Recent.java
+++ b/app/src/processing/app/ui/Recent.java
@@ -103,6 +103,7 @@ public class Recent {
 
 
   static protected void save() {
+    file.setWritable(true, false);
     PrintWriter writer = PApplet.createWriter(file);
     writer.println(VERSION);
     for (Record record : records) {


### PR DESCRIPTION
This is #5054 but also overwrites `getSettingsFolder` taking `$HOME` into account, so that `sudo -E` works. Since now the root user is now potentially writing into the settings folder, the patch tries to make those files world-writable.

Compared to #5054, this also handles these situations:
* more than one user running `sudo -E processing` (previously this created settings in the root users home directory pointing the sketch directory to the first that called)
* user having a custom path for the sketch folder set
* the root user having `.processing` & `sketchbook` herself (this is still possible to make use of by running `sudo` without the `-E`)

Modifying all files that get created by P5 to be world-writable is probably a futile attempt, but if this is the way to go I would consider adding this at least for:
* creating the sketchbook and .processing folders (so that `sudo -E` without them being already present wouldn't create folders that can later not be written into)
* Processing's `save` family of functions