### PR TITLE
Fixes for Net library

### DIFF
--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -95,16 +95,14 @@ public class Client implements Runnable {
       // which would be called each time an event comes in
       try {
         clientEventMethod =
-          parent.getClass().getMethod("clientEvent",
-                                      new Class[] { Client.class });
+          parent.getClass().getMethod("clientEvent", Client.class);
       } catch (Exception e) {
         // no such method, or an error.. which is fine, just ignore
       }
       // do the same for disconnectEvent(Client c);
       try {
         disconnectEventMethod =
-          parent.getClass().getMethod("disconnectEvent",
-                                      new Class[] { Client.class });
+          parent.getClass().getMethod("disconnectEvent", Client.class);
       } catch (Exception e) {
         // no such method, or an error.. which is fine, just ignore
       }
@@ -138,8 +136,7 @@ public class Client implements Runnable {
     // public void disconnectEvent(processing.net.Client)
     try {
       disconnectEventMethod =
-        parent.getClass().getMethod("disconnectEvent",
-                                    new Class[] { Client.class });
+        parent.getClass().getMethod("disconnectEvent", Client.class);
     } catch (Exception e) {
       // no such method, or an error.. which is fine, just ignore
     }
@@ -160,7 +157,7 @@ public class Client implements Runnable {
   public void stop() {    
     if (disconnectEventMethod != null && thread != null){
       try {
-        disconnectEventMethod.invoke(parent, new Object[] { this });
+        disconnectEventMethod.invoke(parent, this);
       } catch (Exception e) {
         e.printStackTrace();
         disconnectEventMethod = null;
@@ -211,6 +208,7 @@ public class Client implements Runnable {
   }
 
 
+  @Override
   public void run() {
     byte[] readBuffer = new byte[2048]; // Ethernet MTU = 1500 B
     while (Thread.currentThread() == thread) {
@@ -269,7 +267,7 @@ public class Client implements Runnable {
           // now post an event
           if (clientEventMethod != null) {
             try {
-              clientEventMethod.invoke(parent, new Object[] { this });
+              clientEventMethod.invoke(parent, this);
             } catch (Exception e) {
               System.err.println("error, disabling clientEvent() for " + host);
               e.printStackTrace();

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -219,7 +219,15 @@ public class Client implements Runnable {
 
   @Override
   public void run() {
-    byte[] readBuffer = new byte[2048]; // Ethernet MTU = 1500 B
+    byte[] readBuffer;
+    { // make the read buffer same size as socket receive buffer so that
+      // we don't waste cycles calling listeners when there is more data waiting
+      int readBufferSize = 2 << 16; // 64 KB (default socket receive buffer size)
+      try {
+        readBufferSize = socket.getReceiveBufferSize();
+      } catch (SocketException ignore) { }
+      readBuffer = new byte[readBufferSize];
+    }
     while (Thread.currentThread() == thread) {
       try {
         while (input != null) {

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -236,9 +236,18 @@ public class Client implements Runnable {
             // todo: at some point buffer should stop increasing in size, 
             // otherwise it could use up all the memory.
             if (bufferLast == buffer.length) {
-              byte temp[] = new byte[bufferLast << 1];
-              System.arraycopy(buffer, 0, temp, 0, bufferLast);
-              buffer = temp;
+              if (bufferIndex > 0) {
+                // compact the buffer
+                int bufferLength = bufferLast - bufferIndex;
+                System.arraycopy(buffer, bufferIndex, buffer, 0, bufferLength);
+                bufferLast -= bufferIndex;
+                bufferIndex = 0;
+              } else {
+                // resize the buffer
+                byte temp[] = new byte[bufferLast << 1];
+                System.arraycopy(buffer, 0, temp, 0, bufferLast);
+                buffer = temp;
+              }
             }
             buffer[bufferLast++] = (byte)value;
           }

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -107,10 +107,6 @@ public class Client implements Runnable {
         // no such method, or an error.. which is fine, just ignore
       }
 
-    } catch (ConnectException ce) {
-      ce.printStackTrace();
-      dispose();
-
     } catch (IOException e) {
       e.printStackTrace();
       dispose();

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -155,7 +155,12 @@ public class Client implements Runnable {
       try {
         disconnectEventMethod.invoke(parent, this);
       } catch (Exception e) {
-        e.printStackTrace();
+        Throwable cause = e;
+        // unwrap the exception if it came from the user code
+        if (e instanceof InvocationTargetException && e.getCause() != null) {
+          cause = e.getCause();
+        }
+        cause.printStackTrace();
         disconnectEventMethod = null;
       }
     }
@@ -266,7 +271,12 @@ public class Client implements Runnable {
               clientEventMethod.invoke(parent, this);
             } catch (Exception e) {
               System.err.println("error, disabling clientEvent() for " + host);
-              e.printStackTrace();
+              Throwable cause = e;
+              // unwrap the exception if it came from the user code
+              if (e instanceof InvocationTargetException && e.getCause() != null) {
+                cause = e.getCause();
+              }
+              cause.printStackTrace();
               clientEventMethod = null;
             }
           }

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -129,7 +129,15 @@ public class Client implements Runnable {
     thread.start();
 
     // reflection to check whether host sketch has a call for
-    // public void disconnectEvent(processing.net.Client)
+    // public void clientEvent(processing.net.Client)
+    // which would be called each time an event comes in
+    try {
+      clientEventMethod =
+          parent.getClass().getMethod("clientEvent", Client.class);
+    } catch (Exception e) {
+      // no such method, or an error.. which is fine, just ignore
+    }
+    // do the same for disconnectEvent(Client c);
     try {
       disconnectEventMethod =
         parent.getClass().getMethod("disconnectEvent", Client.class);

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -57,6 +57,8 @@ public class Client implements Runnable {
   public InputStream input;
   public OutputStream output;
 
+  final Object bufferLock = new Object[0];
+
   byte buffer[] = new byte[32768];
   int bufferIndex;
   int bufferLast;
@@ -230,7 +232,7 @@ public class Client implements Runnable {
             return;
           }
 
-          synchronized (buffer) {
+          synchronized (bufferLock) {
             // todo: at some point buffer should stop increasing in size, 
             // otherwise it could use up all the memory.
             if (bufferLast == buffer.length) {
@@ -341,7 +343,7 @@ public class Client implements Runnable {
   public int read() {
     if (bufferIndex == bufferLast) return -1;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int outgoing = buffer[bufferIndex++] & 0xff;
       if (bufferIndex == bufferLast) {  // rewind
         bufferIndex = 0;
@@ -394,7 +396,7 @@ public class Client implements Runnable {
   public byte[] readBytes() {
     if (bufferIndex == bufferLast) return null;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int length = bufferLast - bufferIndex;
       byte outgoing[] = new byte[length];
       System.arraycopy(buffer, bufferIndex, outgoing, 0, length);
@@ -419,7 +421,7 @@ public class Client implements Runnable {
   public byte[] readBytes(int max) {
     if (bufferIndex == bufferLast) return null;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int length = bufferLast - bufferIndex;
       if (length > max) length = max;
       byte outgoing[] = new byte[length];
@@ -451,7 +453,7 @@ public class Client implements Runnable {
   public int readBytes(byte bytebuffer[]) {
     if (bufferIndex == bufferLast) return 0;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int length = bufferLast - bufferIndex;
       if (length > bytebuffer.length) length = bytebuffer.length;
       System.arraycopy(buffer, bufferIndex, bytebuffer, 0, length);
@@ -490,7 +492,7 @@ public class Client implements Runnable {
     if (bufferIndex == bufferLast) return null;
     byte what = (byte)interesting;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int found = -1;
       for (int k = bufferIndex; k < bufferLast; k++) {
         if (buffer[k] == what) {
@@ -531,7 +533,7 @@ public class Client implements Runnable {
     if (bufferIndex == bufferLast) return 0;
     byte what = (byte)interesting;
 
-    synchronized (buffer) {
+    synchronized (bufferLock) {
       int found = -1;
       for (int k = bufferIndex; k < bufferLast; k++) {
         if (buffer[k] == what) {

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -621,10 +621,9 @@ public class Client implements Runnable {
    * @brief Returns the buffer as a String
    */
   public String readString() {
-    synchronized (bufferLock) {
-      if (bufferIndex == bufferLast) return null;
-      return new String(readBytes());
-    }
+    byte b[] = readBytes();
+    if (b == null) return null;
+    return new String(b);
   }
 
 

--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -308,7 +308,12 @@ public class Server implements Runnable {
               serverEventMethod.invoke(parent, this, client);
             } catch (Exception e) {
               System.err.println("Disabling serverEvent() for port " + port);
-              e.printStackTrace();
+              Throwable cause = e;
+              // unwrap the exception if it came from the user code
+              if (e instanceof InvocationTargetException && e.getCause() != null) {
+                cause = e.getCause();
+              }
+              cause.printStackTrace();
               serverEventMethod = null;
             }
           }

--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -327,9 +327,6 @@ public class Server implements Runnable {
         e.printStackTrace();
         thread = null;
       }
-      try {
-        Thread.sleep(8);
-      } catch (InterruptedException ex) { }
     }
   }
 

--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -100,9 +100,7 @@ public class Server implements Runnable {
       // which is called when a new guy connects
       try {
         serverEventMethod =
-          parent.getClass().getMethod("serverEvent",
-                                      new Class[] { Server.class,
-                                                    Client.class });
+          parent.getClass().getMethod("serverEvent", Server.class, Client.class);
       } catch (Exception e) {
         // no such method, or an error.. which is fine, just ignore
       }
@@ -297,6 +295,7 @@ public class Server implements Runnable {
   }
 
 
+  @Override
   public void run() {
     while (Thread.currentThread() == thread) {
       try {
@@ -306,7 +305,7 @@ public class Server implements Runnable {
           addClient(client);
           if (serverEventMethod != null) {
             try {
-              serverEventMethod.invoke(parent, new Object[] { this, client });
+              serverEventMethod.invoke(parent, this, client);
             } catch (Exception e) {
               System.err.println("Disabling serverEvent() for port " + port);
               e.printStackTrace();


### PR DESCRIPTION
Fixes
- Fix synchronization (probably fixes #4419)
- Compact client buffer before making it bigger (fixes #5360)
- Set limit to the size of client buffer (128 MB - might be too much)

Performance, style
- Read blocks of data instead of byte by byte
- Remove sleep in the server loop (probably there to 'fix' some threading issues)
- Code cleanup (creating varargs arrays manually, missing Override annotations)

Features
- Server now calls `clientEvent(Client c)` if it receives data from any client (fixes #3970)
- Unwrap exceptions thrown from the user code before printing them to the console