### PR TITLE
add install / uninstall scripts for linux a-la-Arduino + correct mime types for IDE

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <project name="Processing" default="build">
-  
+
   <!-- Sets properties for macosx/windows/linux depending on current system -->
   <condition property="platform" value="macosx">
-    <os family="mac" /> 
+    <os family="mac" />
   </condition>
 
   <condition property="platform" value="windows">
-    <os family="windows" /> 
+    <os family="windows" />
   </condition>
 
   <condition property="platform" value="linux">
@@ -53,20 +53,20 @@
   </target>
 
   <!-- Require Java 8 everywhere. -->
-  <fail message="Unsupported Java version: ${java.version}. To build, make sure that Java 8 (aka Java 1.8) is installed."> 
-    <condition> 
-      <not> 
-        <or> 
-          <contains string="${java.version}" substring="1.8" /> 
-        </or> 
-      </not> 
-    </condition> 
-  </fail> 
+  <fail message="Unsupported Java version: ${java.version}. To build, make sure that Java 8 (aka Java 1.8) is installed.">
+    <condition>
+      <not>
+        <or>
+          <contains string="${java.version}" substring="1.8" />
+        </or>
+      </not>
+    </condition>
+  </fail>
 
   <!-- could prompt here to download the necessary JRE
        (Windows/Linux) or JDK (on Mac OS X) -->
 
-  <property name="examples.dir" 
+  <property name="examples.dir"
 	    value="../../processing-docs/content/examples" />
 
   <property name="jdk.version" value="8" />
@@ -81,12 +81,12 @@
 
   <!-- Figure out the JRE download location for Linux and Windows. -->
   <!--
-  <condition property="jre.file" 
-             value="jre-${jdk.short}-${platform}-i586.tar.gz"> 
+  <condition property="jre.file"
+             value="jre-${jdk.short}-${platform}-i586.tar.gz">
     <equals arg1="${sun.arch.data.model}" arg2="32" />
   </condition>
-  <condition property="jre.file" 
-             value="jre-${jdk.short}-${platform}-x64.tar.gz"> 
+  <condition property="jre.file"
+             value="jre-${jdk.short}-${platform}-x64.tar.gz">
     <equals arg1="${sun.arch.data.model}" arg2="64" />
   </condition>
   -->
@@ -144,7 +144,7 @@
     <include name="lib/cmm/PYCC.pf" />
   </fileset>
 
-  <!-- Unused JavaFX files that can be removed from the JRE on Windows 
+  <!-- Unused JavaFX files that can be removed from the JRE on Windows
        and Linux. On Mac OS X, this is removed by the appbundler task.
        www.oracle.com/technetwork/java/javase/jdk-7-readme-429198.html
        However, we're now looking into using JavaFX as the default 2D
@@ -203,7 +203,7 @@
   <echo message="${java.class.path}" />
   -->
 
-  <!-- Set a property named macosx, linux, or windows. 
+  <!-- Set a property named macosx, linux, or windows.
        The 'value' chosen is arbitrary. -->
   <property name="${platform}" value="${platform}" />
 
@@ -211,7 +211,7 @@
 
   <property name="jre.tgz.path" value="${platform}/jre-${jdk.short}.tgz" />
 
-  <target name="jre-check"> 
+  <target name="jre-check">
     <available file="${jre.tgz.path}" property="jre.tgz.downloaded" />
   </target>
 
@@ -220,7 +220,7 @@
     <subant buildpath="jre" target="dist" />
 
     <!-- define our special JRE downloader task -->
-    <taskdef name="downloader" 
+    <taskdef name="downloader"
 	     classname="Downloader"
 	     classpath="jre/downloader.jar" />
   </target>
@@ -239,45 +239,45 @@
       <equals arg1="${sun.arch.data.model}" arg2="64" />
     </condition>
 
-    <downloader version="${jdk.version}" 
-                update="${jdk.update}" 
+    <downloader version="${jdk.version}"
+                update="${jdk.update}"
                 build="${jdk.build}"
-                hash="${jdk.hash}" 
+                hash="${jdk.hash}"
                 jdk="${jre.download.jdk}"
                 flavor="${jre.downloader}"
-                path="${jre.tgz.path}" />    
+                path="${jre.tgz.path}" />
   </target>
 
   <target name="download-jdk-macosx" depends="downloader-setup">
-    <downloader version="${jdk.version}" 
-                update="${jdk.update}" 
+    <downloader version="${jdk.version}"
+                update="${jdk.update}"
                 build="${jdk.build}"
-                hash="${jdk.hash}" 
-                jdk="true" 
+                hash="${jdk.hash}"
+                jdk="true"
                 flavor="macosx-x64.dmg"
                 path="${env.HOME}/Desktop/jdk-${jdk.short}.dmg" />
   </target>
 
   <!-- code signing hack, turns on code signing during dist -->
-  <condition property="codesign"> 
+  <condition property="codesign">
     <equals arg1="${env.USER}" arg2="fry" />
   </condition>
 
   <!-- Set the version of Java that must be present to build. -->
-  <property name="jdk.path.macosx" 
+  <property name="jdk.path.macosx"
             value="/Library/Java/JavaVirtualMachines/jdk${jdk.esoteric}.jdk" />
 
   <available file="${jdk.path.macosx}" property="macosx_jdk_found" />
 
   <!--
-  <fail if="linux" unless="java_tools_found" 
+  <fail if="linux" unless="java_tools_found"
         message="The JAVA_HOME variable must be set to the location of a full JDK. For instance, on Ubuntu Linux, this might be /usr/lib/jvm/java-6-sun." />
   -->
-               
+
   <!-- Figure out the platform-specific output directory for all this work. -->
-  <condition property="target.path" 
+  <condition property="target.path"
              value="macosx/work/Processing.app/Contents/Java">
-    <os family="mac" /> 
+    <os family="mac" />
   </condition>
 
   <condition property="target.path" value="linux/work">
@@ -285,7 +285,7 @@
   </condition>
 
   <condition property="target.path" value="windows/work">
-    <os family="windows" /> 
+    <os family="windows" />
   </condition>
 
   <!-- Libraries required for running processing -->
