### PR TITLE
OpenGL ES: Fix GLSL version number for 1.00 (#5582)

### DIFF
--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -513,7 +513,8 @@ public class PJOGL extends PGL {
 
   @Override
   protected String getGLSLVersionSuffix() {
-    if (context.isGLESProfile()) {
+    VersionNumber vn = context.getGLSLVersionNumber();
+    if (context.isGLESProfile() && 1 < vn.getMajor()) {
       return " es";
     } else {
       return "";


### PR DESCRIPTION
@benfry: Another fallout from 3.3.7.1