### PR TITLE
Add new strings to Ukrainian translation

### DIFF
--- a/build/shared/lib/languages/PDE_uk.properties
+++ b/build/shared/lib/languages/PDE_uk.properties
@@ -31,6 +31,9 @@ menu.file.quit = Вийти
 menu.edit = Редагування
 menu.edit.undo = Скасувати
 menu.edit.redo = Повторити
+menu.edit.redo.keystroke.macosx = shift meta pressed Z
+menu.edit.redo.keystroke.windows = ctrl pressed Y
+menu.edit.redo.keystroke.linux = shift ctrl pressed Z
 menu.edit.action.addition = додавання
 menu.edit.action.deletion = видалення
 menu.edit.cut = Вирізати
@@ -40,8 +43,17 @@ menu.edit.paste = Вставити
 menu.edit.select_all = Виділити все
 menu.edit.auto_format = Автоформатування
 menu.edit.comment_uncomment = Коментувати/Розкоментувати
+menu.edit.comment_uncomment.keystroke.macosx = meta pressed SLASH
+menu.edit.comment_uncomment.keystroke.windows = ctrl pressed SLASH
+menu.edit.comment_uncomment.keystroke.linux = ctrl pressed SLASH
 menu.edit.increase_indent = → Збільшити відступ
+menu.edit.increase_indent.keystroke.macosx = meta pressed CLOSE_BRACKET
+menu.edit.increase_indent.keystroke.windows = ctrl pressed CLOSE_BRACKET
+menu.edit.increase_indent.keystroke.linux = ctrl pressed CLOSE_BRACKET
 menu.edit.decrease_indent = ← Зменшити відступ
+menu.edit.decrease_indent.keystroke.macosx = meta pressed OPEN_BRACKET
+menu.edit.decrease_indent.keystroke.windows = ctrl pressed OPEN_BRACKET
+menu.edit.decrease_indent.keystroke.linux = ctrl pressed OPEN_BRACKET
 menu.edit.find = Знайти...
 menu.edit.find_next = Знайти наступне
 menu.edit.find_previous = Знайти попереднє
@@ -77,8 +89,17 @@ menu.debug.toggle_breakpoint = Додати / вилучити точку зуп
 # ---
 # used for both menus and toolbars
 menu.debug.step = Крок
+menu.debug.step.keystroke.macosx = meta pressed J
+menu.debug.step.keystroke.windows = ctrl pressed J
+menu.debug.step.keystroke.linux = ctrl pressed J
 menu.debug.step_into = Крок із заходом
+menu.debug.step_into.keystroke.macosx = shift meta pressed J
+menu.debug.step_into.keystroke.windows = shift ctrl pressed J
+menu.debug.step_into.keystroke.linux = shift ctrl pressed J
 menu.debug.step_out = Крок із виходом
+menu.debug.step_out.keystroke.macosx = meta alt pressed J
+menu.debug.step_out.keystroke.windows = ctrl alt pressed J
+menu.debug.step_out.keystroke.linux = ctrl alt pressed J
 menu.debug.continue = Продовжити
 # ---
 #menu.debug.print_stack_trace = Друкувати стек викликів
@@ -166,6 +187,8 @@ preferences.editor_and_console_font = Шрифт редактора і конс�
 preferences.editor_and_console_font.tip = Виберіть шрифт, що використовуватиметься у редакторі та консолі.<br>Можна використовувати лише моноширинні шрифти.
 preferences.editor_font_size = Розмір шрифту редактора
 preferences.console_font_size = Розмір шрифту консолі
+preferences.zoom = Розмір інтерфейсу
+preferences.zoom.auto = Автоматичний
 preferences.background_color = Колір фону в режимі презентації
 preferences.background_color.tip = Виберіть фоновий колір для режиму презентації.<br>Режим презентації використовується для повноекранної презентації ескізу<br>і доступний з меню Ескіз.
 preferences.use_smooth_text = Використовувати згладжений текст у вікні редактора
@@ -311,7 +334,13 @@ editor.header.new_tab = Нова вкладка
 editor.header.rename = Перейменувати
 editor.header.delete = Видалити
 editor.header.previous_tab = Попередня вкладка
