### PR TITLE
Recreate FBOs when offscreen PGraphicsOpenGL is resized

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -6797,6 +6797,9 @@ public class PGraphicsOpenGL extends PGraphics {
       } else {
         // offscreen surfaces are transparent by default.
         background(0x00 << 24 | (backgroundColor & 0xFFFFFF));
+
+        // Recreate offscreen FBOs
+        restartPGL();
       }
 
       // Sets the default projection and camera (initializes modelview).


### PR DESCRIPTION
Otherwise FBOs keep the old size and things understandably break.