### PR TITLE
Remove "Pipe Organ" from exec javadoc

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -3457,7 +3457,7 @@ public class PApplet implements PConstants {
    * method, which uses the operating system's launcher to open the files.
    * It's always a good idea to use a full path to the executable here.
    * <pre>
-   * exec("/usr/bin/say", "-v", "Pipe Organ", "welcome to the command line");
+   * exec("/usr/bin/say", "welcome to the command line");
    * </pre>
    * Or if you want to wait until it's completed, something like this:
    * <pre>


### PR DESCRIPTION
Recent OS X releases no longer come with the "Pipe Organ" voice installed by default. As a result, the exec example fails silently with no console feedback. Removing the -v voice argument causes the example to work on current OS X -- and still work on older OS X.