### PR TITLE
Add support for custom icon file for macOS builds

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -819,7 +819,13 @@ public class JavaBuild {
       File resourcesFolder = new File(contentsFolder, "Resources");
       Util.copyDir(new File(contentsOrig, "Resources/en.lproj"),
                    new File(resourcesFolder, "en.lproj"));
-      Util.copyFile(mode.getContentFile("application/sketch.icns"),
+
+      String = SKETCH_ICNS = "sketch.icns";
+      File bundleIconFile = new File(sketch.getFolder(), SKETCH_ICNS);
+      if (!bundleIconFile.exists()) {
+        bundleIconFile = mode.getContentFile("application/sketch.icns");
+      }
+      Util.copyFile(bundleIconFile,
                     new File(resourcesFolder, "sketch.icns"));
 
     } else if (exportPlatform == PConstants.LINUX) {


### PR DESCRIPTION
Currently macOS builds only support custom `Info.plist` files.
It is possible to change the dock icon from there, but not the
bundle icon.
This commit allows putting your own `sketch.icns` file inside
your sketch folder, which overwrites the default.