### PR TITLE
Adding copy constructor to the class PVector

### DIFF
--- a/core/src/processing/core/PVector.java
+++ b/core/src/processing/core/PVector.java
@@ -123,6 +123,16 @@ public class PVector implements Serializable {
 
 
   /**
+  * Copy constructor.
+  */
+  public PVector(PVector otherPVector) {
+    this.x = otherPVector.x;
+    this.y = otherPVector.y;
+    this.z = otherPVector.z;
+  }
+  
+  
+  /**
    * Constructor for a 3D vector.
    *
    * @param  x the x coordinate.


### PR DESCRIPTION
I think it is good practice to have a copy constructor in a class.
I have often experienced that it would be easier to write more clear code if PVector had a copy constructor.