### PR TITLE
Added method setMinimumSize(int x, int y) : void

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -583,6 +583,15 @@ public class PSurfaceAWT extends PSurfaceNone {
     }
   }
 
+    /** Set the minimum size of frame */
+  @Override
+  public void setMinimumSize(int x, int y) {
+    if (frame != null) {
+      sketchWidth = x;
+      sketchHeight = y;
+      frame.setMinimumSize(new Dimension(x, y));
+    }
+  } 
 
   @Override
   public void setIcon(PImage image) {


### PR DESCRIPTION
When I used the method `setResizable(boolean resizable) : void`, I had trouble resizing the application window. I was able to make windows with 0px height and width, now the programmer can set a minimum window size.