### PR TITLE
Add Linux man pages

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -845,6 +845,9 @@
     <copy file="linux/processing-pde.xml" todir="linux/work/lib" />
     <copy file="linux/appdata.xml" todir="linux/work/lib" />
     <copy file="linux/desktop.template" todir="linux/work/lib" />
+    <copy todir="linux/work/lib/man">
+      <fileset dir="linux/man" />
+    </copy>
 
 <!--
     Cannot use ant version of tar because it doesn't preserve properties.
@@ -948,6 +951,7 @@
    <mkdir dir="linux/debian/opt" />
    <mkdir dir="linux/debian/usr/bin" />
    <mkdir dir="linux/debian/usr/share/applications/" />
+   <mkdir dir="linux/debian/usr/share/man/man1/" />
    <mkdir dir="linux/debian/usr/share/mime/packages/" />
    <!-- rename the work folder temporarily -->
    <move file="linux/work" tofile="linux/debian/opt/processing" />
@@ -967,6 +971,12 @@
    </copy>
    <copy file="linux/processing.sharedmimeinfo"
          tofile="linux/debian/usr/share/mime/packages/processing.xml" />
+
+   <!-- Place man pages -->
+   <gzip src="linux/man/processing.1"
+         destfile="linux/debian/usr/share/man/man1/processing.1.gz" />
+   <gzip src="linux/man/processing-java.1"
+         destfile="linux/debian/usr/share/man/man1/processing-java.1.gz" />
 
    <!-- Set properties for DEBIAN/control file -->
    <condition property="linux.deb" value="linux/processing-${version}-linux-armv6hf.deb">

--- a/build/linux/man/processing-java.1
+++ b/build/linux/man/processing-java.1
@@ -1,0 +1,60 @@
+.TH PROCESSING-JAVA 1 . processing
+.SH NAME
+processing-java \- command-line tool for Processing (Java Mode)
+.SH SYNOPSIS
+.B processing-java
+[\fI\,OPTIONS\/\fR]...
+.SH DESCRIPTION
+Processing is a flexible software sketchbook and a language for learning how to code within the context of the visual arts.
+Since 2001, Processing has promoted software literacy within the visual arts and visual literacy within technology.
+There are tens of thousands of students, artists, designers, researchers, and hobbyists who use Processing for learning and prototyping.
+.PP
+This command is the command-line tool.
+.SH OPTIONS
+.TP
+.BR \-\-help
+Show this help text. Congratulations.
+.TP
+.BR \-\-sketch =\fIname\fR
+Specify the sketch folder (required)
+.TP
+.BR \-\-output =\fIname\fR
+Specify the output folder (optional and cannot be the same as the sketch folder.)
+.TP
+.B \-\-force
+The sketch will not build if the output folder already exists, because the contents will be replaced.
+This option erases the folder first. Use with extreme caution!
+.TP
+.B \-\-build
+Preprocess and compile a sketch into .class files.
+.TP
+.B \-\-run
+Preprocess, compile, and run a sketch.
+.TP
+.B \-\-present
+Preprocess, compile, and run a sketch in presentation mode.
+.TP
+.B \-\-export
+Export an application.
+.TP
+.B \-\-no-java
+Do not embed Java.
+Use at your own risk!
+.TP
+.B \-\-platform
+Specify the platform (export to application only).
+Should be one of
+.BR windows ", " macosx ", or " linux .
+.PP
+.RB "The " --build ", " --run ", " --present ", or " --export
+must be the final parameter passed to Processing.
+Arguments passed following one of those four will be passed through to the
+sketch itself, and therefore available to the sketch via the 'args' field.
+To pass options understood by PApplet.main(), write a custom main() method
+so that the preprocessor does not add one.
+.SH "SEE ALSO"
+\fBprocessing\fP(1): the main GUI for Processing.
+.PP
+Online documentation: <https://github.com/processing/processing/wiki/Command-Line>
+.PP
+The Processing website: <https://processing.org/>

--- a/build/linux/man/processing.1
+++ b/build/linux/man/processing.1
@@ -1,0 +1,17 @@
+.TH PROCESSING 1 . processing
+.SH NAME
+processing \- a language for learning how to code in the context of the visual arts
+.SH SYNOPSIS
+.B processing
+[\fI\,FILE\/\fR]...
+.SH DESCRIPTION
+Processing is a flexible software sketchbook and a language for learning how to code within the context of the visual arts.
+Since 2001, Processing has promoted software literacy within the visual arts and visual literacy within technology.
+There are tens of thousands of students, artists, designers, researchers, and hobbyists who use Processing for learning and prototyping.
+.PP
+This command opens .pde FILE(s), if any, that are passed as arguments. If no arguments are passed, an empty editor is opened.
+.SH "SEE ALSO"
+\fBprocessing-java\fP(1): a command-line tool for Processing
+.PP
+.br
+The Processing website: <https://processing.org/>


### PR DESCRIPTION
Ages ago I told you I'd produce and maintain an official Debian package of Processing (#4266). That didn't really happen, because Debian requires that all of Processing's dependencies would be packaged first, and the Debianized Eclipse dependencies were so out of date that they couldn't handle Java 8. So I sat on my nearly-finished code for a while, but I've decided to send it to you as feature-by-feature pull requests, since that way it's easy to review and it minimizes the work involved in eventually getting a package moving.

Attached are the man pages required by Debian policy, which I've included in the package currently produced by `ant deb`.