### PR TITLE
Fixes blend mode not being set correctly, fixing #5645.

### DIFF
--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -6177,7 +6177,7 @@ public class PGraphics extends PImage implements PConstants {
     ellipseMode(s.ellipseMode);
     shapeMode(s.shapeMode);
 
-    if (blendMode != 0) {
+    if (blendMode != s.blendMode) {
       blendMode(s.blendMode);
     }
 


### PR DESCRIPTION
Blend mode can incorrectly be set to REPLACE in P2D when rendering certain bitmap fonts. This breaks rendering of images with alpha channels in the same sketch on 3.4. See #5645 which is fixed by this PR.