### PR TITLE
Fix freeze when restarting sketch with variables in size

### DIFF
--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -27,6 +27,7 @@
 
 package processing.mode.java.preproc;
 
+import java.awt.*;
 import java.io.*;
 import java.util.*;
 import java.util.regex.MatchResult;
@@ -380,7 +381,9 @@ public class PdePreprocessor {
           "The size of this sketch could not be determined from your code.\n" +
           "Use only numbers (not variables) for the size() command.\n" +
           "Read the size() reference for more details.";
-        Messages.showWarning("Could not find sketch size", message, null);
+        EventQueue.invokeLater(() -> {
+          Messages.showWarning("Could not find sketch size", message, null);
+        });
 //        new Exception().printStackTrace(System.out);
 //        return null;
         throw new SketchException("Please fix the size() line to continue.", false);


### PR DESCRIPTION
While sketch is running, rewriting sketch size to variables and trying to restart the sketch by pressing the play button causes PDE to freeze. It has to be killed and unsaved changes are lost. Fixed by moving AWT call to EDT.