### PR TITLE
Fixed for JEP-223 support

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -119,8 +119,11 @@ public class PApplet implements PConstants {
     String version = javaVersionName;
     if (javaVersionName.startsWith("1.")) {
       version = version.substring(2);
+      javaPlatform = parseInt(version.substring(0, version.indexOf('.')));
+    } else {
+      // Remove -xxx and .yyy from java.version (@see JEP-223)
+      javaPlatform = parseInt(version.replaceAll("-.*","").replaceAll("\\..*",""));
     }
-    javaPlatform = parseInt(version.substring(0, version.indexOf('.')));
   }
 
   /**


### PR DESCRIPTION
This PR modifies the javaPlatform extraction method so it works with the newest java.version format (as per JEP-223).