### PR TITLE
Make sure editor is updated after reloading changes

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1404,8 +1404,8 @@ public class Sketch {
 //      System.out.println(current.visited);
 //    }
     // if current is null, then this is the first setCurrent(0)
-    if (((currentIndex == which) && (current != null))
-      || which >= codeCount || which < 0) {
+    if (which < 0 || which >= codeCount ||
+        ((currentIndex == which) && (current == code[currentIndex]))) {
       return;
     }
 

--- a/app/src/processing/app/ui/ChangeDetector.java
+++ b/app/src/processing/app/ui/ChangeDetector.java
@@ -215,8 +215,7 @@ public class ChangeDetector implements WindowFocusListener {
         );
       }
       editor.rebuildHeader();
-      sketch.handleNextCode();
-      sketch.handlePrevCode();
+      sketch.setCurrentCode(sketch.getCurrentCodeIndex());
       editor.repaintHeader();
 
       editor.sketchChanged();


### PR DESCRIPTION
Fixes #5466

Update was done by switching to the next tab and then back to the prev tab, however that is a no-op in a single tab sketch. Updated the code to reload the current code if it was modified.