### PR TITLE
getShape() - Type of vertex was wrong for Cubic

### DIFF
--- a/core/src/processing/core/PFont.java
+++ b/core/src/processing/core/PFont.java
@@ -782,7 +782,7 @@ public class PFont implements PConstants {
       case PathIterator.SEG_CUBICTO:  // 3 points
 //        System.out.println("cubicto");
 //        PApplet.println(iterPoints);
-        s.quadraticVertex(iterPoints[0], iterPoints[1],
+        s.bezierVertex(iterPoints[0], iterPoints[1],
                           iterPoints[2], iterPoints[3],
                           iterPoints[4], iterPoints[5]);
         break;


### PR DESCRIPTION
When 'detail' is set to 0, it was causing getShape to break with OTF fonts that use cubic bezier paths.
By mistake, a 3D quadratic was being drawn instead of a proper cubic bezier.