### PR TITLE
Add JavaFX runtime to error checker class path

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -520,6 +520,7 @@ public class JavaBuild {
   protected boolean ignorableImport(String pkg) {
     if (pkg.startsWith("java.")) return true;
     if (pkg.startsWith("javax.")) return true;
+    if (pkg.startsWith("javafx.")) return true;
 
     if (pkg.startsWith("processing.core.")) return true;
     if (pkg.startsWith("processing.data.")) return true;

--- a/java/src/processing/mode/java/pdex/PreprocessingService.java
+++ b/java/src/processing/mode/java/pdex/PreprocessingService.java
@@ -596,16 +596,31 @@ public class PreprocessingService {
   static private List<String> buildJavaRuntimeClassPath() {
     StringBuilder classPath = new StringBuilder();
 
-    // Java runtime
-    String rtPath = System.getProperty("java.home") +
-        File.separator + "lib" + File.separator + "rt.jar";
-    if (new File(rtPath).exists()) {
-      classPath.append(File.pathSeparator).append(rtPath);
-    } else {
-      rtPath = System.getProperty("java.home") + File.separator + "jre" +
+    { // Java runtime
+      String rtPath = System.getProperty("java.home") +
           File.separator + "lib" + File.separator + "rt.jar";
       if (new File(rtPath).exists()) {
         classPath.append(File.pathSeparator).append(rtPath);
+      } else {
+        rtPath = System.getProperty("java.home") + File.separator + "jre" +
+            File.separator + "lib" + File.separator + "rt.jar";
+        if (new File(rtPath).exists()) {
+          classPath.append(File.pathSeparator).append(rtPath);
+        }
+      }
+    }
+
+    { // JavaFX runtime
+      String jfxrtPath = System.getProperty("java.home") +
+          File.separator + "lib" + File.separator + "ext" + File.separator + "jfxrt.jar";
+      if (new File(jfxrtPath).exists()) {
+        classPath.append(File.pathSeparator).append(jfxrtPath);
+      } else {
+        jfxrtPath = System.getProperty("java.home") + File.separator + "jre" +
+            File.separator + "lib" + File.separator + "ext" + File.separator + "jfxrt.jar";
+        if (new File(jfxrtPath).exists()) {
+          classPath.append(File.pathSeparator).append(jfxrtPath);
+        }
       }
     }
 


### PR DESCRIPTION
In case somebody needs to work with native FX windows or events, here they are, ready to be imported (like AWT stuff).