@@ -307,8 +307,8 @@
     <antcall target="${platform}-run" />
   </target>
 
-  <!-- Run the app in a more "native" manner, i.e. no additional 
-       console for debugging. Ensures that double-clicking shortcuts 
+  <!-- Run the app in a more "native" manner, i.e. no additional
+       console for debugging. Ensures that double-clicking shortcuts
        and other desktop integration features work properly. -->
   <target name="app" description="Run Processing w/o console.">
     <antcall target="${platform}-run-app" />
@@ -316,7 +316,7 @@
 
   <target name="dist" depends="revision-check"
           description="Build Processing for distribution.">
-    <input message="Enter version number:" 
+    <input message="Enter version number:"
            addproperty="version"
            defaultvalue="${revision}" />
 
@@ -327,7 +327,7 @@
     <exec executable="git" dir="${examples.dir}">
       <arg line="pull" />
     </exec>
-   
+
     <antcall target="${platform}-dist" />
   </target>
 
@@ -337,11 +337,11 @@
       <arg value="-p" />
     </java>
   </target>
-  
+
   <!-- - - - - - - - - - - - - - - - - - -->
   <!-- Subprojects: Core, App, Libraries -->
   <!-- - - - - - - - - - - - - - - - - - -->
-  
+
   <target name="subprojects-clean">
     <subant buildpath="../core" target="clean"/>
     <subant buildpath="../app" target="clean"/>
@@ -357,7 +357,7 @@
     <!-- make sure this isn't around from an old build 140730 -->
     <delete dir="../java/examples" />
   </target>
-  
+
   <target name="subprojects-build">
     <subant buildpath="../core" target="build"/>
     <subant buildpath="../app" target="build"/>
@@ -381,11 +381,11 @@
   <!-- - - - - - - - - -->
   <!-- Basic Assembly  -->
   <!-- - - - - - - - - -->
- 
+
   <target name="assemble" depends="version-clear, version-write">
-    <fail unless="target.path" 
+    <fail unless="target.path"
           message="Do not call assemble from the command line." />
-    
+
     <!-- copy shared tools folder -->
     <copy todir="${target.path}/tools">
       <fileset dir="shared/tools" />
@@ -412,13 +412,13 @@
     </condition>
 
     <!--<echo message="ref ignoreable? ${reference.ignorable}" />-->
-    <get src="http://download.processing.org/reference.zip" 
+    <get src="http://download.processing.org/reference.zip"
          dest="../java/reference.zip"
          ignoreerrors="${reference.ignorable}"
          usetimestamp="true" />
 
-    <unzip dest="${target.path}/modes/java" 
-           src="../java/reference.zip" 
+    <unzip dest="${target.path}/modes/java"
+           src="../java/reference.zip"
            overwrite="false">
       <patternset>
         <exclude name="__MACOSX/**" />
@@ -437,13 +437,13 @@
 
   <target name="version-clear">
     <delete file="${target.path}/lib/version.txt" />
-  </target> 
+  </target>
 
   <target name="version-write" if="version">
     <echo file="${target.path}/lib/version.txt" message="${version}"/>
-  </target> 
+  </target>
 
-  
+
   <!-- - - - - - - - - -->
   <!-- Revision check  -->
   <!-- - - - - - - - - -->
@@ -460,9 +460,9 @@
       </filterchain>
     </loadfile>
     <!-- <echo message="revision is ${revision}." /> -->
-    
+
     <!-- figure out the revision number in base.java -->
-    <loadfile srcfile="../app/src/processing/app/Base.java" 
+    <loadfile srcfile="../app/src/processing/app/Base.java"
               property="revision.base">
       <filterchain>
         <tokenfilter>
@@ -473,20 +473,20 @@
       </filterchain>
     </loadfile>
     <!-- <echo message="base revision is ${revision.base}." /> -->
-    
+
     <condition property="revision.correct">
       <!-- Using contains because I can't figure out how to get rid of the
            LF in revision.base. Please file a bug if you have a fix. -->
       <contains string="${revision.base}" substring="${revision}"/>
     </condition>
-    
+
     <!-- the revision.base property won't be set
          if $revision wasn't found... -->
-    <fail unless="revision.correct" 
+    <fail unless="revision.correct"
           message="Fix revision number in Base.java" />
   </target>
-  
-  
+
+
   <!-- - - - - - - - -->
   <!-- Mac OS X      -->
   <!-- - - - - - - - -->
@@ -497,18 +497,18 @@
       <fileset dir="macosx" includes="processing-*zip" />
     </delete>
   </target>
-  
+
   <target name="macosx-check-os" unless="macosx">
     <echo>
       =======================================================
       Processing for Mac OS X can only be built on Mac OS X.
-      
-      Bye. 
+
+      Bye.
       =======================================================
     </echo>
     <fail message="wrong platform (${os.name})" />
   </target>
-  
+
   <target name="macosx-build" if="macosx" depends="revision-check, macosx-check-os, subprojects-build" description="Build Mac OS X version">
 
     <!-- Require that a JDK be installed, but call this on build, so that
@@ -517,10 +517,10 @@
           message="JDK ${jdk.short} required.${line.separator}To build on OS X, you must install Oracle's JDK ${jdk.short} from${line.separator}http://www.oracle.com/technetwork/java/javase/downloads${line.separator}Or... type 'ant download-jdk-macosx' to download it to your Desktop.${line.separator}Note that only ${jdk.short} (not a later or earlier version) will work. ${line.separator}And it must be the JDK, not the JRE. And do not try to defy me again." />
 
     <mkdir dir="macosx/work" />
-    
+
     <!-- app bundler for OS X and Java 1.7 -->
     <taskdef name="bundleapp"
-             classname="com.oracle.appbundler.AppBundlerTask"   
+             classname="com.oracle.appbundler.AppBundlerTask"
              classpath="macosx/appbundler.jar" />
 
     <bundleapp outputDirectory="macosx/work"
@@ -539,11 +539,11 @@
                mainClassName="processing.app.BaseSplash">
 
       <!-- The appbundler task needs a couple files (the Info.plist and
-           anything else outside /jre) from the full JDK, even though 
+           anything else outside /jre) from the full JDK, even though
            it's primarily copying over the JRE folder. -->
       <runtime dir="${jdk.path.macosx}/Contents/Home" />
