### PR TITLE
PDE UI fonts are ugly outside of editor area

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -112,6 +112,17 @@ public class Base {
 
 
   static public void main(final String[] args) {
+    if (Platform.isLinux()) {
+      // Those properties helps enabling anti-aliasing on Linux
+      // (but not on Windows where they made things worse actually
+      // and the font rendering becomes ugly).
+
+      // Those properties must be set before initializing any
+      // graphic object, otherwise they don't have any effect.
+      System.setProperty("awt.useSystemAAFontSettings", "on");
+      System.setProperty("swing.aatext", "true");
+    }
+
     EventQueue.invokeLater(new Runnable() {
         public void run() {
           try {

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -112,7 +112,7 @@ public class Base {
 
 
   static public void main(final String[] args) {
-    if (Platform.isLinux()) {
+    if (Preferences.getBoolean("editor.smooth")) {
       // Those properties helps enabling anti-aliasing on Linux
       // (but not on Windows where they made things worse actually
       // and the font rendering becomes ugly).

--- a/build/linux/processing
+++ b/build/linux/processing
@@ -102,9 +102,6 @@ log PATH
 current_name=`basename $0`
 cmd_name='processing-java'
 
-# PDE UI Fonts workaround
-export _JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=on -Dswing.aatext=true'
-
 if [ $current_name = $cmd_name ]
 then
     java -Djna.nosys=true -Djava.ext.dirs="$APPDIR"/java/lib/ext -Xmx256m processing.mode.java.Commander "$@"

--- a/build/linux/processing
+++ b/build/linux/processing
@@ -102,6 +102,9 @@ log PATH
 current_name=`basename $0`
 cmd_name='processing-java'
 
+# PDE UI Fonts workaround
+export _JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=on -Dswing.aatext=true'
+
 if [ $current_name = $cmd_name ]
 then
     java -Djna.nosys=true -Djava.ext.dirs="$APPDIR"/java/lib/ext -Xmx256m processing.mode.java.Commander "$@"


### PR DESCRIPTION
I tried adding workaround.

Before
![screenshot from 2017-09-17 02-23-36](https://user-images.githubusercontent.com/1528093/30514453-ac7c1930-9b4f-11e7-896c-0c3e502dbfe0.png)

After
![screenshot from 2017-09-17 02-25-01](https://user-images.githubusercontent.com/1528093/30514458-b6b3f92c-9b4f-11e7-92b4-6f5d82cd30f8.png)

reference: https://forum.processing.org/one/topic/pde-linux-fonts-are-bad.html