### PR TITLE
Fixes #5246 by overriding getPreferredSize and setting height to 0.

### DIFF
--- a/app/src/processing/app/ui/ZoomTreeCellRenderer.java
+++ b/app/src/processing/app/ui/ZoomTreeCellRenderer.java
@@ -22,8 +22,8 @@
 
 package processing.app.ui;
 
-import java.awt.Component;
-import java.awt.EventQueue;
+import java.awt.*;
+import java.util.Optional;
 
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -37,6 +37,12 @@ public class ZoomTreeCellRenderer extends DefaultTreeCellRenderer {
     setFont(mode.getFont("tree.font"));
   }
 
+  @Override
+  public Dimension getPreferredSize() {
+    return Optional.ofNullable(super.getPreferredSize())
+            .map(d -> new Dimension(d.width, (int) (d.height * 1.15f)))
+            .orElse(null);
+  }
 
   @Override
   public Component getTreeCellRendererComponent(JTree tree, Object value,
@@ -48,21 +54,9 @@ public class ZoomTreeCellRenderer extends DefaultTreeCellRenderer {
     // Adjust height for magnified displays. The font is scaled properly,
     // but the rows don't automatically use the scaled preferred size.
     // https://github.com/processing/processing/issues/4936
-    int high = getPreferredSize().height;
-    if (high != 0) {
-      // Source Sans leading too short, so also add 15% for nicer spacing
-      final int targetHeight = (int) (high * 1.15f);
-      int currentHeight = getSize().height;
-      if (currentHeight != targetHeight) {
-        // Using invokeLater() to avoid infinite loop on Windows
-        // https://github.com/processing/processing/issues/5246
-        EventQueue.invokeLater(new Runnable() {
-          public void run() {
-            tree.setRowHeight(targetHeight);
-          }
-        });
-      }
-    }
+    // Using setRowHeight(0) to force using this cell renderer's preferred height
+    // https://github.com/processing/processing/issues/5246#issuecomment-379503233
+    tree.setRowHeight(0);
     return super.getTreeCellRendererComponent(tree, value, selected,
                                               expanded, leaf, row, hasFocus);
   }


### PR DESCRIPTION
This works on my machine. Haven't tested it on Mac or Linux, so there's a need to make sure this doesn't screw things up on other operating systems.

Before:
![exampleswindowspinningbefore](https://user-images.githubusercontent.com/613667/45737994-8e132f80-bbef-11e8-8b43-c3b71e5327ad.png)

After:
![exampleswindowspinningafter](https://user-images.githubusercontent.com/613667/45737999-910e2000-bbef-11e8-8a94-eb5f4b07301a.png)