### PR TITLE
fix NPE when closing sketch window on Mac (#5214)

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -3703,8 +3703,7 @@ public class PApplet implements PConstants {
     if (platform == MACOSX) {
       try {
         final String td = "processing.core.ThinkDifferent";
-        final Class<?> thinkDifferent =
-          Thread.currentThread().getContextClassLoader().loadClass(td);
+        final Class<?> thinkDifferent = getClass().getClassLoader().loadClass(td);
         thinkDifferent.getMethod("cleanup").invoke(null);
       } catch (Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
This fixes the first error mentioned in the issue, but not the other one mentioned by @christianbender. Tested on OSX High Sierra (10.13.2)