### PR TITLE
ARM Mali upbringing

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -2232,7 +2232,7 @@ public abstract class PGL {
 
   protected boolean hasAnisoSamplingSupport() {
     int major = getGLVersion()[0];
-    if (major < 3) {
+    if (isES() || major < 3) {
       String ext = getString(EXTENSIONS);
       return -1 < ext.indexOf("_texture_filter_anisotropic");
     } else {

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -1935,7 +1935,11 @@ public abstract class PGL {
 
       fragSrc = preprocessShaderSource(fragSrc0, search, replace, offset);
       fragSrc[0] = "#version " + version + versionSuffix;
-      fragSrc[1] = "out vec4 _fragColor;";
+      if (" es".equals(versionSuffix)) {
+        fragSrc[1] = "out mediump vec4 _fragColor;";
+      } else {
+        fragSrc[1] = "out vec4 _fragColor;";
+      }
     }
 
     return fragSrc;

--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -1287,9 +1287,9 @@ public abstract class PGL {
     PGL ppgl = primaryPGL ? this : graphics.getPrimaryPGL();
 
     if (!ppgl.loadedTex2DShader || ppgl.tex2DShaderContext != ppgl.glContext) {
-      String[] preprocVertSrc = preprocessVertexSource(texVertShaderSource, getGLSLVersion());
+      String[] preprocVertSrc = preprocessVertexSource(texVertShaderSource, getGLSLVersion(), getGLSLVersionSuffix());
       String vertSource = PApplet.join(preprocVertSrc, "\n");
-      String[] preprocFragSrc = preprocessFragmentSource(tex2DFragShaderSource, getGLSLVersion());
+      String[] preprocFragSrc = preprocessFragmentSource(tex2DFragShaderSource, getGLSLVersion(), getGLSLVersionSuffix());
       String fragSource = PApplet.join(preprocFragSrc, "\n");
       ppgl.tex2DVertShader = createShader(VERTEX_SHADER, vertSource);
       ppgl.tex2DFragShader = createShader(FRAGMENT_SHADER, fragSource);
@@ -1419,9 +1419,9 @@ public abstract class PGL {
     PGL ppgl = primaryPGL ? this : graphics.getPrimaryPGL();
 
     if (!ppgl.loadedTexRectShader || ppgl.texRectShaderContext != ppgl.glContext) {
-      String[] preprocVertSrc = preprocessVertexSource(texVertShaderSource, getGLSLVersion());
+      String[] preprocVertSrc = preprocessVertexSource(texVertShaderSource, getGLSLVersion(), getGLSLVersionSuffix());
       String vertSource = PApplet.join(preprocVertSrc, "\n");
-      String[] preprocFragSrc = preprocessFragmentSource(texRectFragShaderSource, getGLSLVersion());
+      String[] preprocFragSrc = preprocessFragmentSource(texRectFragShaderSource, getGLSLVersion(), getGLSLVersionSuffix());
       String fragSource = PApplet.join(preprocFragSrc, "\n");
       ppgl.texRectVertShader = createShader(VERTEX_SHADER, vertSource);
       ppgl.texRectFragShader = createShader(FRAGMENT_SHADER, fragSource);
@@ -1848,6 +1848,7 @@ public abstract class PGL {
 
 
   abstract protected int getGLSLVersion();
+  abstract protected String getGLSLVersionSuffix();
 
 
   protected String[] loadVertexShader(String filename) {
@@ -1880,28 +1881,29 @@ public abstract class PGL {
   }
 
 
-  protected String[] loadVertexShader(String filename, int version) {
+  protected String[] loadVertexShader(String filename, int version, String versionSuffix) {
     return loadVertexShader(filename);
   }
 
 
-  protected String[] loadFragmentShader(String filename, int version) {
+  protected String[] loadFragmentShader(String filename, int version, String versionSuffix) {
     return loadFragmentShader(filename);
   }
 
 
-  protected String[] loadFragmentShader(URL url, int version) {
+  protected String[] loadFragmentShader(URL url, int version, String versionSuffix) {
     return loadFragmentShader(url);
   }
 
 
-  protected String[] loadVertexShader(URL url, int version) {
+  protected String[] loadVertexShader(URL url, int version, String versionSuffix) {
     return loadVertexShader(url);
   }
 
 
   protected static String[] preprocessFragmentSource(String[] fragSrc0,
-                                                     int version) {
+                                                     int version,
+                                                     String versionSuffix) {
     if (containsVersionDirective(fragSrc0)) {
       // The user knows what she or he is doing
       return fragSrc0;
@@ -1915,7 +1917,7 @@ public abstract class PGL {
       int offset = 1;
 
       fragSrc = preprocessShaderSource(fragSrc0, search, replace, offset);
-      fragSrc[0] = "#version " + version;
+      fragSrc[0] = "#version " + version + versionSuffix;
     } else {
       // We need to replace 'texture' uniform by 'texMap' uniform and
       // 'textureXXX()' functions by 'texture()' functions. Order of these
@@ -1932,7 +1934,7 @@ public abstract class PGL {
       int offset = 2;
 
       fragSrc = preprocessShaderSource(fragSrc0, search, replace, offset);
-      fragSrc[0] = "#version " + version;
+      fragSrc[0] = "#version " + version + versionSuffix;
       fragSrc[1] = "out vec4 _fragColor;";
     }
 
@@ -1940,7 +1942,8 @@ public abstract class PGL {
   }
 
   protected static String[] preprocessVertexSource(String[] vertSrc0,
-                                                   int version) {
+                                                   int version,
+                                                   String versionSuffix) {
     if (containsVersionDirective(vertSrc0)) {
       // The user knows what she or he is doing
       return vertSrc0;
@@ -1954,7 +1957,7 @@ public abstract class PGL {
       int offset = 1;
 
       vertSrc = preprocessShaderSource(vertSrc0, search, replace, offset);
-      vertSrc[0] = "#version " + version;
+      vertSrc[0] = "#version " + version + versionSuffix;
     } else {
       // We need to replace 'texture' uniform by 'texMap' uniform and
       // 'textureXXX()' functions by 'texture()' functions. Order of these
@@ -1971,7 +1974,7 @@ public abstract class PGL {
       int offset = 1;
 
       vertSrc = preprocessShaderSource(vertSrc0, search, replace, offset);
-      vertSrc[0] = "#version " + version;
+      vertSrc[0] = "#version " + version + versionSuffix;
     }
 
     return vertSrc;

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -509,50 +509,58 @@ public class PJOGL extends PGL {
     return vn.getMajor() * 100 + vn.getMinor();
   }
 
+  protected String getGLSLVersionSuffix() {
+    if (context.isGLESProfile()) {
+      return " es";
+    } else {
+      return "";
+    }
+  }
+
 
   @Override
   protected String[] loadVertexShader(String filename) {
-    return loadVertexShader(filename, getGLSLVersion());
+    return loadVertexShader(filename, getGLSLVersion(), getGLSLVersionSuffix());
   }
 
 
   @Override
   protected String[] loadFragmentShader(String filename) {
-    return loadFragmentShader(filename, getGLSLVersion());
+    return loadFragmentShader(filename, getGLSLVersion(), getGLSLVersionSuffix());
   }
 
 
   @Override
   protected String[] loadVertexShader(URL url) {
-    return loadVertexShader(url, getGLSLVersion());
+    return loadVertexShader(url, getGLSLVersion(), getGLSLVersionSuffix());
   }
 
 
   @Override
   protected String[] loadFragmentShader(URL url) {
-    return loadFragmentShader(url, getGLSLVersion());
+    return loadFragmentShader(url, getGLSLVersion(), getGLSLVersionSuffix());
   }
 
 
   @Override
-  protected String[] loadFragmentShader(String filename, int version) {
+  protected String[] loadFragmentShader(String filename, int version, String versionSuffix) {
     String[] fragSrc0 = sketch.loadStrings(filename);
-    return preprocessFragmentSource(fragSrc0, version);
+    return preprocessFragmentSource(fragSrc0, version, versionSuffix);
   }
 
 
   @Override
-  protected String[] loadVertexShader(String filename, int version) {
+  protected String[] loadVertexShader(String filename, int version, String versionSuffix) {
     String[] vertSrc0 = sketch.loadStrings(filename);
-    return preprocessVertexSource(vertSrc0, version);
+    return preprocessVertexSource(vertSrc0, version, versionSuffix);
   }
 
 
   @Override
-  protected String[] loadFragmentShader(URL url, int version) {
+  protected String[] loadFragmentShader(URL url, int version, String versionSuffix) {
     try {
       String[] fragSrc0 = PApplet.loadStrings(url.openStream());
-      return preprocessFragmentSource(fragSrc0, version);
+      return preprocessFragmentSource(fragSrc0, version, versionSuffix);
     } catch (IOException e) {
       PGraphics.showException("Cannot load fragment shader " + url.getFile());
     }
@@ -561,10 +569,10 @@ public class PJOGL extends PGL {
 
 
   @Override
-  protected String[] loadVertexShader(URL url, int version) {
+  protected String[] loadVertexShader(URL url, int version, String versionSuffix) {
     try {
       String[] vertSrc0 = PApplet.loadStrings(url.openStream());
-      return preprocessVertexSource(vertSrc0, version);
+      return preprocessVertexSource(vertSrc0, version, versionSuffix);
     } catch (IOException e) {
       PGraphics.showException("Cannot load vertex shader " + url.getFile());
     }

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1937,6 +1937,8 @@ public class PJOGL extends PGL {
       gl2x.glRenderbufferStorageMultisample(target, samples, format, width, height);
     } else if (gl3 != null) {
       gl3.glRenderbufferStorageMultisample(target, samples, format, width, height);
+    } else if (gl3es3 != null) {
+      gl3es3.glRenderbufferStorageMultisample(target, samples, format, width, height);
     } else {
       throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glRenderbufferStorageMultisample()"));
     }

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1950,6 +1950,8 @@ public class PJOGL extends PGL {
       gl2x.glReadBuffer(buf);
     } else if (gl3 != null) {
       gl3.glReadBuffer(buf);
+    } else if (gl3es3 != null) {
+      gl3es3.glReadBuffer(buf);
     } else {
       throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glReadBuffer()"));
     }

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1973,6 +1973,11 @@ public class PJOGL extends PGL {
       gl2x.glDrawBuffer(buf);
     } else if (gl3 != null) {
       gl3.glDrawBuffer(buf);
+    } else if (gl3es3 != null) {
+      IntBuffer intBuffer = IntBuffer.allocate(1);
+      intBuffer.put(buf);
+      intBuffer.rewind();
+      gl3es3.glDrawBuffers(1, intBuffer);
     } else {
       throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glDrawBuffer()"));
     }

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1934,6 +1934,8 @@ public class PJOGL extends PGL {
       gl2x.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     } else if (gl3 != null) {
       gl3.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    } else if (gl3es3 != null) {
+      gl3es3.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     } else {
       throw new RuntimeException(String.format(MISSING_GLFUNC_ERROR, "glBlitFramebuffer()"));
     }


### PR DESCRIPTION
This makes P3D work on Linux SBCs using ARM Mali graphics and their (closed-source) OpenGL ES 3.1 driver.

I don't have matching hardware, so all testing was done by user seongwook in the Processing Forums, who was very generous with his time in this effort. He tested with an ODROID-XU4 board, which reports a "Mali-T628" model and the following driver string "OpenGL ES 3.1 v1.r17p0-01rel0.a881d28363cdb20f0017ed13c980967e".

Re review: I specifically don't know if my code in d351070d30afe4861e04ec04c55af4a69770570f makes sense in this way.