### PR TITLE
Make getSettingsFolder error more descriptive

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1889,7 +1889,7 @@ public class Base {
       }
     } catch (Exception e) {
       Messages.showError("Problem getting the settings folder",
-                         "Error getting the Processing the settings folder.", e);
+                         e.getMessage(), e);
     }
     return settingsFolder;
   }


### PR DESCRIPTION
Came across "Error getting the Processing the settings folder" in #5528. At least for Windows the exceptions thrown by Platform.getSettingsFolder should tell us precisely what is wrong.