### PR TITLE
make "loadXML(String)" handle "file not found"

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -5922,8 +5922,11 @@ public class PApplet implements PConstants {
   public XML loadXML(String filename, String options) {
     try {
       BufferedReader br = createReader(filename);
-      if (br != null) return new XML(br, options);
-      else br = null;
+      if (br != null) {
+        return new XML(br, options);
+      } else {
+        br = null;
+      }
 
       // can't use catch-all exception, since it might catch the
       // RuntimeException about the incorrect case sensitivity

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -5921,7 +5921,9 @@ public class PApplet implements PConstants {
    */
   public XML loadXML(String filename, String options) {
     try {
-      return new XML(createReader(filename), options);
+      BufferedReader br = createReader(filename);
+      if (br != null) return new XML(br, options);
+      else br = null;
 
       // can't use catch-all exception, since it might catch the
       // RuntimeException about the incorrect case sensitivity


### PR DESCRIPTION
when file is not found, a null pointer exception crashes processing i guess is because these lines.