### PR TITLE
added javadoc comment for XML#trim()

### DIFF
--- a/core/src/processing/data/XML.java
+++ b/core/src/processing/data/XML.java
@@ -594,7 +594,14 @@ public class XML implements Serializable {
     children = null;  // TODO not efficient
   }
 
-
+  /**
+   * Removes whitespace nodes.
+   * Those whitespace nodes are required to reconstruct the original XML's spacing and indentation.
+   * If you call this and use saveXML() your original spacing will be gone.
+   * 
+   * @nowebref
+   * @brief Removes whitespace nodes
+   */
   public void trim() {
     try {
       XPathFactory xpathFactory = XPathFactory.newInstance();


### PR DESCRIPTION
I have included the `@nowebref` and `@brief` tags like similar functions have, not sure if this was the right move, just mimicing what other javadocs had.

Of course the `@nowebref` has an explanation: there is no web reference for trim(), but I wasn't sure about the `@brief`.