### PR TITLE
Base64 image support

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1888,62 +1888,10 @@ public class PShape implements PConstants {
     g.endShape(close ? CLOSE : OPEN);
   }
 
-  private void loadImage(PGraphics g){
-
-      if(this.imagePath.startsWith("data:image")){
-          loadBase64Image();
-      }
-
-      if(this.imagePath.startsWith("file://")){
-          loadFileSystemImage(g);
-      }
-      this.imagePath = null;
-  }
-
-  private void loadFileSystemImage(PGraphics g){
-    imagePath = imagePath.substring(7);
-    PImage loadedImage = g.parent.loadImage(imagePath);
-    if(loadedImage == null){
-      System.err.println("Error loading image file: " + imagePath);
-    }else{
-      setTexture(loadedImage);
-    }
-  }
-
- private void loadBase64Image(){
-    String[] parts = this.imagePath.split(";base64,");
-    String extension = parts[0].substring(11);
-    String encodedData = parts[1];
-
-    byte[] decodedBytes = DatatypeConverter.parseBase64Binary(encodedData);
-
-    if(decodedBytes == null){
-      System.err.println("Decode Error on image: " + imagePath.substring(0, 20));
-      return;
-    }
-
-    Image awtImage = new ImageIcon(decodedBytes).getImage();
-
-    if (awtImage instanceof BufferedImage) {
-      BufferedImage buffImage = (BufferedImage) awtImage;
-      int space = buffImage.getColorModel().getColorSpace().getType();
-      if (space == ColorSpace.TYPE_CMYK) {
-       return;
-      }
-    }
-
-    PImage loadedImage = new PImage(awtImage);
-    if (loadedImage.width == -1) {
-      // error...
-    }
-
-    // if it's a .gif image, test to see if it has transparency
-    if (extension.equals("gif") || extension.equals("png") ||
-      extension.equals("unknown")) {
-    loadedImage.checkAlpha();
-    }
-
+  protected void loadImage(PGraphics g){
+    PImage loadedImage = g.parent.loadImage(this.imagePath);
     setTexture(loadedImage);
+    this.imagePath = null;
   }
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .


### PR DESCRIPTION
Some time ago poqudrof did some amazing work with extending the support for svg.
https://github.com/processing/processing/pull/4168

One of the things he worked on was support for base64 images.
Unfortunately this is only for SVG.

To quote him on another aspect:

> #### Here are the bad parts : 
> * I introduce some code duplication in :
> 
> ```java
> private void loadBase64Image() 
> ```

Basically his loadBase64Image was some kind of copy of the loadImage of processing.
There where some down sites with that:

- Error messages are inconsistent (no cmyk error anymore etc.)
- Error assumed the extension format was 3 chars, so on tiff or jpeg it would report `tif` and `jpe`.
- Due to code duplication it is harder to maintain
- certain image formats like tga and tiff are no longer supported
- It assumes that data:image/ is always base64, but this is not always the case

I cleaned things up so the loadImage for the SVG is the loadImage from PApplet now.
And I added support for all the types he did not support with loadImage.

In other words, there is full base64 support now for loadImage.

Here is a gist to check it:

https://gist.github.com/clankill3r/03f4a7dbc64a4b48fbace1912b99c678