### PR TITLE
Add console hiding button

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -320,6 +320,17 @@ public abstract class Editor extends JFrame implements RunnerListener {
         status = new EditorStatus(this, Editor.this);
         return status;
       }
+
+
+      @Override
+      public void finishDraggingTo(int location) {
+        super.finishDraggingTo(location);
+        // JSplitPane issue: if you only make the lower component visible at
+        // the last minute, its minmum size is ignored.
+        if (location > splitPane.getMaximumDividerLocation()) {
+          splitPane.setDividerLocation(splitPane.getMaximumDividerLocation());
+        }
+      }
     });
 
     box.add(splitPane);


### PR DESCRIPTION
Fixes #970. Gives a bit more room to code on a smaller screen. I haven't automatically unhidden it when the sketch starts since that's just bothering the user and the status bar still changes colour on exceptions. Also, I'm not leaving space for the `RIGHT_MARGIN` in EditorStatus; should I be? (N.B. you have push access to my PR branches, feel free to make trivial changes to constants/text etc. rather than describing them to me when that's convenient).
Also (mouseExited listener) fixed a bug where if you moved your mouse off an URL in the status bar vertically it would stay the hovered-over color because it only cares about `mouseX`.
![image](https://user-images.githubusercontent.com/5357642/26884484-c30b6cf8-4b97-11e7-8f03-a661ae4c57f9.png)
![image](https://user-images.githubusercontent.com/5357642/26884539-e793c3e0-4b97-11e7-9b3d-618ee1b6c738.png)

