### PR TITLE
Make sure Ctrl+Left Mouse on MacOS is consistent

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -1231,14 +1231,6 @@ public class PSurfaceAWT extends PSurfaceNone {
   */
 
 
-  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
-  // track of whether the conversion happened on PRESS, because we should report
-  // the same button during DRAG and on RELEASE, even though CTRL might have
-  // been released already. Otherwise the events are inconsistent, e.g.
-  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
-  // See: https://github.com/processing/processing/issues/5672
-  private boolean macosxLeftButtonWithCtrlPressed;
-
   /**
    * Figure out how to process a mouse event. When loop() has been
    * called, the events will be queued up until drawing is complete.
@@ -1322,21 +1314,6 @@ public class PSurfaceAWT extends PSurfaceNone {
       peButton = PConstants.CENTER;
     } else if ((modifiers & InputEvent.BUTTON3_MASK) != 0) {
       peButton = PConstants.RIGHT;
-    }
-
-    // If running on Mac OS, allow ctrl-click as right mouse. Prior to 0215,
-    // this used isPopupTrigger() on the native event, but that doesn't work
-    // for mouseClicked and mouseReleased (or others).
-    if (/*PApplet.platform == PConstants.MACOSX &&*/ peButton == PConstants.LEFT) {
-      if (peAction == MouseEvent.PRESS && (modifiers & InputEvent.CTRL_MASK) != 0) {
-        macosxLeftButtonWithCtrlPressed = true;
-      }
-      if (macosxLeftButtonWithCtrlPressed) {
-        peButton = PConstants.RIGHT;
-      }
-      if (peAction == MouseEvent.RELEASE) {
-        macosxLeftButtonWithCtrlPressed = false;
-      }
     }
 
     sketch.postEvent(new MouseEvent(nativeEvent, nativeEvent.getWhen(),

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -1231,6 +1231,14 @@ public class PSurfaceAWT extends PSurfaceNone {
   */
 
 
+  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
+  // track of whether the conversion happened on PRESS, because we should report
+  // the same button during DRAG and on RELEASE, even though CTRL might have
+  // been released already. Otherwise the events are inconsistent, e.g.
+  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
+  // See: https://github.com/processing/processing/issues/5672
+  private boolean macosxLeftButtonWithCtrlPressed;
+
   /**
    * Figure out how to process a mouse event. When loop() has been
    * called, the events will be queued up until drawing is complete.
@@ -1319,10 +1327,15 @@ public class PSurfaceAWT extends PSurfaceNone {
     // If running on Mac OS, allow ctrl-click as right mouse. Prior to 0215,
     // this used isPopupTrigger() on the native event, but that doesn't work
     // for mouseClicked and mouseReleased (or others).
-    if (PApplet.platform == PConstants.MACOSX) {
-      //if (nativeEvent.isPopupTrigger()) {
-      if ((modifiers & InputEvent.CTRL_MASK) != 0) {
+    if (/*PApplet.platform == PConstants.MACOSX &&*/ peButton == PConstants.LEFT) {
+      if (peAction == MouseEvent.PRESS && (modifiers & InputEvent.CTRL_MASK) != 0) {
+        macosxLeftButtonWithCtrlPressed = true;
+      }
+      if (macosxLeftButtonWithCtrlPressed) {
         peButton = PConstants.RIGHT;
+      }
+      if (peAction == MouseEvent.RELEASE) {
+        macosxLeftButtonWithCtrlPressed = false;
       }
     }
 

--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -27,7 +27,6 @@ import com.sun.glass.ui.Screen;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
-import java.awt.event.InputEvent;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -824,16 +823,6 @@ public class PSurfaceFX implements PSurface {
     mouseMap.put(MouseEvent.MOUSE_EXITED, processing.event.MouseEvent.EXIT);
   }
 
-
-  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
-  // track of whether the conversion happened on PRESS, because we should report
-  // the same button during DRAG and on RELEASE, even though CTRL might have
-  // been released already. Otherwise the events are inconsistent, e.g.
-  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
-  // See: https://github.com/processing/processing/issues/5672
-  private boolean macosxLeftButtonWithCtrlPressed;
-
-
   protected void fxMouseEvent(MouseEvent fxEvent) {
     // the 'amount' is the number of button clicks for a click event,
     // or the number of steps/clicks on the wheel for a mouse wheel event.
@@ -869,20 +858,6 @@ public class PSurfaceFX implements PSurface {
       case NONE:
         // not currently handled
         break;
-    }
-
-    // If running on Mac OS, allow ctrl-click as right mouse.
-    // Verified to be necessary with Java 8u45.
-    if (PApplet.platform == PConstants.MACOSX && button == PConstants.LEFT) {
-      if (action == processing.event.MouseEvent.PRESS && fxEvent.isControlDown()) {
-        macosxLeftButtonWithCtrlPressed = true;
-      }
-      if (macosxLeftButtonWithCtrlPressed) {
-        button = PConstants.RIGHT;
-      }
-      if (action == processing.event.MouseEvent.RELEASE) {
-        macosxLeftButtonWithCtrlPressed = false;
-      }
     }
 
     //long when = nativeEvent.getWhen();  // from AWT

--- a/core/src/processing/javafx/PSurfaceFX.java
+++ b/core/src/processing/javafx/PSurfaceFX.java
@@ -27,6 +27,7 @@ import com.sun.glass.ui.Screen;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
+import java.awt.event.InputEvent;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -823,6 +824,16 @@ public class PSurfaceFX implements PSurface {
     mouseMap.put(MouseEvent.MOUSE_EXITED, processing.event.MouseEvent.EXIT);
   }
 
+
+  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
+  // track of whether the conversion happened on PRESS, because we should report
+  // the same button during DRAG and on RELEASE, even though CTRL might have
+  // been released already. Otherwise the events are inconsistent, e.g.
+  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
+  // See: https://github.com/processing/processing/issues/5672
+  private boolean macosxLeftButtonWithCtrlPressed;
+
+
   protected void fxMouseEvent(MouseEvent fxEvent) {
     // the 'amount' is the number of button clicks for a click event,
     // or the number of steps/clicks on the wheel for a mouse wheel event.
@@ -862,10 +873,16 @@ public class PSurfaceFX implements PSurface {
 
     // If running on Mac OS, allow ctrl-click as right mouse.
     // Verified to be necessary with Java 8u45.
-    if (PApplet.platform == PConstants.MACOSX &&
-        fxEvent.isControlDown() &&
-        button == PConstants.LEFT) {
-      button = PConstants.RIGHT;
+    if (PApplet.platform == PConstants.MACOSX && button == PConstants.LEFT) {
+      if (action == processing.event.MouseEvent.PRESS && fxEvent.isControlDown()) {
+        macosxLeftButtonWithCtrlPressed = true;
+      }
+      if (macosxLeftButtonWithCtrlPressed) {
+        button = PConstants.RIGHT;
+      }
+      if (action == processing.event.MouseEvent.RELEASE) {
+        macosxLeftButtonWithCtrlPressed = false;
+      }
     }
 
     //long when = nativeEvent.getWhen();  // from AWT

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1011,6 +1011,15 @@ public class PSurfaceJOGL implements PSurface {
   }
 
 
+  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
+  // track of whether the conversion happened on PRESS, because we should report
+  // the same button during DRAG and on RELEASE, even though CTRL might have
+  // been released already. Otherwise the events are inconsistent, e.g.
+  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
+  // See: https://github.com/processing/processing/issues/5672
+  private boolean macosxLeftButtonWithCtrlPressed;
+
+
   protected void nativeMouseEvent(com.jogamp.newt.event.MouseEvent nativeEvent,
                                   int peAction) {
     int modifiers = nativeEvent.getModifiers();
@@ -1033,10 +1042,16 @@ public class PSurfaceJOGL implements PSurface {
         break;
     }
 
-    if (PApplet.platform == PConstants.MACOSX) {
-      //if (nativeEvent.isPopupTrigger()) {
-      if ((modifiers & InputEvent.CTRL_MASK) != 0) {
+    // If running on Mac OS, allow ctrl-click as right mouse.
+    if (PApplet.platform == PConstants.MACOSX && peButton == PConstants.LEFT) {
+      if (peAction == MouseEvent.PRESS && (modifiers & InputEvent.CTRL_MASK) != 0) {
+        macosxLeftButtonWithCtrlPressed = true;
+      }
+      if (macosxLeftButtonWithCtrlPressed) {
         peButton = PConstants.RIGHT;
+      }
+      if (peAction == MouseEvent.RELEASE) {
+        macosxLeftButtonWithCtrlPressed = false;
       }
     }
 

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1011,15 +1011,6 @@ public class PSurfaceJOGL implements PSurface {
   }
 
 
-  // MACOSX: CTRL + Left Mouse is converted to Right Mouse. This boolean keeps
-  // track of whether the conversion happened on PRESS, because we should report
-  // the same button during DRAG and on RELEASE, even though CTRL might have
-  // been released already. Otherwise the events are inconsistent, e.g.
-  // Left Pressed - Left Drag - CTRL Pressed - Right Drag - Right Released.
-  // See: https://github.com/processing/processing/issues/5672
-  private boolean macosxLeftButtonWithCtrlPressed;
-
-
   protected void nativeMouseEvent(com.jogamp.newt.event.MouseEvent nativeEvent,
                                   int peAction) {
     int modifiers = nativeEvent.getModifiers();
@@ -1040,19 +1031,6 @@ public class PSurfaceJOGL implements PSurface {
       case com.jogamp.newt.event.MouseEvent.BUTTON3:
         peButton = PConstants.RIGHT;
         break;
-    }
-
-    // If running on Mac OS, allow ctrl-click as right mouse.
-    if (PApplet.platform == PConstants.MACOSX && peButton == PConstants.LEFT) {
-      if (peAction == MouseEvent.PRESS && (modifiers & InputEvent.CTRL_MASK) != 0) {
-        macosxLeftButtonWithCtrlPressed = true;
-      }
-      if (macosxLeftButtonWithCtrlPressed) {
-        peButton = PConstants.RIGHT;
-      }
-      if (peAction == MouseEvent.RELEASE) {
-        macosxLeftButtonWithCtrlPressed = false;
-      }
     }
 
     int peCount = 0;


### PR DESCRIPTION
Make sure PRESS, DRAG and RELEASE report the same mouse button on MacOS.

- If CTRL was pressed during Left PRESS, report Right Button until the button is released, regardless of whether CTRL is still down.
- If CTRL was not pressed during Left PRESS, report Left Button until the button is released, regardless of CTRL state.

Fixes #5672