+editor.header.previous_tab.keystroke.macosx = meta alt pressed LEFT
+editor.header.previous_tab.keystroke.windows = ctrl pressed PAGE_UP
+editor.header.previous_tab.keystroke.linux = ctrl pressed PAGE_UP
 editor.header.next_tab = Наступна вкладка
+editor.header.next_tab.keystroke.macosx = meta alt pressed RIGHT
+editor.header.next_tab.keystroke.windows = ctrl pressed PAGE_DOWN
+editor.header.next_tab.keystroke.linux = ctrl pressed PAGE_DOWN
 editor.header.delete.warning.title = Хех, ні.
 editor.header.delete.warning.text = Не можна видалити головну вкладку єдиного відкритого ескізу.
 
@@ -362,6 +391,7 @@ editor.status.missing.right_paren = Відсутня ")"
 editor.status.missing.left_curly_bracket = Відсутня "{"
 editor.status.missing.right_curly_bracket = Відсутня "}"
 editor.status.missing.add = Спробуйте додати "%s"
+editor.status.bad_curly_quote = Фігурні лапки %s не працюють. Використовуйте прямі лапки. Ctrl-T для автозаміни.
 editor.status.reserved_words = "color" і "int" - зарезервовані ідентифікатори і не можуть бути назвами змінних
 editor.status.undefined_method = Функція "%s(%s)" не існує
 editor.status.undefined_constructor = Конструктор "%s(%s)" не існує
@@ -371,10 +401,12 @@ editor.status.undef_global_var = Глобальна змінна "%s" не іс�
 editor.status.undef_class = Клас "%s" не існує
 editor.status.undef_var = Змінна "%s" не існує
 editor.status.undef_name = Ім’я "%s" не може бути розпізнано
+editor.status.unterm_string_curly = Рядковий літерал не оточений прямими лапками. Фігурні лапки %s не працюють.
 editor.status.type_mismatch = Неспівпадіння типів "%s" та "%s"
 editor.status.unused_variable = Локальна змінна "%s" ніде не використовується
 editor.status.uninitialized_variable = Локальна змінна "%s" може бути не ініціалізована
 editor.status.no_effect_assignment = Присвоєння змінної "%s" не має чинності
+editor.status.hiding_enclosing_type = Клас "%s" не може мати ім'я ескізу або батьківського класу.
 
 # Footer buttons
 editor.footer.errors = Помилки
@@ -448,6 +480,18 @@ ensure_exist.messages.unrecoverable.description = Не вдалось повто
 
 # Check name
 check_name.messages.is_name_modified = Ім’я ескізу потрібно було змінити. Імена ескізів можуть містити\nтільки ASCII-символи і числа (але не можуть починатися з числа).\nКрім того, вони мають бути не довшими за 64 символи.
+
+# External changes detector
+change_detect.reload.title=Вкладка змінена ззовні
+change_detect.reload.question="%s" була змінена іншою програмою.
+change_detect.reload.comment=Бажаєте залишити цю версію чи завантажити зміни ззовні?\nТак чи інакше, файл буде збережено в папці з ескізами.
+change_detect.button.keep=Залишити
+change_detect.button.load_new=Завантажити зміни ззовні
+change_detect.delete.title=Вкладка видалена
+change_detect.delete.question="%s" зникла з папки з ескізами.
+change_detect.delete.comment=Бажаєте повторно її зберегти чи видалити зі свого ескізу?
+change_detect.button.discard=Видалити назавжди
+change_detect.button.resave=Повторно зберегти
 
 # ---------------------------------------
 # Contributions
@@ -533,6 +577,8 @@ contrib.import.errors.link = Помилка: У бібліотеки %s неді
 warn.delete = Видалення
 warn.delete.sketch = Ви впевнені, що хочете видалити цей ескіз?
 warn.delete.file = Ви впевнені, що хочете видалити "%s"?
+warn.cannot_change_mode.title = Зміна режиму неможлива
+warn.cannot_change_mode.body = Зміна режиму неможлива,\nоскільки режим "%s" несумісний з поточним режимом.
 
 
 # ---------------------------------------


### PR DESCRIPTION
Updates my 2016 Ukrainian translation file to add in some of the newer localization strings.
The various `keystroke` strings are copied to this file, despite being identical to the originals. Let me know if these should be removed outright!