### PR TITLE
Add a simple extended error message (#4646)

### DIFF
--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -62,8 +62,6 @@ public class Compiler {
     SketchException exception = null;
     boolean success = false;
 
-    // System.out.printf("DEBUG: class Compiler -- BEGIN compile(...)\n"); //DEBUG
-
     String baseCommand[] = new String[] {
       "-g",
       "-Xemacs",
@@ -112,9 +110,6 @@ public class Compiler {
       // so that it can grab the compiler JAR files from it.
       ClassLoader loader = build.mode.getClassLoader();
 
-      // System.out.printf("DEBUG: class Compiler -- line 114 -- compile(...) exception=%s\n",exception); // DEBUG 
-      // System.err.println(errorBuffer.toString()); //DEBUG
-
       try {
         Class<?> batchClass =
           Class.forName("org.eclipse.jdt.core.compiler.batch.BatchCompiler", false, loader);
@@ -125,14 +120,11 @@ public class Compiler {
         Method compileMethod = batchClass.getMethod("compile", compileArgs);
         success = (Boolean)
           compileMethod.invoke(null, new Object[] { command, outWriter, writer, null });
-        // System.err.println(errorBuffer.toString()); //DEBUG
 
       } catch (Exception e) {
         e.printStackTrace();
         throw new SketchException("Unknown error inside the compiler.");
       }
-
-      // System.err.println(errorBuffer.toString()); //DEBUG
 
       // Close out the stream for good measure
       writer.flush();
@@ -140,18 +132,14 @@ public class Compiler {
 
       BufferedReader reader =
         new BufferedReader(new StringReader(errorBuffer.toString()));
-      // System.err.println(errorBuffer.toString()); //DEBUG
 
       String line = null;
       while ((line = reader.readLine()) != null) {
-        // System.out.println("got line " + line);  // debug
 
         // get first line, which contains file name, line number,
         // and at least the first line of the error message
         String errorFormat = "([\\w\\d_]+.java):(\\d+):\\s*(.*):\\s*(.*)\\s*";
         String[] pieces = PApplet.match(line, errorFormat);
-        // PApplet.println(pieces);
-        // System.out.println(pieces[4]); //DEBUG 
 
         // if it's something unexpected, die and print the mess to the console
         if (pieces == null) {
@@ -173,7 +161,8 @@ public class Compiler {
         String errorMessage = pieces[4];
 
         // extended error message or certain error message
-        if (errorMessage.length() <= 3) {
+        
+        if (!errorMessage.matches("(a-zA-Z| )+")) {
           switch (errorMessage) {
             case "23)": // cast error: int -> boolean
               errorMessage = "int constant cannot be casted into boolean";
@@ -191,7 +180,6 @@ public class Compiler {
         
 
         if (exception == null) {
-          // System.err.println(errorMessage); //DEBUG
           exception = new SketchException(errorMessage);
         }
 

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -172,9 +172,16 @@ public class Compiler {
         int dotJavaLineIndex = PApplet.parseInt(pieces[2]) - 1;
         String errorMessage = pieces[4];
 
-        // extended error message
+        // extended error message or certain error message
         if (errorMessage.length() <= 3) {
-          errorMessage = pieces[3] + " " + errorMessage;
+          switch (errorMessage) {
+            case "23)": // cast error: int -> boolean
+              errorMessage = "int constant cannot be casted into boolean";
+              break;
+            default:
+              errorMessage = pieces[3] + " " + errorMessage;
+              break;
+          }
         }
 
 

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -158,7 +158,7 @@ public class Compiler {
 
         // extended error message or certain error message
         
-        if (!errorMessage.matches("(a-zA-Z|\\s)+")) {
+        if (!errorMessage.matches("([\\w\\d_]+.java):(\\d+):\\s*(.*):\\s*(.*)\\s*")) {
           switch (errorMessage) {
             case "23)": // cast error: int -> boolean
               errorMessage = "int constant cannot be casted into boolean";

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -73,13 +73,9 @@ public class Compiler {
       "-nowarn", // we're not currently interested in warnings (works in ecj)
       "-d", build.getBinFolder().getAbsolutePath() // output the classes in the buildPath
     };
-    //PApplet.println(baseCommand);
 
     String[] sourceFiles = Util.listFiles(build.getSrcFolder(), false, ".java");
     String[] command = PApplet.concat(baseCommand, sourceFiles);
-    //PApplet.println(command);
-
-    // System.out.printf("DEBUG: class Compiler -- BEGIN  -- compile(...) exception=%s\n",exception); // DEBUG 
 
     try {
       // Load errors into a local StringBuilder
@@ -193,7 +189,6 @@ public class Compiler {
           String[] m = PApplet.match(errorMessage, "The import (.*) cannot be resolved");
           //what = what.substring(0, what.indexOf(' '));
           if (m != null) {
-//            System.out.println("'" + m[1] + "'");
             if (m[1].equals("processing.xml")) {
               exception.setMessage("processing.xml no longer exists, this code needs to be updated for 2.0.");
               System.err.println("The processing.xml library has been replaced " +
@@ -237,9 +232,7 @@ public class Compiler {
           }
 
         } else if (errorMessage.endsWith("cannot be resolved")) {
-          // xxx cannot be resolved
-          //println(xxx);
-
+        
           String what = errorMessage.substring(0, errorMessage.indexOf(' '));
 
           if (what.equals("LINE_LOOP") ||

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -158,7 +158,7 @@ public class Compiler {
 
         // extended error message or certain error message
         
-        if (!errorMessage.matches("(a-zA-Z| )+")) {
+        if (!errorMessage.matches("(a-zA-Z|\\s)+")) {
           switch (errorMessage) {
             case "23)": // cast error: int -> boolean
               errorMessage = "int constant cannot be casted into boolean";


### PR DESCRIPTION
I fixed the issue #4646.
Now we get for the code the following error message 
```processing
void setup() {
  size(200, 200, FX2D);
}

void draw() {
  boolean c = (boolean) 1 || (boolean) 1;
}
```

produces the error message
![screenshot](https://user-images.githubusercontent.com/23243382/42139115-f888fd46-7d87-11e8-84e5-209732061a6f.png)

instead of mere ```23)``` 

I put in a chunk of code that check the size of the error message. If the size to small (mere 3 characters) then the error message will be extended.  

