### PR TITLE
trash solution for color method and give posibility to naming a variable color

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeEmitter.java
+++ b/java/src/processing/mode/java/preproc/PdeEmitter.java
@@ -687,11 +687,12 @@ public class PdeEmitter implements PdeTokenTypes {
       break;
 
     // the color datatype is just an alias for int
+    /*
     case LITERAL_color:
       out.print("int");
       dumpHiddenAfter(ast);
       break;
-
+    */
     case WEBCOLOR_LITERAL:
       if (ast.getText().length() != 6) {
         System.err.println("Internal error: incorrect length of webcolor "

--- a/java/src/processing/mode/java/preproc/pde.g
+++ b/java/src/processing/mode/java/preproc/pde.g
@@ -179,11 +179,12 @@ builtInConsCastType
 // rules so that constructor casts can just use the original typelist, since
 // we don't want to support the color type as a constructor cast.
 //
-builtInType
-    :   builtInConsCastType
-    |   "color"              // aliased to an int in PDE
-        { processing.app.Preferences.getBoolean("preproc.color_datatype") }? 
-    ;
+
+// builtInType
+//    :   builtInConsCastType
+//    |   "color"              // aliased to an int in PDE
+//        { processing.app.Preferences.getBoolean("preproc.color_datatype") }? 
+//    ;
 
 // constructor style casts.
 constructorCast!
@@ -245,12 +246,13 @@ builtInConsCastTypeSpec[boolean addImagNode]
 // that can generate a method call from an expression that starts with this
 // token
 //
-colorMethodCall
-    : c:"color" {#c.setType(IDENT);} // this would default to LITERAL_color
-      lp:LPAREN^ {#lp.setType(METHOD_CALL);}
-      argList
-      RPAREN!
-    ;  
+
+// colorMethodCall
+//    : c:"color" {#c.setType(IDENT);} // this would default to LITERAL_color
+//      lp:LPAREN^ {#lp.setType(METHOD_CALL);}
+//      argList
+//      RPAREN!
+//    ;  
 
 // copy of the java.g rule with added constructorCast and colorMethodCall 
 // alternatives
@@ -266,7 +268,7 @@ primaryExpression
     |   "this"
     |   "super"
     |   LPAREN! assignmentExpression RPAREN!
-    |   colorMethodCall
+//    |   colorMethodCall
         // look for int.class and int[].class
     |   builtInType
         ( lbt:LBRACK^ {#lbt.setType(ARRAY_DECLARATOR);} RBRACK! )*


### PR DESCRIPTION
Sure, it's my first trash pull request. I try to work around color problem.
When we remove the variable color as a `int`, after that we can use `color` for naming variable and method. For me that's can be a solution, because i'm not sur keep `color` like a int is very useful and advantage, because it's easy to understand it's a `int ` and my students understand easily when I write `int c = colot(255,0,0)`
May be a lot of people use var `color` so it's a balancing choice.  May be a little survey / poll to knnow if a lot of people use `color`like a `int `.

Happy to make this first pull request for the community and manage it... very long day to do that !