### PR TITLE
Change method name 'sadness' to 'printError', 'loop' to 'enableLooping', 'list' to 'getFonts', 'available' to 'getNextActiveClients', 'paint' to 'setTextSelection', 'empty' to 'getSketchInstance' 

### DIFF
--- a/core/src/japplemenubar/JAppleMenuBar.java
+++ b/core/src/japplemenubar/JAppleMenuBar.java
@@ -51,19 +51,19 @@ public class JAppleMenuBar {
 	        instance = new JAppleMenuBar();
 
 	      } else {
-	        sadness("Problem saving " + FILENAME + " for full screen use.");
+	        printError("Problem saving " + FILENAME + " for full screen use.");
 	      }
 	    } else {
-        sadness("Could not load " + FILENAME + " from core.jar");
+        printError("Could not load " + FILENAME + " from core.jar");
 	    }
 	  } catch (IOException e) {
-	    sadness("Unknown error, here's the stack trace.");
+	    printError("Unknown error, here's the stack trace.");
 	    e.printStackTrace();
 	  }
 	}
 	
 	
-	static void sadness(String msg) {
+	static void printError(String msg) {
 	  System.err.println("Full screen mode disabled. " + msg);
 	}
 

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1810,7 +1810,7 @@ public class PApplet implements PConstants {
  * @webref structure
  * @usage web_application
  * @see PApplet#size(int, int)
- * @see PApplet#loop()
+ * @see PApplet#enableLooping()
  * @see PApplet#noLoop()
  * @see PApplet#draw()
  */
@@ -1840,7 +1840,7 @@ public class PApplet implements PConstants {
  * @webref structure
  * @usage web_application
  * @see PApplet#setup()
- * @see PApplet#loop()
+ * @see PApplet#enableLooping()
  * @see PApplet#noLoop()
  * @see PApplet#redraw()
  * @see PApplet#frameRate(float)
@@ -2544,7 +2544,7 @@ public class PApplet implements PConstants {
  * @webref structure
  * @usage web_application
  * @see PApplet#draw()
- * @see PApplet#loop()
+ * @see PApplet#enableLooping()
  * @see PApplet#noLoop()
  * @see PApplet#frameRate(float)
  */
@@ -2578,7 +2578,7 @@ public class PApplet implements PConstants {
  * @see PApplet#redraw()
  * @see PApplet#draw()
  */
-  synchronized public void loop() {
+  synchronized public void enableLooping() {
     if (!looping) {
       looping = true;
     }
@@ -2607,7 +2607,7 @@ public class PApplet implements PConstants {
    * ( end auto-generated )
  * @webref structure
  * @usage web_application
- * @see PApplet#loop()
+ * @see PApplet#enableLooping()
  * @see PApplet#redraw()
  * @see PApplet#draw()
  */
@@ -3409,7 +3409,7 @@ public class PApplet implements PConstants {
    * @see PApplet#frameCount
    * @see PApplet#setup()
    * @see PApplet#draw()
-   * @see PApplet#loop()
+   * @see PApplet#enableLooping()
    * @see PApplet#noLoop()
    * @see PApplet#redraw()
    */
@@ -3895,7 +3895,7 @@ public class PApplet implements PConstants {
    * @param name name of the function to be executed in a separate thread
    * @see PApplet#setup()
    * @see PApplet#draw()
-   * @see PApplet#loop()
+   * @see PApplet#enableLooping()
    * @see PApplet#noLoop()
    */
   public void thread(final String name) {

--- a/core/src/processing/core/PFont.java
+++ b/core/src/processing/core/PFont.java
@@ -883,7 +883,7 @@ public class PFont implements PConstants {
    * @usage application
    * @brief     Gets a list of the fonts installed on the system
    */
-  static public String[] list() {
+  static public String[] getFonts() {
     loadFonts();
     String list[] = new String[fonts.length];
     for (int i = 0; i < list.length; i++) {

--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -223,7 +223,7 @@ public class Server implements Runnable {
    * @webref server
    * @usage application
    */
-  public Client available() {
+  public Client getNextActiveClients() {
     synchronized (clientsLock) {
       int index = lastAvailable + 1;
       if (index >= clientCount) index = 0;

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -2094,7 +2094,7 @@ public class JavaEditor extends Editor {
       // revert to breakpoint color if any is set on this line
       for (LineHighlight hl : breakpointedLines) {
         if (hl.getLineID().equals(currentLine.getLineID())) {
-          hl.paint();
+          hl.setTextSelection();
           break;
         }
       }
@@ -2113,7 +2113,7 @@ public class JavaEditor extends Editor {
     breakpointedLines.add(hl);
     // repaint current line if it's on this line
     if (currentLine != null && currentLine.getLineID().equals(lineID)) {
-      currentLine.paint();
+      currentLine.setTextSelection();
     }
   }
 
@@ -2139,7 +2139,7 @@ public class JavaEditor extends Editor {
       foundLine.dispose();
       // repaint current line if it's on this line
       if (currentLine != null && currentLine.getLineID().equals(line)) {
-        currentLine.paint();
+        currentLine.setTextSelection();
       }
     }
   }
@@ -2158,7 +2158,7 @@ public class JavaEditor extends Editor {
 
     // repaint current line
     if (currentLine != null) {
-      currentLine.paint();
+      currentLine.setTextSelection();
     }
   }
 
@@ -2223,14 +2223,14 @@ public class JavaEditor extends Editor {
       if (breakpointedLines != null) {
         for (LineHighlight hl : breakpointedLines) {
           if (isInCurrentTab(hl.getLineID())) {
-            hl.paint();
+            hl.setTextSelection();
           }
         }
       }
       // now paint current line (if any)
       if (currentLine != null) {
         if (isInCurrentTab(currentLine.getLineID())) {
-          currentLine.paint();
+          currentLine.setTextSelection();
         }
       }
     }

--- a/java/src/processing/mode/java/debug/LineHighlight.java
+++ b/java/src/processing/mode/java/debug/LineHighlight.java
@@ -47,7 +47,7 @@ public class LineHighlight {
     this.editor = editor;
     lineID.addListener(this);
     lineID.startTracking(editor.getTab(lineID.fileName()).getDocument()); // TODO: overwrite a previous doc?
-    paint(); // already checks if on current tab
+    setTextSelection(); // already checks if on current tab
     allHighlights.add(this);
   }
 
@@ -93,7 +93,7 @@ public class LineHighlight {
    */
   public void setMarker(String marker) {
     this.marker = marker;
-    paint();
+    setTextSelection();
   }
 
 
@@ -136,7 +136,7 @@ public class LineHighlight {
     // but only if it's on top -> fixes current line being hidden by breakpoint moving it down.
     // lineChanged events seem to come in inverse order of startTracking the LineID. (and bp is created first...)
     if (LineHighlight.isHighestPriority(this)) {
-      paint();
+      setTextSelection();
     }
   }
 
@@ -155,7 +155,7 @@ public class LineHighlight {
   /**
    * (Re-)paint this line highlight.
    */
-  public void paint() {
+  public void setTextSelection() {
     if (editor.isInCurrentTab(lineID)) {
       if (marker != null) {
         editor.getJavaTextArea().setGutterText(lineID.lineIdx(), marker);

--- a/java/src/processing/mode/java/pdex/PreprocessedSketch.java
+++ b/java/src/processing/mode/java/pdex/PreprocessedSketch.java
@@ -241,7 +241,7 @@ public class PreprocessedSketch {
     }
   }
 
-  public static PreprocessedSketch empty() {
+  public static PreprocessedSketch getSketchInstance() {
     return new Builder().build();
   }
 


### PR DESCRIPTION
The class JAppleMenuBar is used as the starting point for the application. This method named 'sadness' is to print error. Thus, the method name 'printError' is more intuitive than 'sadness'.

The class PApplet is used to represent PApplet.  This method named 'loop' is to enable the looping mode. Thus, the method name 'enableLooping' is more intuitive than 'loop'.

The class PFont is used to represent the fonts in the system.  This method named 'list' is to get the list of the fonts installed on the system. Thus, the method name 'getFonts' is more intuitive than 'list'.

The class Server is used to represent Server.  This method named 'available' is to return the next client in line with a new message. Thus, the method name 'getNextActiveClient' is more intuitive than 'available'.

The class LineHighlight is used to Model/Controller for a highlighted source code line.  This method named 'paint' is to set text as selection. Thus, the method name 'setTextToSelection' is more intuitive than 'paint'.

The class PreprocessedSketch is used to represent PreprocessedSketch.  This method named 'empty' is to build a new PreprocessedSketch. Thus, the method name 'getSketchInstance' is more intuitive than 'empty'.