-      <!-- Eventually we'll want to load the JRE directly from 
-           the .tgz on the Oracle site, though it's in a folder called 
+      <!-- Eventually we'll want to load the JRE directly from
+           the .tgz on the Oracle site, though it's in a folder called
            jre1.7.0_40.jre, so we'll need to strip that out. -->
 
       <!-- Same as runtime.jars, seen above; plus core.jar. -->
@@ -573,7 +573,7 @@
 
       <!-- Sets dock icon when debugging (not launched via launch svcs) -->
       <option value="-Xdock:icon=$APP_ROOT/Contents/Resources/processing.icns" />
-      <!-- Don't think these actually make any difference. 
+      <!-- Don't think these actually make any difference.
            (The apple.awt.application.name property is used.)-->
       <!--
       <option value="-Xdock:name=Processing" />
@@ -619,13 +619,13 @@
 -->
     </bundleapp>
 
-    <!-- Temporary fix until new appbundler is included again after solving 
+    <!-- Temporary fix until new appbundler is included again after solving
          https://github.com/processing/processing/issues/3359
          https://github.com/processing/processing/issues/3360
          The 'keytool' file is deleted by our appbundler. Add it back so that
 	 Android signing works properly. (Not modifying our appbundler since
-	 most of the time that appbundler is used, keytool isn't needed). 
-	 Also, because Ant's copy task does not retain file permissions on 
+	 most of the time that appbundler is used, keytool isn't needed).
+	 Also, because Ant's copy task does not retain file permissions on
 	 Unix systems, we need to use <exec executable="cp" ... > instead -->
     <exec executable="cp">
       <arg line="${jdk.path.macosx}/Contents/Home/bin/keytool macosx/work/Processing.app/Contents/PlugIns/jdk${jdk.esoteric}.jdk/Contents/Home/jre/bin"/>
@@ -634,7 +634,7 @@
     <property name="contents.dir"
               location="macosx/work/Processing.app/Contents" />
 
-    <!-- Replace libjli.dylib symlink with actual file. 
+    <!-- Replace libjli.dylib symlink with actual file.
          Deals with code signing issues on OS X 10.9.5+ -->
     <property name="jli.path" value="${contents.dir}/PlugIns/jdk${jdk.esoteric}.jdk/Contents/MacOS/libjli.dylib" />
     <delete file="${jli.path}" />
@@ -683,8 +683,8 @@
       <fileset dir="${launch4j.dir}/bin" includes="windres-*" />
     </delete>
   </target>
-  
-  <target name="macosx-run" depends="macosx-build" 
+
+  <target name="macosx-run" depends="macosx-build"
           description="Run Mac OS X version">
     <exec executable="open" dir="macosx/work" spawn="true">
       <arg value="-a" />
@@ -692,8 +692,8 @@
       <arg value="Processing.app/Contents/MacOS/Processing" />
     </exec>
   </target>
-  
-  <target name="macosx-run-app" depends="macosx-build" 
+
+  <target name="macosx-run-app" depends="macosx-build"
           description="Run Mac OS X version without console">
     <exec executable="open" dir="macosx/work" spawn="true">
       <arg value="Processing.app" />
@@ -725,7 +725,7 @@
       <arg value="Processing.app" />
     </exec>
 
-    <!-- Verify that the signature will pass Gatekeeper checks 
+    <!-- Verify that the signature will pass Gatekeeper checks
          https://developer.apple.com/library/mac/technotes/tn2206 -->
     <!--
     <exec executable="/usr/bin/codesign" dir="macosx/work">
@@ -738,8 +738,8 @@
     <!-- Disabling since it's a lot of gunk but not that useful. -->
   </target>
 
-  <target name="macosx-dist" if="macosx" 
-          depends="macosx-build" 
+  <target name="macosx-dist" if="macosx"
+          depends="macosx-build"
           description="Create a downloadable .zip for the Mac OS X version">
 
     <antcall target="macosx-dist-sign" />
@@ -751,39 +751,39 @@
     <echo>
       =======================================================
       Processing for Mac OS X was built. Grab it from
-      
+
       macosx/processing-${version}-macosx.zip
       =======================================================
     </echo>
   </target>
 
-  
+
   <!-- - - - - - - - -->
   <!-- Linux         -->
   <!-- - - - - - - - -->
-  
+
   <target name="linux-clean" depends="subprojects-clean" description="Clean linux version">
     <delete dir="linux/work" />
     <delete>
       <fileset dir="linux" includes="processing-*tgz" />
     </delete>
   </target>
-  
+
   <target name="linux-check-os" unless="linux">
     <echo>
       =======================================================
       Processing for Linux can only be built on *nix systems.
-      
-      Bye. 
+
+      Bye.
       =======================================================
     </echo>
-    
+
     <fail message="wrong platform (${os.name})" />
   </target>
-  
+
   <target name="linux-build" depends="ignore-tools, check-linux-arm32, check-linux-arm64, revision-check, linux-check-os, jre-download, subprojects-build, subprojects-build-linux-arm32, subprojects-build-linux-arm64" description="Build Linux version">
     <mkdir dir="linux/work" />
-    
+
     <copy todir="linux/work">
       <fileset dir=".." includes="core/library/**" />
       <fileset dir="shared" includes="launch4j/**" />
@@ -796,7 +796,7 @@
       <param name="target.path" value="linux/work" />
     </antcall>
 
-    <property name="launch4j.dir" 
+    <property name="launch4j.dir"
               value="linux/work/modes/java/application/launch4j" />
 
     <!-- rename the version we need -->
@@ -814,7 +814,7 @@
       <fileset dir="${launch4j.dir}/bin" includes="ld-*" />
       <fileset dir="${launch4j.dir}/bin" includes="windres-*" />
     </delete>
-    
+
     <copy todir="linux/work/lib" flatten="true">
       <fileset refid="runtime.jars" />
     </copy>
@@ -826,17 +826,39 @@
     <copy file="linux/processing" tofile="linux/work/processing-java" />
     <chmod perm="ugo+x" file="linux/work/processing-java" />
 
+    <!-- Additions by the Arduino folks having beer on a Friday evening -->
+    <!-- this allows Linux users to add mime types to IDE by simply running the
+         install script added to the Processing folder. This adds the following features:
+         - the icons for the IDE in different resolutions
+         - icons for the files
+         - a desktop icon
+         - when double clicking the *.pde files, the IDE will be opened
+
+         from Sweden with <3
+       -->
+       <copy file="linux/install.sh" todir="linux/work" />
+       <chmod perm="ugo+x" file="linux/work/install.sh" />
+
+        <copy file="linux/uninstall.sh" todir="linux/work" />
+        <chmod perm="ugo+x" file="linux/work/uninstall.sh" />
+
+        <copy file="linux/processing-processingide.xml" todir="linux/work/lib" />
+        <copy file="linux/appdata.xml" todir="linux/work/lib" />
+        <copy file="linux/desktop.template" todir="linux/work/lib" />
+
+
+
 <!--
-    <get src="http://download.processing.org/java/${jre.file}" 
-         dest="linux/jre.tgz" 
+    <get src="http://download.processing.org/java/${jre.file}"
+         dest="linux/jre.tgz"
          usetimestamp="true" />
 -->
 
-<!--           
+<!--
     Cannot use ant version of tar because it doesn't preserve properties.
-    <untar compression="gzip" 
-           dest="linux/work" 
-           src="linux/jre.tgz" 
+    <untar compression="gzip"
+           dest="linux/work"
+           src="linux/jre.tgz"
            overwrite="false"/>
 -->
 
@@ -846,7 +868,7 @@
     <exec executable="tar" dir="linux">
       <!-- Change directory -->
       <!--
-      <arg value="-C" /> 
+      <arg value="-C" />
       <arg value="linux/work" />
       <arg value="-xzpf" />
       -->
@@ -889,13 +911,13 @@
       <fileset refid="jre-optional-linux" />
     </delete>
   </target>
-  
-  <target name="linux-run" depends="linux-build" 
+
+  <target name="linux-run" depends="linux-build"
           description="Run Linux version">
     <exec executable="./processing" dir="linux/work" spawn="true"/>
   </target>
-  
-  <target name="linux-dist" depends="linux-build" 
+
+  <target name="linux-dist" depends="linux-build"
 	  description="Build .tar.gz of linux version">
 
 <!--
@@ -922,14 +944,14 @@
 
     <echo>
       =======================================================
-      Processing for Linux was built. Grab the archive from   
-      
+      Processing for Linux was built. Grab the archive from
+
       ${linux.dist}
       =======================================================
     </echo>
   </target>
-  
-  <target name="deb" depends="dist" 
+
+  <target name="deb" depends="dist"
 	  description="Build .deb of linux version">
 
    <!-- start with a clean debian folder -->
@@ -942,13 +964,13 @@
    <mkdir dir="linux/debian/usr/share/mime/packages/" />
    <!-- rename the work folder temporarily -->
    <move file="linux/work" tofile="linux/debian/opt/processing" />
-   <symlink link="linux/debian/usr/bin/processing" 
+   <symlink link="linux/debian/usr/bin/processing"
             resource="../../opt/processing/processing" />
    <symlink link="linux/debian/usr/bin/processing-java"
             resource="../../opt/processing/processing-java" />
 
    <!-- place .desktop and .sharedmimeinfo file -->
-   <copy file="linux/processing.desktop" 
+   <copy file="linux/processing.desktop"
          tofile="linux/debian/usr/share/applications/processing.desktop">
        <filterchain>
            <replacetokens>
@@ -956,7 +978,7 @@
            </replacetokens>
        </filterchain>
    </copy>
-   <copy file="linux/processing.sharedmimeinfo" 
+   <copy file="linux/processing.sharedmimeinfo"
          tofile="linux/debian/usr/share/mime/packages/processing.xml" />
 
    <!-- Set properties for DEBIAN/control file -->
@@ -975,10 +997,10 @@
    <condition property="deb.arch" value="arm64">
      <equals arg1="${linux-arm64}" arg2="linux-arm64" />
    </condition>
-   <condition property="deb.arch" value="i386"> 
+   <condition property="deb.arch" value="i386">
      <equals arg1="${sun.arch.data.model}" arg2="32" />
    </condition>
-   <condition property="deb.arch" value="amd64"> 
+   <condition property="deb.arch" value="amd64">
      <equals arg1="${sun.arch.data.model}" arg2="64" />
    </condition>
 
@@ -1019,23 +1041,23 @@
    <!-- (rename the debian processing version to work) -->
    <move file="linux/debian/opt/processing" tofile="linux/work" />
 
-   <!-- cleanup --> 
+   <!-- cleanup -->
    <delete dir="linux/debian" />
 
     <echo>
       ========================================================
-      Processing for Debian Linux was built. Grab the deb from   
-      
+      Processing for Debian Linux was built. Grab the deb from
+
       ${linux.deb}
       ========================================================
     </echo>
   </target>
- 
+
 
   <!-- - - - - - - - -->
   <!-- Windows       -->
   <!-- - - - - - - - -->
-  
+
   <target name="windows-clean" depends="subprojects-clean"
           description="Clean windows version">
     <delete dir="windows/work" />
@@ -1043,22 +1065,22 @@
       <fileset dir="windows" includes="processing-*zip" />
     </delete>
   </target>
-  
+
   <target name="windows-check-os" unless="windows">
     <echo>
       =======================================================
       Processing for Windows can only be built on windows.
-      
-      Bye. 
+
+      Bye.
       =======================================================
     </echo>
-    
+
     <fail message="wrong platform (${os.name})" />
   </target>
-  
+
   <target name="windows-build" depends="ignore-tools, revision-check, windows-check-os, jre-download, subprojects-build" description="Build Windows version">
     <mkdir dir="windows/work" />
-    
+
     <!-- assemble the pde -->
     <mkdir dir="windows/work/lib" />
     <copy todir="windows/work/lib" flatten="true">
@@ -1068,7 +1090,7 @@
     <!-- unpack the JNA DLLs for Windows to work around
          https://github.com/processing/processing/issues/3624 -->
 
-    <condition property="jna.subfolder" value="win32-x86"> 
+    <condition property="jna.subfolder" value="win32-x86">
       <equals arg1="${sun.arch.data.model}" arg2="32" />
     </condition>
     <condition property="jna.subfolder" value="win32-x86-64">
@@ -1081,7 +1103,7 @@
       </patternset>
       <mapper type="flatten"/>
     </unzip>
-    
+
     <copy todir="windows/work">
       <fileset dir=".." includes="core/library/**" />
       <fileset dir="shared" includes="launch4j/**" />
@@ -1109,12 +1131,12 @@
       <fileset dir="${launch4j.dir}/bin" includes="ld-*" />
       <fileset dir="${launch4j.dir}/bin" includes="windres-*" />
     </delete>
-    
-    <taskdef name="launch4j" 
-             classname="net.sf.launch4j.ant.Launch4jTask" 
+
+    <taskdef name="launch4j"
+             classname="net.sf.launch4j.ant.Launch4jTask"
              classpath="${launch4j.dir}/launch4j.jar; ${launch4j.dir}/lib/xstream.jar" />
 
-    <!-- not all launch4j options are available when embedded inside this 
+    <!-- not all launch4j options are available when embedded inside this
          file (i.e. the icon param doesn't work), so use a config file -->
     <launch4j configFile="windows/config.xml" />
     <launch4j configFile="windows/config-cmd.xml" />
@@ -1126,21 +1148,21 @@
 
     <!-- starting with 2.0a7, require the local JRE + tools.jar -->
 <!--
-    <get src="http://download.processing.org/java/${jre.file}" 
-         dest="windows/jre.tgz" 
+    <get src="http://download.processing.org/java/${jre.file}"
+         dest="windows/jre.tgz"
          usetimestamp="true" />
 -->
 
     <!--
     <unzip dest="windows/work" src="windows/jre.zip" overwrite="false"/>
     -->
-    <!-- Hopefully this is OK with the permissions (unlike Linux), 
+    <!-- Hopefully this is OK with the permissions (unlike Linux),
          since those shouldn't matter on Windows. -->
     <untar compression="gzip"
-           dest="windows/work" 
-           src="${jre.tgz.path}" 
+           dest="windows/work"
+           src="${jre.tgz.path}"
            overwrite="false" />
-    <move file="windows/work/jre${jdk.esoteric}" 
+    <move file="windows/work/jre${jdk.esoteric}"
           tofile="windows/work/java" />
 
     <!-- Remove unused JRE bloat. -->
@@ -1152,56 +1174,56 @@
       <fileset refid="jre-optional-windows" />
     </delete>
   </target>
-  
-  <target name="windows-run" depends="windows-build" 
+
+  <target name="windows-run" depends="windows-build"
           description="Run windows version">
-    <exec executable="windows/work/processing.exe" 
+    <exec executable="windows/work/processing.exe"
           dir="windows/work" spawn="true"/>
   </target>
 
-  <target name="windows-dist" depends="windows-build" 
+  <target name="windows-dist" depends="windows-build"
           description="Create .zip files of windows version">
     <!--
-    <zip basedir="windows/work" 
+    <zip basedir="windows/work"
          prefix="processing-${version}"
          destfile="windows/processing-${version}.zip" />
-    <zip basedir="windows/work" 
+    <zip basedir="windows/work"
          prefix="processing-${version}"
-         destfile="windows/processing-${version}-expert.zip" 
+         destfile="windows/processing-${version}-expert.zip"
          excludes="java/**" />
     -->
 
     <property name="windows.dist" value="windows/processing-${version}-windows${sun.arch.data.model}.zip" />
 
     <zip destfile="${windows.dist}">
-      <zipfileset dir="windows/work" 
+      <zipfileset dir="windows/work"
                   prefix="processing-${version}" />
     </zip>
 
 <!-- Expert is too much of a headache. Just nix it for 2.0. -->
 <!--
     <zip destfile="windows/processing-${version}-windows-expert.zip">
-      <zipfileset dir="windows/work" 
-                  prefix="processing-${version}" 
+      <zipfileset dir="windows/work"
+                  prefix="processing-${version}"
                   excludes="java/**" />
     </zip>
 -->
-    
+
     <echo>
       =======================================================
-      Processing for Windows was built. Grab the archive from   
+      Processing for Windows was built. Grab the archive from
 
       ${windows.dist}
       =======================================================
     </echo>
-  </target> 
+  </target>
 
 
   <!-- bundle a bunch of PNGs into an OS X iconset -->
   <target name="iconset">
     <mkdir dir="${icon.set}" />
     <!--<echo message="root = ${icon.root} / set = ${icon.set}" />-->
-    
+
     <copy file="${icon.root}-16.png"
           tofile="${icon.set}/icon_16x16.png" />
     <copy file="${icon.root}-32.png"
@@ -1211,7 +1233,7 @@
           tofile="${icon.set}/icon_32x32.png" />
     <copy file="${icon.root}-64.png"
           tofile="${icon.set}/icon_32x32@2x.png" />
-    
+
     <copy file="${icon.root}-128.png"
           tofile="${icon.set}/icon_128x128.png" />
     <copy file="${icon.root}-256.png"
@@ -1234,7 +1256,7 @@
     <delete dir="${icon.set}" />
   </target>
 
-  
+
   <!-- Target to create the icons... putting this in here rather than docs.
        For OS X (though Linux might work), not intended for general use,
        because it requires things like iconutil (on OS X) or ImageMagick's
@@ -1253,8 +1275,8 @@
       <param name="icon.root" value="../core/src/icon/icon" />
       <param name="icon.icns" value="../java/application/sketch.icns" />
     </antcall>
-    
-    <!-- Create .ico for the PDE itself 
+
+    <!-- Create .ico for the PDE itself
          https://msdn.microsoft.com/en-us/library/dn742485.aspx
          "Application icons and Control Panel items: The full set includes
          16x16, 32x32, 48x48, and 256x256 (code scales between 32 and 256).
@@ -1271,7 +1293,7 @@
     </exec>
   </target>
 
-  
+
   <!-- - - - - - - - - - - - - - - - - - -->
   <!-- Package source 'n tag the release -->
   <!-- - - - - - - - - - - - - - - - - - -->
@@ -1305,8 +1327,8 @@ remove the spaces for depth since it should be double dash, but screws up commen
 
     <javadoc access="public" author="false" classpath="../core/library/jogl-all.jar:../core/bin:../core/library/gluegen-rt.jar" destdir="javadoc/core" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.8" splitindex="false" use="false" version="false">
 
-      <!-- provide links for java.* classes. 
-           also suppresses the java.lang prefix in the text.  --> 
+      <!-- provide links for java.* classes.
+           also suppresses the java.lang prefix in the text.  -->
       <link href="http://docs.oracle.com/javase/7/docs/api/" />
 
       <!-- prevent files from always appearing to have changed -->
@@ -1331,9 +1353,9 @@ remove the spaces for depth since it should be double dash, but screws up commen
     </javadoc>
 
 <!--
-    <copy file="javadoc/stylesheet.css" 
+    <copy file="javadoc/stylesheet.css"
           tofile="javadoc/core/stylesheet.css" />
-    <copy file="javadoc/index.html" 
+    <copy file="javadoc/index.html"
           tofile="javadoc/core/index.html" />
 -->
 
@@ -1349,7 +1371,7 @@ remove the spaces for depth since it should be double dash, but screws up commen
       <arg value="-quiet" />
 
       <link href="http://docs.oracle.com/javase/7/docs/api/" />
-      
+
       <packageset dir="../app/src">
         <include name="antlr/**" />
         <include name="processing/**" />
@@ -1391,7 +1413,7 @@ remove the spaces for depth since it should be double dash, but screws up commen
 
       <link href="http://docs.oracle.com/javase/7/docs/api/" />
       <link href="../../javadoc/core/" />
-      
+
       <tag name="webref" enabled="false" />
       <tag name="nowebref" enabled="false" />
       <tag name="generate" enabled="false" />
@@ -1431,9 +1453,9 @@ remove the spaces for depth since it should be double dash, but screws up commen
 
 
 <!--
-    <copy file="javadoc/stylesheet.css" 
+    <copy file="javadoc/stylesheet.css"
           tofile="javadoc/everything/stylesheet.css" />
-    <copy file="javadoc/index.html" 
+    <copy file="javadoc/index.html"
           tofile="javadoc/everything/index.html" />
 -->
 
@@ -1468,12 +1490,12 @@ remove the spaces for depth since it should be double dash, but screws up commen
   </target>
 -->
 
-  
+
   <!-- - - - - - - - -->
   <!-- Run It!       -->
   <!-- - - - - - - - -->
-  
-  <target name="clean" description="Perform a spring cleaning" 
+
+  <target name="clean" description="Perform a spring cleaning"
           depends="linux-clean, windows-clean, macosx-clean, subprojects-clean">
   </target>
 

--- a/build/linux/appdata.xml
+++ b/build/linux/appdata.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- See https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html -->
+<component type="desktop-application">
+  <id>org.processing.processingide.desktop</id>
+  <metadata_license>GPLv3</metadata_license>
+  <developer_name>Processing Foundation</developer_name>
+
+  <name>Processing IDE</name>
+  <summary>Open-source software prototyping platform</summary>
+
+  <description>
+    <p>
+      Processing is the first easy-to-use software sketching platform
+      created by C. Reas and B. Fry and supported by the Processing
+      Foundation.
+    </p>
+    <p>
+      Included is an integrated development environment that can be used
+      to develop interactive applications using different programming
+      languages but mainly Java, Android, Python, and Javascript.
+    </p>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://upload.wikimedia.org/wikipedia/commons/6/6b/Processing_screen_shot.png</image>
+      <caption>The Processing IDE showing a simple example program</caption>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">http://www.processing.org/</url>
+  <url type="help">https://processing.org/reference/</url>
+  <url type="bugtracker">https://github.com/processing/processing/issues?q=is%3Aopen</url>
+  <url type="translate">https://github.com/processing/processing/tree/master/build/shared/lib/languages</url>
+  <url type="donation">https://processing.org/download/support.html</url>
+
+  <update_contact>foundation@processing.org</update_contact>
+</component>

--- a/build/linux/desktop.template
+++ b/build/linux/desktop.template
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Processing IDE
+GenericName=Processing IDE
+Comment=Open-source software prototyping platform
+Exec=<BINARY_LOCATION>
+Icon=<ICON_NAME>
+Terminal=false
+Categories=Development;IDE;Programming;
+MimeType=text/x-processing;
+Keywords=sketching;software;animation;programming;coding;
+StartupWMClass=processing-app-Base

--- a/build/linux/install.sh
+++ b/build/linux/install.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+
+# This script adds a menu item, icons and mime type for Arduino for the current
+# user. If possible, it will use the xdg-utils - or fall back to just creating
+# and copying a desktop file to the user's dir.
+# If called with the "-u" option, it will undo the changes.
+
+# Resource name to use (including vendor prefix)
+RESOURCE_NAME=processing-processingide
+
+# Get absolute path from which this script file was executed
+# (Could be changed to "pwd -P" to resolve symlinks to their target)
+SCRIPT_PATH=$( cd $(dirname $0) ; pwd )
+cd "${SCRIPT_PATH}"
+
+# Default mode is to install.
+UNINSTALL=false
+
+# If possible, get location of the desktop folder. Default to ~/Desktop
+XDG_DESKTOP_DIR="${HOME}/Desktop"
+if [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/user-dirs.dirs" ]; then
+  . "${XDG_CONFIG_HOME:-${HOME}/.config}/user-dirs.dirs"
+fi
+
+# Install using xdg-utils
+xdg_install_f() {
+
+  # Create a temp dir accessible by all users
+  TMP_DIR=`mktemp --directory`
+
+  # Create *.desktop file using the existing template file
+  sed -e "s,<BINARY_LOCATION>,${SCRIPT_PATH}/processing,g" \
+      -e "s,<ICON_NAME>,${RESOURCE_NAME},g" "${SCRIPT_PATH}/lib/desktop.template" > "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+
+  # Install the icon files using name and resolutions
+  xdg-icon-resource install --context mimetypes --size 16 "${SCRIPT_PATH}/lib/icons/pde-16.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 32 "${SCRIPT_PATH}/lib/icons/pde-32.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 48 "${SCRIPT_PATH}/lib/icons/pde-48.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 64 "${SCRIPT_PATH}/lib/icons/pde-64.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 128 "${SCRIPT_PATH}/lib/icons/pde-128.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 256 "${SCRIPT_PATH}/lib/icons/pde-256.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 512 "${SCRIPT_PATH}/lib/icons/pde-512.png" $RESOURCE_NAME
+  xdg-icon-resource install --context mimetypes --size 1024 "${SCRIPT_PATH}/lib/icons/pde-1024.png" $RESOURCE_NAME
+
+  # Install the created *.desktop file
+  xdg-desktop-menu install "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+
+  # Create icon on the desktop
+  xdg-desktop-icon install "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+
+  # Install Processing mime type
+  xdg-mime install "${SCRIPT_PATH}/lib/${RESOURCE_NAME}.xml"
+
+  # Install icons for mime type
+  xdg-icon-resource install --context mimetypes --size 16 "${SCRIPT_PATH}/lib/icons/pde-16.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 32 "${SCRIPT_PATH}/lib/icons/pde-32.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 48 "${SCRIPT_PATH}/lib/icons/pde-48.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 64 "${SCRIPT_PATH}/lib/icons/pde-64.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 128 "${SCRIPT_PATH}/lib/icons/pde-128.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 256 "${SCRIPT_PATH}/lib/icons/pde-256.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 512 "${SCRIPT_PATH}/lib/icons/pde-512.png" text-x-processing
+  xdg-icon-resource install --context mimetypes --size 1024 "${SCRIPT_PATH}/lib/icons/pde-1024.png" text-x-processing
+
+  # Make Processing IDE the default application for *.pde
+  xdg-mime default ${RESOURCE_NAME}.desktop text/x-processing
+
+  # Clean up
+  rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+  rmdir "$TMP_DIR"
+
+}
+
+# Install by simply copying desktop file (fallback)
+simple_install_f() {
+
+  # Create a temp dir accessible by all users
+  TMP_DIR=`mktemp --directory`
+
+  # Create *.desktop file using the existing template file
+  sed -e "s,<BINARY_LOCATION>,${SCRIPT_PATH}/processing,g" \
+      -e "s,<ICON_NAME>,${SCRIPT_PATH}/lib/icons/pde-128.png,g" "${SCRIPT_PATH}/lib/desktop.template" > "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+
+  mkdir -p "${HOME}/.local/share/applications"
+  cp "${TMP_DIR}/${RESOURCE_NAME}.desktop" "${HOME}/.local/share/applications/"
+
+  mkdir -p "${HOME}/.local/share/metainfo"
+  cp "${SCRIPT_PATH}/lib/appdata.xml" "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml"
+
+  # Copy desktop icon if desktop dir exists (was found)
+  if [ -d "${XDG_DESKTOP_DIR}" ]; then
+   cp "${TMP_DIR}/${RESOURCE_NAME}.desktop" "${XDG_DESKTOP_DIR}/"
+   # Altering file permissions to avoid "Untrusted Application Launcher" error on Ubuntu
+   chmod u+x "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop"
+  fi
+
+  # Clean up temp dir
+  rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+  rmdir "${TMP_DIR}"
+
+}
+
+# Uninstall using xdg-utils
+xdg_uninstall_f() {
+
+  # Remove *.desktop file
+  xdg-desktop-menu uninstall ${RESOURCE_NAME}.desktop
+
+  # Remove icon from desktop
+  xdg-desktop-icon uninstall ${RESOURCE_NAME}.desktop
+
+  # Remove icons
+  xdg-icon-resource uninstall --size 16 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 32 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 48 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 64 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 128 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 256 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 512 $RESOURCE_NAME
+  xdg-icon-resource uninstall --size 1024 $RESOURCE_NAME
+
+  # Remove MIME type icons
+  xdg-icon-resource uninstall --size 16 text-x-processing
+  xdg-icon-resource uninstall --size 32 text-x-processing
+  xdg-icon-resource uninstall --size 48 text-x-processing
+  xdg-icon-resource uninstall --size 64 text-x-processing
+  xdg-icon-resource uninstall --size 128 text-x-processing
+  xdg-icon-resource uninstall --size 256 text-x-processing
+  xdg-icon-resource uninstall --size 512 text-x-processing
+  xdg-icon-resource uninstall --size 1024 text-x-processing
+
+  # Remove Arduino MIME type
+  xdg-mime uninstall "${SCRIPT_PATH}/lib/${RESOURCE_NAME}.xml"
+
+}
+
+# Uninstall by simply removing desktop files (fallback), incl. old one
+simple_uninstall_f() {
+
+  # delete legacy cruft .desktop file
+  if [ -f "${HOME}/.local/share/applications/processing.desktop" ]; then
+    rm "${HOME}/.local/share/applications/processing.desktop"
+  fi
+
+  # delete another legacy .desktop file
+  if [ -f "${HOME}/.local/share/applications/processing-processingide.desktop" ]; then
+    rm "${HOME}/.local/share/applications/processing-processingide.desktop"
+  fi
+
+  if [ -f "${HOME}/.local/share/applications/${RESOURCE_NAME}.desktop" ]; then
+    rm "${HOME}/.local/share/applications/${RESOURCE_NAME}.desktop"
+  fi
+
+  if [ -f "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml" ]; then
+    rm "${HOME}/.local/share/metainfo/${RESOURCE_NAME}.appdata.xml"
+  fi
+
+  if [ -f "${XDG_DESKTOP_DIR}/processing.desktop" ]; then
+    rm "${XDG_DESKTOP_DIR}/processing.desktop"
+  fi
+
+  if [ -f "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop" ]; then
+    rm "${XDG_DESKTOP_DIR}/${RESOURCE_NAME}.desktop"
+  fi
+
+}
+
+# Update desktop file and mime databases (if possible)
+updatedbs_f() {
+
+  if [ -d "${HOME}/.local/share/applications" ]; then
+    if command -v update-desktop-database > /dev/null; then
+      update-desktop-database "${HOME}/.local/share/applications"
+    fi
+  fi
+
+  if [ -d "${HOME}/.local/share/mime" ]; then
+    if command -v update-mime-database > /dev/null; then
+      update-mime-database "${HOME}/.local/share/mime"
+    fi
+  fi
+
+}
+
+# Check availability of xdg-utils
+xdg_exists_f() {
+
+  if ! command -v xdg-icon-resource > /dev/null; then return 1; fi
+  if ! command -v xdg-desktop-menu > /dev/null; then return 1; fi
+  if ! command -v xdg-desktop-icon > /dev/null; then return 1; fi
+  if ! command -v xdg-mime > /dev/null; then return 1; fi
+  return 0
+
+}
+
+# Shows a description of the available options
+display_help_f() {
+  printf "\nThis script will add a Processing IDE desktop shortcut, menu item,\n"
+  printf "icons and file associations for the current user.\n"
+  if ! xdg_exists_f; then
+    printf "\nxdg-utils are recommended to be installed, so this script can use them.\n"
+  fi
+  printf "\nOptional arguments are:\n\n"
+  printf "\t-u, --uninstall\t\tRemoves shortcut, menu item and icons.\n\n"
+  printf "\t-h, --help\t\tShows this help again.\n\n"
+}
+
+# Check for provided arguments
+while [ $# -gt 0 ] ; do
+  ARG="${1}"
+  case $ARG in
+      -u|--uninstall)
+        UNINSTALL=true
+        shift
+      ;;
+      -h|--help)
+        display_help_f
+        exit 0
+      ;;
+      *)
+        printf "\nInvalid option -- '${ARG}'\n"
+        display_help_f
+        exit 1
+      ;;
+  esac
+done
+
+# If possible, use xdg-utils, if not, use a more basic approach
+if xdg_exists_f; then
+  if [ ${UNINSTALL} = true ]; then
+    printf "Removing desktop shortcut and menu item for Processing IDE..."
+    xdg_uninstall_f
+    simple_uninstall_f
+  else
+    printf "Adding desktop shortcut, menu item and file associations for Processing IDE..."
+    xdg_uninstall_f
+    simple_uninstall_f
+    xdg_install_f
+  fi
+else
+  if [ ${UNINSTALL} = true ]; then
+    printf "Removing desktop shortcut and menu item for Processing IDE..."
+    simple_uninstall_f
+  else
+    printf "Adding desktop shortcut and menu item for Processing IDE..."
+    simple_uninstall_f
+    simple_install_f
+  fi
+fi
+updatedbs_f
+printf " done!\n"
+
+exit 0

--- a/build/linux/processing-processingide.xml
+++ b/build/linux/processing-processingide.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='utf-8'?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="text/x-processing">
+        <comment>Processing source code</comment>
+	<comment xml:lang="ara">شفرة مصدر Processing</comment>
+	<comment xml:lang="be@latin">Kryničny kod Processing</comment>
+	<comment xml:lang="bg">Изходен код на Processing</comment>
+	<comment xml:lang="ca">codi font en Processing</comment>
+	<comment xml:lang="da">Processingkildekode</comment>
+	<comment xml:lang="de">Processing-Quelltext</comment>
+	<comment xml:lang="el">πηγαίος κώδικας Processing</comment>
+	<comment xml:lang="en_GB">Processing source code</comment>
+	<comment xml:lang="eo">Processing-fontkodo</comment>
+	<comment xml:lang="es">código fuente en Processing</comment>
+	<comment xml:lang="eu">Processing iturburu-kodea</comment>
+	<comment xml:lang="fi">Processing-lähdekoodi</comment>
+	<comment xml:lang="fr">code source Processing</comment>
+	<comment xml:lang="ga">cód foinseach Processing</comment>
+	<comment xml:lang="hu">Processing-forráskód</comment>
+	<comment xml:lang="id">Kode program Processing</comment>
+	<comment xml:lang="it">Codice sorgente Processing</comment>
+	<comment xml:lang="ja">Processing ソースコード</comment>
+	<comment xml:lang="lt">Processing pradinis kodas</comment>
+	<comment xml:lang="lv">Processing pirmkods</comment>
+	<comment xml:lang="ms">Kod sumber Processing</comment>
+	<comment xml:lang="nb">Processing-kildekode</comment>
+	<comment xml:lang="nl">Processing-broncode</comment>
+	<comment xml:lang="nn">Processing-kjeldekode</comment>
+	<comment xml:lang="pl">Kod źródłowy Processing</comment>
+	<comment xml:lang="pt">código fonte Processing</comment>
+	<comment xml:lang="pt_BR">Código fonte Processing</comment>
+	<comment xml:lang="ru">исходный код Processing</comment>
+	<comment xml:lang="sq">Kod burues Processing</comment>
+	<comment xml:lang="sv">Processing-källkod</comment>
+	<comment xml:lang="uk">Вихідний код на мові Processing</comment>
+	<comment xml:lang="vi">Mã nguồn Processing</comment>
+	<comment xml:lang="zh_CN">Processing 源代码</comment>
+	<comment xml:lang="zh_TW">Processing 源代碼</comment>
+        <sub-class-of type="text/x-csrc"/>
+        <glob pattern="*.pde"/>
+    </mime-type>
+</mime-info>

--- a/build/linux/uninstall.sh
+++ b/build/linux/uninstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+SCRIPT_PATH=$( cd $(dirname $0) ; pwd )
+cd "$SCRIPT_PATH"
+
+./install.sh -u


### PR DESCRIPTION
Yo!
we had to celebrate that Carlos finished his thesis and decided to go in a hacking session ... and guess what ... we thought that it would be super-cool if the Processing IDE that we adore had a proper install script the same as the Arduino one.
We modified ant's build.xml file to add the files, as well as added the proper application files, install scripts, etc.
Using this patch, you will be able of installing the right icons in linux and let your users click directly on *.pde files for them to open automagically.
The last thing ... you should allow Processing to continue talking in 3rd person about itself ... it is such a nice IDE that we love and respect ...

Hugs from Sweden,

/Carlos and David

PS. you should revise the metadata for this to properly represent the Processing Foundation, I am not sure you will like how we wrote it ... we tried our best :-)