### PR TITLE
BugFix for Duplicate Library Conflicts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ._*
 *~
 /build/shared/reference.zip
+/bugfix_info/processing_bugfix_duplicateLibraryConflict_new.png
+/bugfix_info/processing_bugfix_duplicateLibraryConflict_old.png
+/build/ant_run.bat

--- a/core/methods/.classpath
+++ b/core/methods/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/usr/share/ant/lib/ant.jar"/>
+	<classpathentry kind="lib" path="/processing-app/lib/ant.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -27,7 +27,10 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -52,6 +55,7 @@ import processing.core.PApplet;
 import processing.core.PConstants;
 import processing.data.StringList;
 import processing.data.XML;
+import processing.mode.java.pdex.ImportStatement;
 import processing.mode.java.preproc.PdePreprocessor;
 import processing.mode.java.preproc.PreprocessorResult;
 import processing.mode.java.preproc.SurfaceInfo;
@@ -389,7 +393,11 @@ public class JavaBuild {
       javaLibraryPath += File.pathSeparator + core.getNativePath();
     }
 
-//    System.out.println("extra imports: " + result.extraImports);
+    
+    
+    // init map by setting package imports as keys and libraries to null
+    HashMap<String, Library> pkg_libs = new HashMap<String, Library>();
+    
     for (String item : result.extraImports) {
 //      System.out.println("item = '" + item + "'");
       // remove things up to the last dot
@@ -397,7 +405,7 @@ public class JavaBuild {
       // http://dev.processing.org/bugs/show_bug.cgi?id=1145
       String entry = (dot == -1) ? item : item.substring(0, dot);
 //      System.out.print(entry + " => ");
-
+  
       if (item.startsWith("static ")) {
         // import static - https://github.com/processing/processing/issues/8
         // Remove more stuff.
@@ -405,11 +413,28 @@ public class JavaBuild {
         entry = entry.substring(7, (dot2 == -1) ? entry.length() : dot2);
 //        System.out.println(entry);
       }
-
-//      System.out.println("library searching for " + entry);
-      Library library = mode.getLibrary(entry);
-//      System.out.println("  found " + library);
-
+      
+      // add package import as key, library is null atm
+      pkg_libs.put(entry, null);
+    }
+    
+    
+    // for each package import, find a library that makes sense
+    // no more "duplicate library" conflicts"
+    mode.getLibraries(pkg_libs);
+    
+    
+    // checkout the generated mapping
+    // some imports are still mapped to null, which is the case if not
+    // a single library was found
+    Iterator<Entry<String, Library>> iter = pkg_libs.entrySet().iterator();
+    while (iter.hasNext()) {
+      
+      Map.Entry<String, Library> pkg_lib = iter.next();
+      
+      String  entry   = pkg_lib.getKey();
+      Library library = pkg_lib.getValue();
+  
       if (library != null) {
         if (!importedLibraries.contains(library)) {
           importedLibraries.add(library);
@@ -436,7 +461,10 @@ public class JavaBuild {
           System.err.println("No library found for " + entry);
         }
       }
+      
     }
+    
+  
 //    PApplet.println(PApplet.split(libraryPath, File.pathSeparatorChar));
 
     // Finally, add the regular Java CLASSPATH. This contains everything

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -6,9 +6,11 @@ import java.beans.*;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.swing.*;
 import javax.swing.border.*;
@@ -1817,39 +1819,74 @@ public class JavaEditor extends Editor {
    * @param importHeaders
    */
   private List<AvailableContribution> getNotInstalledAvailableLibs(ArrayList<String> importHeadersList) {
-    Map<String, Contribution> importMap =
-      ContributionListing.getInstance().getLibrariesByImportHeader();
+    
+    Map<String, Contribution> importMap = ContributionListing.getInstance().getLibrariesByImportHeader();
+    
     List<AvailableContribution> libList = new ArrayList<>();
+
+    
+    // init map by setting package imports as keys and libraries to null
+    
+    HashMap<String, Library> pkg_libs = new HashMap<String, Library>();
+    HashMap<String, Contribution> pkg_contr = new HashMap<String, Contribution>();
+    
     for (String importHeaders : importHeadersList) {
       int dot = importHeaders.lastIndexOf('.');
-      String entry = (dot == -1) ? importHeaders : importHeaders.substring(0,
-          dot);
+      String entry = (dot == -1) ? importHeaders : importHeaders.substring(0, dot);
 
       if (entry.startsWith("java.") ||
           entry.startsWith("javax.") ||
           entry.startsWith("processing.")) {
         continue;
       }
-
-      Library library = null;
-      try {
-        library = this.getMode().getLibrary(entry);
-        if (library == null) {
-          Contribution c = importMap.get(importHeaders);
-          if (c != null && c instanceof AvailableContribution) {
-            libList.add((AvailableContribution) c);// System.out.println(importHeaders
-                                                   // + "not found");
-          }
-        }
-      } catch (Exception e) {
-        // Not gonna happen (hopefully)
-        Contribution c = importMap.get(importHeaders);
-        if (c != null && c instanceof AvailableContribution) {
-          libList.add((AvailableContribution) c);// System.out.println(importHeaders
-                                                 // + "not found");
+      pkg_libs.put(entry, null);
+      pkg_contr.put(entry, importMap.get(entry));
+    }
+    
+    // for each package import, find a library that makes sense
+    // no more "duplicate library" conflicts"
+    mode.getLibraries(pkg_libs);
+    
+    
+    // checkout the generated mapping
+    // some imports are still mapped to null, which is the case if not
+    // a single library was found. Exactly what we want here.
+    Iterator<Entry<String, Library>> iter = pkg_libs.entrySet().iterator();
+    while (iter.hasNext()) {
+      
+      Map.Entry<String, Library> pkg_lib = iter.next();
+      
+      String  pkg = pkg_lib.getKey();
+      Library lib = pkg_lib.getValue();
+      
+      if(lib == null){
+        Contribution contr = pkg_contr.get(pkg);
+        if (contr != null && contr instanceof AvailableContribution) {
+          libList.add((AvailableContribution) contr);
         }
       }
     }
+    
+    
+
+//    for (String importHeaders : importHeadersList) {
+//      int dot = importHeaders.lastIndexOf('.');
+//      String entry = (dot == -1) ? importHeaders : importHeaders.substring(0, dot);
+//
+//      if (entry.startsWith("java.") ||
+//          entry.startsWith("javax.") ||
+//          entry.startsWith("processing.")) {
+//        continue;
+//      }
+//
+//      if (pkg_libs.get(entry) == null) {
+//        Contribution c = importMap.get(importHeaders);
+//        if (c != null && c instanceof AvailableContribution) {
+//          libList.add((AvailableContribution) c);
+//        }
+//      }
+//    }
+      
     return libList;
   }
 

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -31,9 +31,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -575,19 +577,37 @@ public class PreprocessingService {
                                                           List<ImportStatement> programImports) {
     StringBuilder classPath = new StringBuilder();
 
-    programImports.stream()
-        .map(ImportStatement::getPackageName)
-        .filter(pckg -> !ignorableImport(pckg))
-        .map(pckg -> {
-          try {
-            return mode.getLibrary(pckg);
-          } catch (SketchException e) {
-            return null;
-          }
-        })
-        .filter(lib -> lib != null)
-        .map(Library::getClassPath)
-        .forEach(cp -> classPath.append(File.pathSeparator).append(cp));
+
+    // init map by setting package imports as keys and libraries to null
+    HashMap<String, Library> pkg_libs = new HashMap<String, Library>();
+    for(ImportStatement pgk : programImports){
+      pkg_libs.put(pgk.getPackageName(), null);
+    }
+    
+    // for each package import, find a library that makes sense
+    // no more "duplicate library" conflicts"
+    mode.getLibraries(pkg_libs);
+    
+    // checkout the generated mapping
+    // some imports are still mapped to null, which is the case if not
+    // a single library was found
+    Iterator<Entry<String, Library>> iter = pkg_libs.entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<String, Library> pkg_lib = iter.next();
+      
+      Library lib = pkg_lib.getValue();
+      if(lib != null){
+        classPath.append(File.pathSeparator).append(lib.getClassPath());
+      }
+    }
+
+//    programImports.stream()
+//        .map(ImportStatement::getPackageName)
+//        .filter(pckg -> !ignorableImport(pckg))
+//        .map(pckg -> mode.getLibrary(pckg))
+//        .filter(lib -> lib != null)
+//        .map(Library::getClassPath)
+//        .forEach(cp -> classPath.append(File.pathSeparator).append(cp));
 
     return sanitizeClassPath(classPath.toString());
   }


### PR DESCRIPTION
Hi, 

_(this is my first PR for processing. So im not sure if i did everything right so far ... pls let me know.)_

This PR tackles the "Duplicate Library"-Conflict. 
The problem occurs, when libraries are based on same 3rd party libraries (same or different version), like Fisica and Box2D for Processing both use jBox2d. 

Fix:
In case of multiple matching libraries ( = possible duplicates) only the
required one is chosen, by making a guess based on the other, guaranteed,
libraries in use.
In a first pass, the guaranteed libraries are cached.
In a second pass, unresolved package-library mappings are generated, based on pass 1.


old Error message:
![conflict](http://thomasdiewald.com/blog/wp-content/uploads/2017/06/processing_bugfix_duplicateLibraryConflict_old.png)

fixed:
![conflict](http://thomasdiewald.com/blog/wp-content/uploads/2017/06/processing_bugfix_duplicateLibraryConflict_new.png)


Not sure if these verbose print-warnings are necessary, but i kept them for the moment. Most users dont have to deal with possible duplicates anyways i guess.
