### PR TITLE
Support PShape.contains() on GROUP objects

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2906,6 +2906,18 @@ public class PShape implements PConstants {
         }
       }
       return c;
+    } else if (family == GROUP) {
+      // If this is a group, loop through children until we find one that 
+      // contains the supplied coordinates. If a child does not support contains()
+      // just throw a warning and continue.
+      for (int i = 0; i < childCount; i++) {
+        try {
+          if (children[i].contains(x, y)) return true;
+        } catch (IllegalArgumentException e) {
+          PGraphics.showWarning(e);
+        }
+      }
+      return false;
     } else {
       throw new IllegalArgumentException("The contains() method is only implemented for paths.");
     }


### PR DESCRIPTION
Currently, PShape.contains() throws a fatal exception when called on a non-PATH PShape object. This change allows the method to be called also on GROUP objects; in this case, it will loop through children and call `.contains()` on all of them until a match is found. Unsupported children (i.e. non-PATH or non-GROUP objects) will be skipped gracefully and a warning will be generated, but no fatal error will be emitted.