### PR TITLE
Bug loadImage(): Managing files without extension

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -5371,6 +5371,7 @@ public class PApplet implements PConstants {
       if (dot == -1) {
         extension = "unknown";  // no extension found
       }
+      else
       extension = lower.substring(dot + 1);
 
       // check for, and strip any parameters on the url, i.e.


### PR DESCRIPTION
Adding the else clause in this conditional will allow Processing to manage image files "without extension" properly. Test code:

```
String extension=null;
String filename="photo";  //CASE 1:
//String filename="photo";//CASE 2:

if (extension == null) {
  String lower = filename.toLowerCase();
  int dot = filename.lastIndexOf('.');
  if (dot == -1) {
    extension = "unknown";  // no extension found
  }
  extension = lower.substring(dot + 1);
  println(filename+" and extension is "+extension);  
}
```

> //////Output for Case 1 and case 2:
> ////
> ////photo.jpg and extension is jpg
> ////
> ////photo and extension is photo