### PR TITLE
Fix syntax highlighting for hint and find reference enabled

### DIFF
--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -472,7 +472,8 @@ mouseY	KEYWORD4	mouseY
 lerpColor	FUNCTION1	lerpColor_
 array	FUNCTION2	FloatList_array_
 ellipse	FUNCTION1	ellipse_
-stroke	FUNCTION1	stroke_
+stroke  FUNCTION1	stroke_
+hint    FUNCTION1   hint_
 imageMode	FUNCTION1	imageMode_
 settings	FUNCTION4	settings
 pixelWidth	FUNCTION4	pixelWidth


### PR DESCRIPTION
This PR highlights the hint and enables the find by reference for hint().