### PR TITLE
Fix #5317: Modifier keys not recognized with FX2D

### DIFF
--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -1011,40 +1011,6 @@ public class PSurfaceFX implements PSurface {
         return PConstants.CODED;
       case ENTER:
         return '\n';
-      case DIVIDE:
-        return '/';
-      case MULTIPLY:
-        return '*';
-      case SUBTRACT:
-        return '-';
-      case ADD:
-        return '+';
-      case NUMPAD0:
-        return '0';
-      case NUMPAD1:
-        return '1';
-      case NUMPAD2:
-        return '2';
-      case NUMPAD3:
-        return '3';
-      case NUMPAD4:
-        return '4';
-      case NUMPAD5:
-        return '5';
-      case NUMPAD6:
-        return '6';
-      case NUMPAD7:
-        return '7';
-      case NUMPAD8:
-        return '8';
-      case NUMPAD9:
-        return '9';
-      case DECIMAL:
-        // KEY_TYPED does not go through here and will produce
-        // dot or comma based on the keyboard layout.
-        // For KEY_PRESSED and KEY_RELEASED, let's just go with
-        // the dot. Users can detect the key by its keyCode.
-        return '.';
       case UNDEFINED:
         // KEY_TYPED has KeyCode: UNDEFINED
         // and falls through here
@@ -1059,7 +1025,7 @@ public class PSurfaceFX implements PSurface {
     if (fxEvent.getEventType() == KeyEvent.KEY_TYPED) {
       ch = fxEvent.getCharacter();
     } else {
-      ch = kc.impl_getChar();
+      ch = fxEvent.getText();
     }
 
     if (ch.length() < 1) return PConstants.CODED;


### PR DESCRIPTION
This fixes #5317. The fix was rather simple: just removing some default return values, and changing the deprecated `KeyCode#impl_getChar()` method call to `KeyEvent#getText()`.