### PR TITLE
ARM Mali: Don't use GL_MULTISAMPLE or GL_POLYGON_SMOOTH on ES

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -1567,6 +1567,8 @@ public class PGraphicsOpenGL extends PGraphics {
       pgl.disable(PGL.MULTISAMPLE);
     } else if (1 <= smooth) {
       pgl.enable(PGL.MULTISAMPLE);
+    }
+    if (!pgl.isES()) {
       pgl.disable(PGL.POLYGON_SMOOTH);
     }
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -1561,9 +1561,8 @@ public class PGraphicsOpenGL extends PGraphics {
     }
     pgl.depthFunc(PGL.LEQUAL);
 
-    if (OPENGL_RENDERER.equals("VideoCore IV HW")) {
-      // Broadcom's VC IV driver is unhappy with either of these
-      // ignore for now
+    if (pgl.isES()) {
+      // neither GL_MULTISAMPLE nor GL_POLYGON_SMOOTH are part of GLES2 or GLES3
     } else if (smooth < 1) {
       pgl.disable(PGL.MULTISAMPLE);
     } else if (1 <= smooth) {
@@ -6775,16 +6774,14 @@ public class PGraphicsOpenGL extends PGraphics {
 //        quality = temp;
 //      }
     }
-    if (OPENGL_RENDERER.equals("VideoCore IV HW")) {
-      // Broadcom's VC IV driver is unhappy with either of these
-      // ignore for now
+    if (pgl.isES()) {
+      // neither GL_MULTISAMPLE nor GL_POLYGON_SMOOTH are part of GLES2 or GLES3
     } else if (smooth < 1) {
       pgl.disable(PGL.MULTISAMPLE);
     } else if (1 <= smooth) {
       pgl.enable(PGL.MULTISAMPLE);
     }
-    // work around runtime exceptions in Broadcom's VC IV driver
-    if (false == OPENGL_RENDERER.equals("VideoCore IV HW")) {
+    if (!pgl.isES()) {
       pgl.disable(PGL.POLYGON_SMOOTH);
     }
 


### PR DESCRIPTION
@codeanticode @JakubValtar This patch should not be controversial really, but in doing so I came across something that looked a bit strange to me: if you search the tree for `POLYGON_SMOOTH`, you'll find a hit in `restoreGL` and one in `setGLSettings` - but one of them is done unconditionally, and one just when `1 <= smooth` ... bug?