### PR TITLE
 ADD : Dialouge after Install/Update/Remove contributions

### DIFF
--- a/app/src/processing/app/contrib/DetailPanel.java
+++ b/app/src/processing/app/contrib/DetailPanel.java
@@ -550,7 +550,7 @@ class DetailPanel extends JPanel {
 
       ContribProgressBar downloadProgress = new ContribProgressBar(installProgressBar) {
         public void finishedAction() {
-          // nothing?
+          JOptionPane.showMessageDialog(null, "Installation Completed");
         }
 
         public void cancelAction() {
@@ -842,6 +842,7 @@ class DetailPanel extends JPanel {
     public void finishedAction() {
       // Finished uninstalling the library
       preAction();
+      JOptionPane.showMessageDialog(null, "Contribution has been deleted");
     }
 
     public void cancelAction() {


### PR DESCRIPTION
- The user was not being notified when the installation of Contribution was completed.
- This PR involves displaying a dialog , when installation is complete or removed or updated
- Solves Issue : #5822