### PR TITLE
Fix bug with control-click for RIGHT on Mac OS, addresses #5765

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2697,7 +2697,7 @@ public class PApplet implements PConstants {
                                event.getX(), event.getY(),
                                button, event.getCount());
       }
-      if (button == MouseEvent.RELEASE) {
+      if (action == MouseEvent.RELEASE) {
         macosxLeftButtonWithCtrlPressed = false;
       }
     }


### PR DESCRIPTION
When a control-click occurs, the macosxLeftButtonWithCtrlPressed flag
was set, but was never being unset due to accidental comparison with
the button variable instead of action variable. All future mouse
operations reported as right-click on Mac OS. This fixes the comparison
so that only the operations from a mouse press with the control button
down are reported as RIGHT. The flag is cleared after mouse release.