### PR TITLE
Move hotspot position for the `TEXT` cursor type to the center of the icon

### DIFF
--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1252,7 +1252,7 @@ public class PSurfaceJOGL implements PSurface {
         } else if (kind == PConstants.HAND) {
           x = 12; y = 8;
         } else if (kind == PConstants.TEXT) {
-          x = 16; y = 22;
+          x = 16; y = 16;
         }
         cursor = new CursorInfo(img, x, y);
         cursors.put(kind, cursor);


### PR DESCRIPTION
In pretty much any program that has a text cursor when hovering over text, the hotspot position is located in the center of the icon, whereas Processing's text cursor hotspot is located at the bottom of the icon. This makes the cursor feel uncomfortable to use.

This pull request simply moves the hotspot to the center of the icon, following the convention set by most other software.