### PR TITLE
Added a rotate(angle, x, y) shortcut for rotating around a given point

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -13285,6 +13285,7 @@ public class PApplet implements PConstants {
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
+   * @see PGraphics#rotate(float, float, float)
    * @see PGraphics#rotateX(float)
    * @see PGraphics#rotateY(float)
    * @see PGraphics#rotateZ(float)
@@ -13294,6 +13295,48 @@ public class PApplet implements PConstants {
   public void rotate(float angle) {
     if (recorder != null) recorder.rotate(angle);
     g.rotate(angle);
+  }
+  
+  
+  /**
+   * ( begin auto-generated from rotate.xml )
+   *
+   * Rotates a shape the amount specified by the <b>angle</b> parameter,
+   * around the supplied point.
+   * Angles should be specified in radians (values from 0 to TWO_PI) or
+   * converted to radians with the <b>radians()</b> function.
+   * <br/> <br/>
+   * Objects are always rotated around their relative position to the origin
+   * and positive numbers rotate objects in a clockwise direction.
+   * Transformations apply to everything that happens after and subsequent
+   * calls to the function accumulates the effect. For example, calling
+   * <b>rotate(HALF_PI)</b> and then <b>rotate(HALF_PI)</b> is the same as
+   * <b>rotate(PI)</b>. All tranformations are reset when <b>draw()</b>
+   * begins again.
+   * <br/> <br/>
+   * Technically, <b>rotate()</b> multiplies the current transformation
+   * matrix by three matrices: a translation to the center point, a rotation 
+   * and finally another translation in order to reset the origin. This 
+   * function can be further controlled by the <b>pushMatrix()</b> and 
+   * <b>popMatrix()</b>.
+   *
+   * ( end auto-generated )
+   *
+   * @webref transform
+   * @param angle angle of rotation specified in radians
+   * @see PGraphics#popMatrix()
+   * @see PGraphics#pushMatrix()
+   * @see PGraphics#rotate(float)
+   * @see PGraphics#rotateX(float)
+   * @see PGraphics#rotateY(float)
+   * @see PGraphics#rotateZ(float)
+   * @see PGraphics#scale(float, float, float)
+   * @see PApplet#radians(float)
+   */
+  public void rotate(float angle, float x, float y) {
+    translate(-x, -y);
+    rotate(angle);
+    translate(x, y);
   }
 
 


### PR DESCRIPTION
Currently, Processing only offers a `rotate(angle)` function which rotates around 0,0. Rotation around a custom point is cumbersome and requires a combination of rotations and translations, as well as a `pushMatrix()`. While many advanced users are familiar with this logic, it overcomplicates the learning curve for students and beginners because it requires understanding of matrices.
I'm adding a `rotate(angle, x, y)` shortcut that simplifies this transformation.

I'm not sure I did everything right; let me know if this commit does everything we need for introducing a new instruction.