### PR TITLE
made `context` public in `PGraphicsFX2D`

### DIFF
--- a/core/src/processing/javafx/PGraphicsFX2D.java
+++ b/core/src/processing/javafx/PGraphicsFX2D.java
@@ -53,7 +53,7 @@ import processing.core.*;
 
 
 public class PGraphicsFX2D extends PGraphics {
-  GraphicsContext context;
+  public GraphicsContext context;
 
   static final WritablePixelFormat<IntBuffer> argbFormat =
     PixelFormat.getIntArgbInstance();


### PR DESCRIPTION
`g2` is public in `PGraphicsJava2D`, and `context` is its FX2D equivalent.
Change made for consistency.