### PR TITLE
Add separator argument to loadTable() (#5068)

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -6161,6 +6161,10 @@ public class PApplet implements PConstants {
     }
   }
 
+
+  /**
+   * Same method as above inclusive a optiona delimiter. 
+   */
   public Table loadTable(String filename, String options, char delimiter) {
 
     //System.out.printf("DEBUG: class: PApplet loadTable(String, String) filename=%s, options=%s\n",filename, options); //DEBUG
@@ -6181,6 +6185,8 @@ public class PApplet implements PConstants {
         System.err.println(filename + " does not exist or could not be read");
         return null;
       }
+
+      // call a other constructor of Table
       return new Table(input, optionStr, delimiter);
 
     } catch (IOException e) {

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -6134,6 +6134,9 @@ public class PApplet implements PConstants {
    * @param options may contain "header", "tsv", "csv", or "bin" separated by commas
    */
   public Table loadTable(String filename, String options) {
+
+   // System.out.printf("DEBUG: class: PApplet loadTable(String, String) filename=%s, options=%s\n",filename, options); //DEBUG
+
     try {
       String optionStr = Table.extensionOptions(true, filename, options);
       String[] optionList = trim(split(optionStr, ','));
@@ -6151,6 +6154,34 @@ public class PApplet implements PConstants {
         return null;
       }
       return new Table(input, optionStr);
+
+    } catch (IOException e) {
+      printStackTrace(e);
+      return null;
+    }
+  }
+
+  public Table loadTable(String filename, String options, char delimiter) {
+
+    //System.out.printf("DEBUG: class: PApplet loadTable(String, String) filename=%s, options=%s\n",filename, options); //DEBUG
+
+    try {
+      String optionStr = Table.extensionOptions(true, filename, options);
+      String[] optionList = trim(split(optionStr, ','));
+
+      Table dictionary = null;
+      for (String opt : optionList) {
+        if (opt.startsWith("dictionary=")) {
+          dictionary = loadTable(opt.substring(opt.indexOf('=') + 1), "tsv");
+          return dictionary.typedParse(createInput(filename), optionStr);
+        }
+      }
+      InputStream input = createInput(filename);
+      if (input == null) {
+        System.err.println(filename + " does not exist or could not be read");
+        return null;
+      }
+      return new Table(input, optionStr, delimiter);
 
     } catch (IOException e) {
       printStackTrace(e);

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -6122,6 +6122,14 @@ public class PApplet implements PConstants {
 
 
   /**
+   * Other version with a delimiter
+   */
+  public Table loadTable(String filename, char delimiter) {
+    return loadTable(filename, null, delimiter);
+  }
+
+
+  /**
    * Options may contain "header", "tsv", "csv", or "bin" separated by commas.
    *
    * Another option is "dictionary=filename.tsv", which allows users to
@@ -6163,7 +6171,7 @@ public class PApplet implements PConstants {
 
 
   /**
-   * Same method as above inclusive a optiona delimiter. 
+   * Other version with a delimiter
    */
   public Table loadTable(String filename, String options, char delimiter) {
 

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -98,6 +98,7 @@ public class Table {
   // each expansion.
   protected int expandIncrement;
 
+  // free delimiter - standard is the comma-seperator
   protected char delimiter = ',';
 
   /**
@@ -573,6 +574,7 @@ public class Table {
 //    int offset;
     int start; //, stop;
 
+    // free delimiter. standard is comma-seperator
     char delimiter = ',';
 
     String[] handle(String line, BufferedReader reader, char delimiter) throws IOException {

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -129,11 +129,25 @@ public class Table {
           extensionOptions(true, file.getName(), options));
   }
 
+  public Table(File file, String options, char delimiter) throws IOException {
+    // uses createInput() to handle .gz (and eventually .bz2) files
+    this.delimiter = delimiter;
+    init();
+    parse(PApplet.createInput(file),
+          extensionOptions(true, file.getName(), options));
+  }
+
   /**
    * @nowebref
    */
   public Table(InputStream input) throws IOException {
     this(input, null);
+  }
+
+
+  public Table(InputStream input, char delimiter) throws IOException {
+    this(input, null);
+    this.delimiter = delimiter;
   }
 
 
@@ -1274,7 +1288,7 @@ public class Table {
     if (columnTitles != null) {
       for (int col = 0; col < getColumnCount(); col++) {
         if (col != 0) {
-          writer.print(',');
+          writer.print(delimiter);
         }
         try {
           if (columnTitles[col] != null) {  // col < columnTitles.length &&
@@ -1291,7 +1305,7 @@ public class Table {
     for (int row = 0; row < rowCount; row++) {
       for (int col = 0; col < getColumnCount(); col++) {
         if (col != 0) {
-          writer.print(',');
+          writer.print(delimiter);
         }
         String entry = getString(row, col);
         // just write null entries as blanks, rather than spewing 'null'

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -98,6 +98,7 @@ public class Table {
   // each expansion.
   protected int expandIncrement;
 
+  protected char delimiter = ',';
 
   /**
    * Creates a new, empty table. Use addRow() to add additional rows.
@@ -150,6 +151,13 @@ public class Table {
    * @throws IOException
    */
   public Table(InputStream input, String options) throws IOException {
+    init();
+    parse(input, options);
+  }
+
+
+  public Table(InputStream input, String options, char delimiter) throws IOException {
+    this.delimiter = delimiter;
     init();
     parse(input, options);
   }
@@ -565,17 +573,21 @@ public class Table {
 //    int offset;
     int start; //, stop;
 
-    String[] handle(String line, BufferedReader reader) throws IOException {
+    char delimiter = ',';
+
+    String[] handle(String line, BufferedReader reader, char delimiter) throws IOException {
 //      PApplet.println("handle() called for: " + line);
       start = 0;
       pieceCount = 0;
       c = line.toCharArray();
 
+      this.delimiter = delimiter;
+
       // get tally of number of columns and allocate the array
       int cols = 1;  // the first comma indicates the second column
       boolean quote = false;
       for (int i = 0; i < c.length; i++) {
-        if (!quote && (c[i] == ',')) {
+        if (!quote && (c[i] == delimiter)) {
           cols++;
         } else if (c[i] == '\"') {
           // double double quotes (escaped quotes like "") will simply toggle
@@ -606,7 +618,7 @@ public class Table {
           temp[c.length] = '\n';
           nextLine.getChars(0, nextLine.length(), temp, c.length + 1);
 //          c = temp;
-          return handle(new String(temp), reader);
+          return handle(new String(temp), reader, delimiter);
           //System.out.println("  full line is now " + new String(c));
           //stop = nextComma(c, offset);
           //System.out.println("stop is now " + stop);
@@ -675,7 +687,7 @@ public class Table {
               hasEscapedQuotes = true;
               i += 2;
 
-            } else if (c[i+1] == ',') {
+            } else if (c[i+1] == delimiter) {
               // that was our closing quote, get outta here
               addPiece(start, i, hasEscapedQuotes);
               start = i+2;
@@ -702,7 +714,7 @@ public class Table {
               throw new RuntimeException("Unterminated quoted field mid-line");
             }
           }
-        } else if (!quoted && c[i] == ',') {
+        } else if (!quoted && c[i] == delimiter) {
           addPiece(start, i, hasEscapedQuotes);
           start = i+1;
           return true;
@@ -752,7 +764,7 @@ public class Table {
     if (csl == null) {
       csl = new CommaSeparatedLine();
     }
-    return csl.handle(line, reader);
+    return csl.handle(line, reader, delimiter);
   }
 
 


### PR DESCRIPTION
I fixed the issue #5068 (enhancement). Now we can choice a separator for the CSV-files.  And open this as well.  

```processing
Table table;

void setup() {

  table = loadTable("mammal2.csv", "header", ';');

  println(table.getRowCount() + " total rows in table"); 

  for (TableRow row : table.rows()) {

    int id = row.getInt("id");
    String species = row.getString("species");
    String name = row.getString("name");

    println(name + " (" + species + ") has an ID of " + id);
  }
}

```

* The file ```mammal2.csv``` is now seperated with ```;```   

Another example
```processing
Table table;

void setup() {

  table = loadTable("mammal2.csv",';');

  println(table.getRowCount() + " total rows in table"); 

  for (TableRow row : table.rows()) {

    println(row.getString(1));
  }
}
```