### PR TITLE
Merge pull request #5906 from jeremydouglass/patch-2

### DIFF
--- a/java/src/processing/mode/java/pdex/Rename.java
+++ b/java/src/processing/mode/java/pdex/Rename.java
@@ -129,8 +129,8 @@ class Rename {
         final String newName = textField.getText().trim();
         if (!newName.isEmpty()) {
           if (newName.length() >= 1 &&
-              newName.chars().limit(1).allMatch(Character::isUnicodeIdentifierStart) &&
-              newName.chars().skip(1).allMatch(Character::isUnicodeIdentifierPart)) {
+              newName.chars().limit(1).allMatch(Character::isJavaIdentifierStart) &&
+              newName.chars().skip(1).allMatch(Character::isJavaIdentifierPart)) {
             rename(ps, binding, newName);
             window.setVisible(false);
           } else {


### PR DESCRIPTION
Previously it was limited to unicode identifiers--for example a beginning with _ was  forbidden; not so in Java.

Closes #5828  "rename-variable dialog doesn't allow 1st-char underscore"