### PR TITLE
Handle characters with shift modifiers in FX2D (#5317)

### DIFF
--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -1016,9 +1016,16 @@ public class PSurfaceFX implements PSurface {
       case MULTIPLY:
         return '*';
       case SUBTRACT:
+      case MINUS:
+        if (fxEvent.isShiftDown()) {
+          return '_';
+        }
         return '-';
       case ADD:
       case PLUS:
+        if (fxEvent.isShiftDown()) {
+          return '*';
+        }
         return '+';
       case NUMPAD0:
         return '0';
@@ -1040,12 +1047,79 @@ public class PSurfaceFX implements PSurface {
         return '8';
       case NUMPAD9:
         return '9';
+      case DIGIT1:
+        if (fxEvent.isShiftDown()) {
+          return '!';
+        }
+        return '1';
+      case DIGIT2:
+        if (fxEvent.isShiftDown()) {
+          return '"';
+        }
+        return '2';
+      case DIGIT3:
+        if (fxEvent.isShiftDown()) {
+          return '§';
+        }
+        return '3';
+      case DIGIT4:
+        if (fxEvent.isShiftDown()) {
+          return '$';
+        }
+        return '4';
+      case DIGIT5:
+        if (fxEvent.isShiftDown()) {
+          return '%';
+        }
+        return '5';
+      case DIGIT6:
+        if (fxEvent.isShiftDown()) {
+          return '&';
+        }
+        return '6';
+      case DIGIT7:
+        if (fxEvent.isShiftDown()) {
+          return '/';
+        }
+        return '7';
+      case DIGIT8:
+        if (fxEvent.isShiftDown()) {
+          return '(';
+        }
+        return '8';
+      case DIGIT9:
+        if (fxEvent.isShiftDown()) {
+          return ')';
+        }
+        return '9';
+      case DIGIT0:
+        if (fxEvent.isShiftDown()) {
+          return '=';
+        }
+        return '0';
       case DECIMAL:
         // KEY_TYPED does not go through here and will produce
         // dot or comma based on the keyboard layout.
         // For KEY_PRESSED and KEY_RELEASED, let's just go with
         // the dot. Users can detect the key by its keyCode.
         return '.';
+      case NUMBER_SIGN:
+        return '#';
+      case LESS:
+        if (fxEvent.isShiftDown()) {
+          return '>';
+        }
+        return '<';
+      case PERIOD:
+        if (fxEvent.isShiftDown()) {
+          return ':';
+        }
+        return '.';
+      case COMMA:
+        if (fxEvent.isShiftDown()) {
+          return ';';
+        }
+        return ',';
       case UNDEFINED:
         // KEY_TYPED has KeyCode: UNDEFINED
         // and falls through here

--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -1018,6 +1018,7 @@ public class PSurfaceFX implements PSurface {
       case SUBTRACT:
         return '-';
       case ADD:
+      case PLUS:
         return '+';
       case NUMPAD0:
         return '0';


### PR DESCRIPTION
I fixed the issue #5317 .  And test it with the various modes.  (FX2D, P2D, none)  
```java
void setup()
{
  size(200,200, FX2D);
  //size(200,200, P2D);
  //size(200,200);
}

void draw()
{
  if (key == '+')
   {
     // println("catch + inside draw"); 
   }
}

void keyPressed()
{
   //println("key pressed! --> " + key);
   if (key == '+')
   {
      println("catch + inside keyPressed"); 
   }
}
```
Now the ```println("catch + inside keyPressed"); ``` in the function ```keyPressed()``` will correct fired.  
Thank @benfry for the help! Without you I had not found the proper place to fix.   

***NOTE:*** I added the shift characters ```* # < > , ! " § $ % & / ( ) = . : ; - _```