### PR TITLE
A fix for the window resizing problem in Windows

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -945,6 +945,15 @@ public class PSurfaceAWT extends PSurfaceNone {
   // needs to resize the frame, which will resize the canvas, and so on...
   @Override
   public void setSize(int wide, int high) {
+
+    //In Microsoft Windows, when the surface is set to resizable (surface.setResizable(true)),
+    //the height set by the user can become less than or equal to zero and program crashes
+    //when that occurs. This is a simple fix for that
+    //(issue: https://github.com/processing/processing/issues/5052)
+    if(high <= 0) {
+      high = 1;
+    }
+
 //    if (PApplet.DEBUG) {
 //      //System.out.format("frame visible %b, setSize(%d, %d) %n", frame.isVisible(), wide, high);
 //      new Exception(String.format("setSize(%d, %d)", wide, high)).printStackTrace(System.out);

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2254,16 +2254,7 @@ public class PApplet implements PConstants {
 //      if (!primary) {
 //        surface.initImage(pg, w, h);
 //      }
-
-      //setting w/h to 0 if it is is invalid
-      if(w <= 0){
-        w = 0;
-      }
-      if(h <= 0) {
-        h = 0;
-      }
       pg.setSize(w, h);
-
 
       // everything worked, return it
       return pg;
@@ -2308,8 +2299,6 @@ public class PApplet implements PConstants {
         if (e.getMessage().contains("cannot be <= 0")) {
           // IllegalArgumentException will be thrown if w/h is <= 0
           // http://code.google.com/p/processing/issues/detail?id=983
-
-          // a fix should be done here to resize the window back to 0 if new size is not valid
           throw new RuntimeException(e);
 
         } else {

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2254,11 +2254,15 @@ public class PApplet implements PConstants {
 //      if (!primary) {
 //        surface.initImage(pg, w, h);
 //      }
-      if(w <= 0 and h <= 0) { //setting size to 0 if size is invalid
-        pg.setSize(0, 0);
-      } else {
-        pg.setSize(w, h);
+
+      //setting w/h to 0 if it is is invalid
+      if(w <= 0){
+        w = 0;
       }
+      if(h <= 0) {
+        h = 0;
+      }
+      pg.setSize(w, h);
 
 
       // everything worked, return it

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2254,7 +2254,12 @@ public class PApplet implements PConstants {
 //      if (!primary) {
 //        surface.initImage(pg, w, h);
 //      }
-      pg.setSize(w, h);
+      if(w <= 0 and h <= 0) { //setting size to 0 if size is invalid
+        pg.setSize(0, 0);
+      } else {
+        pg.setSize(w, h);
+      }
+
 
       // everything worked, return it
       return pg;
@@ -2299,6 +2304,8 @@ public class PApplet implements PConstants {
         if (e.getMessage().contains("cannot be <= 0")) {
           // IllegalArgumentException will be thrown if w/h is <= 0
           // http://code.google.com/p/processing/issues/detail?id=983
+
+          // a fix should be done here to resize the window back to 0 if new size is not valid
           throw new RuntimeException(e);
 
         } else {


### PR DESCRIPTION
The detailed issue can be found here -> https://github.com/processing/processing/issues/5052. A fix for that is applied by checking if the height being set is zero and if so, resetting it to 1(to make it greater than zero). 