### PR TITLE
Fix PGraphicsJava2D.copy() when src is of same class

### DIFF
--- a/core/src/processing/awt/PGraphicsJava2D.java
+++ b/core/src/processing/awt/PGraphicsJava2D.java
@@ -3001,9 +3001,24 @@ public class PGraphicsJava2D extends PGraphics {
   public void copy(PImage src,
                    int sx, int sy, int sw, int sh,
                    int dx, int dy, int dw, int dh) {
-    g2.drawImage((Image) src.getNative(),
-                 dx, dy, dx + dw, dy + dh,
-                 sx, sy, sx + sw, sy + sh, null);
+
+    if (src instanceof PGraphicsJava2D) {
+      // getNative() returns g2 for this class, need to use getImage() instead
+      g2.drawImage(src.getImage(),
+                   dx, dy, dx + dw, dy + dh,
+                   sx, sy, sx + sw, sy + sh, null);
+    } else {
+      // normally we can use getNative()
+      Object srcImage = src.getNative();
+      if (srcImage instanceof Image) {
+        g2.drawImage((Image) srcImage,
+                     dx, dy, dx + dw, dy + dh,
+                     sx, sy, sx + sw, sy + sh, null);
+      } else {
+        // fall back to using PImage.blend() with REPLACE mode
+        super.copy(src, sx, sy, sw, sh, dx, dy, dw, dh);
+      }
+    }
   }
 
 


### PR DESCRIPTION
Using `copy()` a `PGraphicsJava2D` with a src that is also `PGraphicsJava2D` will produce the following error:

`class sun.java2d.SunGraphics2D cannot be cast to class java.awt.Image`

This is due to `PGraphicsJava2D.native()` returning `g2` (a PGraphicsJava2D instance) rather than a `java.awt.Image` instance, which is what the cast here expects.

I've added specific handling for src being `PGraphicsJava2D`, as well as general handling of other non-Image results from `src.getNative()`. I built and tested this solution locally.